### PR TITLE
CORE-362: new DataSource.inTransaction signatures

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceImpl.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceImpl.scala
@@ -170,7 +170,7 @@ class BucketMigrationServiceImpl(val dataSource: SlickDataSource, val samDAO: Sa
       // get migration progress if it exists
       workspacesWithProgressOpt <- workspaces.traverse { workspace =>
         dataSource
-          .inTransaction(getBucketMigrationProgress(workspace))
+          .inTransaction(dataAccess => getBucketMigrationProgress(workspace)(dataAccess))
           .recover(_ => None)
           .map(workspace -> _)
       }
@@ -309,7 +309,7 @@ class BucketMigrationServiceImpl(val dataSource: SlickDataSource, val samDAO: Sa
     workspaces
       .traverse { workspace =>
         dataSource
-          .inTransaction(getBucketMigrationProgress(workspace))
+          .inTransaction(dataAccess => getBucketMigrationProgress(workspace)(dataAccess))
           .recover(_ => None)
           .map(workspace.toWorkspaceName.toString -> _)
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
 import _root_.slick.basic.DatabaseConfig
-import _root_.slick.jdbc.{JdbcProfile, TransactionIsolation}
+import _root_.slick.jdbc.{JdbcProfile, ResultSetConcurrency, TransactionIsolation}
 import com.google.common.base.Throwables
 import com.typesafe.scalalogging.LazyLogging
 import liquibase.database.jvm.JdbcConnection
@@ -33,10 +33,55 @@ class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcProfile])(implicit 
 
   import dataAccess.driver.api._
 
-  def inTransaction[T](f: (DataAccess) => ReadWriteAction[T],
-                       isolationLevel: TransactionIsolation = TransactionIsolation.RepeatableRead
+  /**
+    * Execute a database query inside a transaction
+    * @param f the database query to execute
+    * @param concurrency read-only vs. updatable. Default: the driver's default
+    * @tparam T type returned by the query
+    * @return query results
+    */
+  def inTransaction[T](concurrency: ResultSetConcurrency)(f: DataAccess => ReadWriteAction[T]): Future[T] =
+    inTransaction[T](f, concurrency = concurrency)
+
+  /**
+    * Execute a database query inside a transaction
+    * @param f the database query to execute
+    * @param isolationLevel isolation level for the transaction. Default: repeatable read
+    * @tparam T type returned by the query
+    * @return query results
+    */
+  def inTransaction[T](isolationLevel: TransactionIsolation)(f: DataAccess => ReadWriteAction[T]): Future[T] =
+    inTransaction[T](f, isolationLevel = isolationLevel)
+
+  /**
+    * Execute a database query inside a transaction
+    * @param f the database query to execute
+    * @param isolationLevel isolation level for the transaction. Default: repeatable read
+    * @tparam T type returned by the query
+    * @return query results
+    */
+  def inTransaction[T](concurrency: ResultSetConcurrency, isolationLevel: TransactionIsolation)(
+    f: DataAccess => ReadWriteAction[T]
   ): Future[T] =
-    database.run(f(dataAccess).transactionally.withTransactionIsolation(isolationLevel))
+    inTransaction[T](f, isolationLevel, concurrency)
+
+  /**
+    * Execute a database query inside a transaction
+    * @param f the database query to execute
+    * @param isolationLevel isolation level for the transaction. Default: repeatable read
+    * @param concurrency read-only vs. updatable. Default: the driver's default
+    * @tparam T type returned by the query
+    * @return query results
+    */
+  def inTransaction[T](f: (DataAccess) => ReadWriteAction[T],
+                       isolationLevel: TransactionIsolation = TransactionIsolation.RepeatableRead,
+                       concurrency: ResultSetConcurrency = ResultSetConcurrency.Auto
+  ): Future[T] =
+    database.run(
+      f(dataAccess).transactionally
+        .withTransactionIsolation(isolationLevel)
+        .withStatementParameters(rsConcurrency = concurrency)
+    )
 
   def createEntityAttributeTempTable =
     sql"""call createEntityAttributeTempTable()""".as[Boolean]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -73,16 +73,14 @@ class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcProfile])(implicit 
     * @tparam T type returned by the query
     * @return query results
     */
-  // the `null` default for concurrency is ugly. However, it is the value specified by
-  // the .withStatementParameters implementation, so that ugliness is carried up to here
   def inTransaction[T](f: (DataAccess) => ReadWriteAction[T],
                        isolationLevel: TransactionIsolation = TransactionIsolation.RepeatableRead,
-                       concurrency: ResultSetConcurrency = null
+                       concurrency: Option[ResultSetConcurrency] = None
   ): Future[T] =
     database.run(
       f(dataAccess).transactionally
         .withTransactionIsolation(isolationLevel)
-        .withStatementParameters(rsConcurrency = concurrency)
+        .withStatementParameters(rsConcurrency = concurrency.orNull) // the .withStatementParameters default is null
     )
 
   def createEntityAttributeTempTable =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -73,9 +73,11 @@ class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcProfile])(implicit 
     * @tparam T type returned by the query
     * @return query results
     */
+  // the `null` default for concurrency is ugly. However, it is the value specified by
+  // the .withStatementParameters implementation, so that ugliness is carried up to here
   def inTransaction[T](f: (DataAccess) => ReadWriteAction[T],
                        isolationLevel: TransactionIsolation = TransactionIsolation.RepeatableRead,
-                       concurrency: ResultSetConcurrency = ResultSetConcurrency.Auto
+                       concurrency: ResultSetConcurrency = null
   ): Future[T] =
     database.run(
       f(dataAccess).transactionally

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -41,7 +41,7 @@ class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcProfile])(implicit 
     * @return query results
     */
   def inTransaction[T](concurrency: ResultSetConcurrency)(f: DataAccess => ReadWriteAction[T]): Future[T] =
-    inTransaction[T](f, concurrency = concurrency)
+    inTransaction[T](f, concurrency = Option(concurrency))
 
   /**
     * Execute a database query inside a transaction
@@ -63,7 +63,7 @@ class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcProfile])(implicit 
   def inTransaction[T](concurrency: ResultSetConcurrency, isolationLevel: TransactionIsolation)(
     f: DataAccess => ReadWriteAction[T]
   ): Future[T] =
-    inTransaction[T](f, isolationLevel, concurrency)
+    inTransaction[T](f, isolationLevel, Option(concurrency))
 
   /**
     * Execute a database query inside a transaction

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -34,9 +34,13 @@ trait EntityProvider {
 
   // ----- implementation methods follow:
 
-  def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition], parentContext: RawlsRequestContext): Future[Traversable[Entity]]
+  def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition],
+                          parentContext: RawlsRequestContext
+  ): Future[Traversable[Entity]]
 
-  def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition], parentContext: RawlsRequestContext): Future[Traversable[Entity]]
+  def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition],
+                          parentContext: RawlsRequestContext
+  ): Future[Traversable[Entity]]
 
   def copyEntities(sourceWorkspaceContext: Workspace,
                    destWorkspaceContext: Workspace,
@@ -52,11 +56,18 @@ trait EntityProvider {
 
   def deleteEntitiesOfType(entityType: String, parentContext: RawlsRequestContext): Future[Int]
 
-  def deleteEntityAttributes(entityType: String, attributeNames: Set[AttributeName], parentContext: RawlsRequestContext): Future[Unit]
+  def deleteEntityAttributes(entityType: String,
+                             attributeNames: Set[AttributeName],
+                             parentContext: RawlsRequestContext
+  ): Future[Unit]
 
   def entityTypeMetadata(useCache: Boolean, parentContext: RawlsRequestContext): Future[Map[String, EntityTypeMetadata]]
 
-  def evaluateExpression(entityType: String, entityName: String, expression: String, parentContext: RawlsRequestContext): Future[Seq[AttributeValue]]
+  def evaluateExpression(entityType: String,
+                         entityName: String,
+                         expression: String,
+                         parentContext: RawlsRequestContext
+  ): Future[Seq[AttributeValue]]
 
   /**
   The overall approach is:
@@ -107,9 +118,17 @@ trait EntityProvider {
                       parentContext: RawlsRequestContext
   ): Future[Int]
 
-  def renameEntity(entityType: String, entityName: String, newName: String, parentContext: RawlsRequestContext): Future[Int]
+  def renameEntity(entityType: String,
+                   entityName: String,
+                   newName: String,
+                   parentContext: RawlsRequestContext
+  ): Future[Int]
 
   def renameEntityType(oldName: String, renameInfo: EntityTypeRename, parentContext: RawlsRequestContext): Future[Int]
 
-  def updateEntity(entityType: String, entityName: String, operations: Seq[AttributeUpdateOperation], parentContext: RawlsRequestContext): Future[Entity]
+  def updateEntity(entityType: String,
+                   entityName: String,
+                   operations: Seq[AttributeUpdateOperation],
+                   parentContext: RawlsRequestContext
+  ): Future[Entity]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -37,11 +37,13 @@ class CompactEntityProvider(implicit protected val executionContext: ExecutionCo
   override def entityStoreId: Option[String] = ???
 
   override def batchUpdateEntities(
-    entityUpdates: Seq[AttributeUpdateOperations.EntityUpdateDefinition], parentContext: RawlsRequestContext
+    entityUpdates: Seq[AttributeUpdateOperations.EntityUpdateDefinition],
+    parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] = ???
 
   override def batchUpsertEntities(
-    entityUpdates: Seq[AttributeUpdateOperations.EntityUpdateDefinition], parentContext: RawlsRequestContext
+    entityUpdates: Seq[AttributeUpdateOperations.EntityUpdateDefinition],
+    parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] = ???
 
   override def copyEntities(sourceWorkspaceContext: Workspace,
@@ -54,17 +56,25 @@ class CompactEntityProvider(implicit protected val executionContext: ExecutionCo
 
   override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] = ???
 
-  override def deleteEntities(entityRefs: Seq[AttributeEntityReference], parentContext: RawlsRequestContext): Future[Int] = ???
+  override def deleteEntities(entityRefs: Seq[AttributeEntityReference],
+                              parentContext: RawlsRequestContext
+  ): Future[Int] = ???
 
   override def deleteEntitiesOfType(entityType: String, parentContext: RawlsRequestContext): Future[Int] = ???
 
-  override def deleteEntityAttributes(entityType: String, attributeNames: Set[AttributeName], parentContext: RawlsRequestContext): Future[Unit] = ???
+  override def deleteEntityAttributes(entityType: String,
+                                      attributeNames: Set[AttributeName],
+                                      parentContext: RawlsRequestContext
+  ): Future[Unit] = ???
 
-  override def entityTypeMetadata(useCache: Boolean, parentContext: RawlsRequestContext): Future[Map[String, EntityTypeMetadata]] = ???
+  override def entityTypeMetadata(useCache: Boolean,
+                                  parentContext: RawlsRequestContext
+  ): Future[Map[String, EntityTypeMetadata]] = ???
 
   override def evaluateExpression(entityType: String,
                                   entityName: String,
-                                  expression: String, parentContext: RawlsRequestContext
+                                  expression: String,
+                                  parentContext: RawlsRequestContext
   ): Future[Seq[AttributeValue]] = ???
 
   override def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext,
@@ -74,7 +84,8 @@ class CompactEntityProvider(implicit protected val executionContext: ExecutionCo
 
   override def expressionValidator: ExpressionValidator = ???
 
-  override def getEntity(entityType: String, entityName: String, parentContext: RawlsRequestContext): Future[Entity] = ???
+  override def getEntity(entityType: String, entityName: String, parentContext: RawlsRequestContext): Future[Entity] =
+    ???
 
   override def listEntities(entityType: String): Source[Entity, NotUsed] = ???
 
@@ -90,15 +101,24 @@ class CompactEntityProvider(implicit protected val executionContext: ExecutionCo
 
   override def renameAttribute(entityType: String,
                                oldAttributeName: AttributeName,
-                               attributeRenameRequest: AttributeRename, parentContext: RawlsRequestContext
+                               attributeRenameRequest: AttributeRename,
+                               parentContext: RawlsRequestContext
   ): Future[Int] = ???
 
-  override def renameEntity(entityType: String, entityName: String, newName: String, parentContext: RawlsRequestContext): Future[Int] = ???
+  override def renameEntity(entityType: String,
+                            entityName: String,
+                            newName: String,
+                            parentContext: RawlsRequestContext
+  ): Future[Int] = ???
 
-  override def renameEntityType(oldName: String, renameInfo: EntityTypeRename, parentContext: RawlsRequestContext): Future[Int] = ???
+  override def renameEntityType(oldName: String,
+                                renameInfo: EntityTypeRename,
+                                parentContext: RawlsRequestContext
+  ): Future[Int] = ???
 
   override def updateEntity(entityType: String,
                             entityName: String,
-                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation], parentContext: RawlsRequestContext
+                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation],
+                            parentContext: RawlsRequestContext
   ): Future[Entity] = ???
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -89,7 +89,9 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
       case None          => requestArguments.workspace.googleProjectId
     }
 
-  override def entityTypeMetadata(useCache: Boolean = false, parentContext: RawlsRequestContext): Future[Map[String, EntityTypeMetadata]] = {
+  override def entityTypeMetadata(useCache: Boolean = false,
+                                  parentContext: RawlsRequestContext
+  ): Future[Map[String, EntityTypeMetadata]] = {
 
     // TODO: AS-321 auto-switch to see if the ref supplied in argument is a UUID or a name?? Use separate query params? Never allow ID?
 
@@ -107,13 +109,18 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
   override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] =
     throw new UnsupportedEntityOperationException("create entity not supported by this provider.")
 
-  override def deleteEntities(entityRefs: Seq[AttributeEntityReference], parentContext: RawlsRequestContext): Future[Int] =
+  override def deleteEntities(entityRefs: Seq[AttributeEntityReference],
+                              parentContext: RawlsRequestContext
+  ): Future[Int] =
     throw new UnsupportedEntityOperationException("delete entities not supported by this provider.")
 
   override def deleteEntitiesOfType(entityType: String, parentContext: RawlsRequestContext): Future[Int] =
     throw new UnsupportedEntityOperationException("delete entities of type not supported by this provider.")
 
-  override def deleteEntityAttributes(entityType: EntityName, attributeNames: Set[AttributeName], parentContext: RawlsRequestContext): Future[Unit] =
+  override def deleteEntityAttributes(entityType: EntityName,
+                                      attributeNames: Set[AttributeName],
+                                      parentContext: RawlsRequestContext
+  ): Future[Unit] =
     throw new UnsupportedEntityOperationException("delete entity attributes not supported by this provider.")
 
   override def getEntity(entityType: String, entityName: String, parentContext: RawlsRequestContext): Future[Entity] = {
@@ -291,7 +298,8 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   override def evaluateExpression(entityType: EntityName,
                                   entityName: EntityName,
-                                  expression: EntityName, parentContext: RawlsRequestContext
+                                  expression: EntityName,
+                                  parentContext: RawlsRequestContext
   ): Future[Seq[AttributeValue]] =
     throw new UnsupportedEntityOperationException("evaluate expression not supported by this provider.")
 
@@ -550,10 +558,14 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   override def expressionValidator: ExpressionValidator = new DataRepoEntityExpressionValidator(snapshotModel)
 
-  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition], parentContext: RawlsRequestContext): Future[Traversable[Entity]] =
+  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition],
+                                   parentContext: RawlsRequestContext
+  ): Future[Traversable[Entity]] =
     throw new UnsupportedEntityOperationException("batch-update entities not supported by this provider.")
 
-  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition], parentContext: RawlsRequestContext): Future[Traversable[Entity]] =
+  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition],
+                                   parentContext: RawlsRequestContext
+  ): Future[Traversable[Entity]] =
     throw new UnsupportedEntityOperationException("batch-upsert entities not supported by this provider.")
 
   override def copyEntities(sourceWorkspaceContext: Workspace,
@@ -567,19 +579,28 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   override def renameAttribute(entityType: EntityName,
                                oldAttributeName: AttributeName,
-                               attributeRenameRequest: AttributeRename, parentContext: RawlsRequestContext
+                               attributeRenameRequest: AttributeRename,
+                               parentContext: RawlsRequestContext
   ): Future[Int] =
     throw new UnsupportedEntityOperationException("rename attribute not supported by this provider.")
 
-  override def renameEntity(entityType: EntityName, entityName: EntityName, newName: EntityName, parentContext: RawlsRequestContext): Future[Int] =
+  override def renameEntity(entityType: EntityName,
+                            entityName: EntityName,
+                            newName: EntityName,
+                            parentContext: RawlsRequestContext
+  ): Future[Int] =
     throw new UnsupportedEntityOperationException("rename entity not supported by this provider.")
 
-  override def renameEntityType(oldName: EntityName, renameInfo: EntityTypeRename, parentContext: RawlsRequestContext): Future[Int] =
+  override def renameEntityType(oldName: EntityName,
+                                renameInfo: EntityTypeRename,
+                                parentContext: RawlsRequestContext
+  ): Future[Int] =
     throw new UnsupportedEntityOperationException("rename entity type not supported by this provider.")
 
   override def updateEntity(entityType: EntityName,
                             entityName: EntityName,
-                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation], parentContext: RawlsRequestContext
+                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation],
+                            parentContext: RawlsRequestContext
   ): Future[Entity] = throw new UnsupportedEntityOperationException("update entity not supported by this provider.")
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -89,7 +89,9 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
 
   final private val queryTimeoutSeconds: Int = queryTimeout.getSeconds.toInt
 
-  override def entityTypeMetadata(useCache: Boolean, parentContext: RawlsRequestContext): Future[Map[String, EntityTypeMetadata]] =
+  override def entityTypeMetadata(useCache: Boolean,
+                                  parentContext: RawlsRequestContext
+  ): Future[Map[String, EntityTypeMetadata]] =
     // start performance tracing
     traceFutureWithParent("LocalEntityProvider.entityTypeMetadata", parentContext) { localContext =>
       setTraceSpanAttribute(localContext,
@@ -170,7 +172,9 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
 
   override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] =
     dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
-      traceDBIOWithParent("getEntity", parentContext) { _ => dataAccess.entityQuery.get(workspaceContext, entity.entityType, entity.name) } flatMap {
+      traceDBIOWithParent("getEntity", parentContext) { _ =>
+        dataAccess.entityQuery.get(workspaceContext, entity.entityType, entity.name)
+      } flatMap {
         case Some(_) =>
           DBIO.failed(
             new RawlsExceptionWithErrorReport(
@@ -180,7 +184,8 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
                 )
             )
           )
-        case None => traceDBIOWithParent("saveEntity", parentContext) { _ => dataAccess.entityQuery.save(workspaceContext, entity) }
+        case None =>
+          traceDBIOWithParent("saveEntity", parentContext)(_ => dataAccess.entityQuery.save(workspaceContext, entity))
       }
     }
 
@@ -229,11 +234,16 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
       }
     }
 
-  override def deleteEntityAttributes(entityType: EntityName, attributeNames: Set[AttributeName], parentContext: RawlsRequestContext): Future[Unit] =
+  override def deleteEntityAttributes(entityType: EntityName,
+                                      attributeNames: Set[AttributeName],
+                                      parentContext: RawlsRequestContext
+  ): Future[Unit] =
     dataSource.inTransaction { dataAccess =>
-      traceDBIOWithParent("deleteEntityAttributes", parentContext) { _ => dataAccess
-        .entityAttributeShardQuery(workspaceContext)
-        .deleteAttributes(workspaceContext, entityType, attributeNames) } flatMap {
+      traceDBIOWithParent("deleteEntityAttributes", parentContext) { _ =>
+        dataAccess
+          .entityAttributeShardQuery(workspaceContext)
+          .deleteAttributes(workspaceContext, entityType, attributeNames)
+      } flatMap {
         case Vector(0) =>
           throw new RawlsExceptionWithErrorReport(
             errorReport = ErrorReport(StatusCodes.BadRequest, s"Could not find any of the given attribute names.")
@@ -250,37 +260,40 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
   ): Future[Seq[AttributeValue]] =
     dataSource.inTransaction(
       dataAccess =>
-        traceDBIOWithParent("withSingleEntityRec", parentContext) { _ => withSingleEntityRec(entityType, entityName, workspaceContext, dataAccess) { entities =>
-          traceDBIOWithParent("withNewExpressionEvaluator", parentContext) { _ => ExpressionEvaluator.withNewExpressionEvaluator(dataAccess, Some(entities)) { evaluator =>
-              traceDBIOWithParent("evalFinalAttribute", parentContext) { _ => evaluator.evalFinalAttribute(workspaceContext, expression).asTry map {
-                  // parsing failure
-                  case Failure(regret) =>
-                    throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regret))
-                  case Success(valuesByEntity) =>
-                    if (valuesByEntity.size != 1) {
-                      // wrong number of entities?!
-                      throw new RawlsException(
-                        s"Expression parsing should have returned a single entity for ${entityType}/$entityName $expression, but returned ${valuesByEntity.size} entities instead"
-                      )
-                    } else {
-                      assert(valuesByEntity.head._1 == entityName)
-                      valuesByEntity.head match {
-                        case (_, Success(result)) => result.toSeq
-                        case (_, Failure(regret)) =>
-                          throw new RawlsExceptionWithErrorReport(
-                            errorReport = ErrorReport(
-                              StatusCodes.BadRequest,
-                              "Unable to evaluate expression '${expression}' on ${entityType}/${entityName} in ${workspaceName}",
-                              ErrorReport(regret)
+        traceDBIOWithParent("withSingleEntityRec", parentContext) { _ =>
+          withSingleEntityRec(entityType, entityName, workspaceContext, dataAccess) { entities =>
+            traceDBIOWithParent("withNewExpressionEvaluator", parentContext) { _ =>
+              ExpressionEvaluator.withNewExpressionEvaluator(dataAccess, Some(entities)) { evaluator =>
+                traceDBIOWithParent("evalFinalAttribute", parentContext) { _ =>
+                  evaluator.evalFinalAttribute(workspaceContext, expression).asTry map {
+                    // parsing failure
+                    case Failure(regret) =>
+                      throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regret))
+                    case Success(valuesByEntity) =>
+                      if (valuesByEntity.size != 1) {
+                        // wrong number of entities?!
+                        throw new RawlsException(
+                          s"Expression parsing should have returned a single entity for ${entityType}/$entityName $expression, but returned ${valuesByEntity.size} entities instead"
+                        )
+                      } else {
+                        assert(valuesByEntity.head._1 == entityName)
+                        valuesByEntity.head match {
+                          case (_, Success(result)) => result.toSeq
+                          case (_, Failure(regret)) =>
+                            throw new RawlsExceptionWithErrorReport(
+                              errorReport = ErrorReport(
+                                StatusCodes.BadRequest,
+                                "Unable to evaluate expression '${expression}' on ${entityType}/${entityName} in ${workspaceName}",
+                                ErrorReport(regret)
+                              )
                             )
-                          )
+                        }
                       }
-                    }
+                  }
                 }
               }
             }
           }
-        }
         },
       TransactionIsolation.ReadCommitted
     )
@@ -348,13 +361,14 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
   }
 
   override def getEntity(entityType: String, entityName: String, parentContext: RawlsRequestContext): Future[Entity] =
-    dataSource.inTransaction(dataAccess =>
-                               traceDBIOWithParent("withEntity", parentContext) { _ =>
-                                 withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
-                                   DBIO.successful(entity)
-                                 }
-                               },
-                             TransactionIsolation.ReadCommitted
+    dataSource.inTransaction(
+      dataAccess =>
+        traceDBIOWithParent("withEntity", parentContext) { _ =>
+          withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
+            DBIO.successful(entity)
+          }
+        },
+      TransactionIsolation.ReadCommitted
     )
 
   /*
@@ -614,10 +628,14 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     }
   }
 
-  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition], parentContext: RawlsRequestContext): Future[Traversable[Entity]] =
+  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition],
+                                   parentContext: RawlsRequestContext
+  ): Future[Traversable[Entity]] =
     batchUpdateEntitiesImpl(entityUpdates, upsert = false, parentContext)
 
-  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition], parentContext: RawlsRequestContext): Future[Traversable[Entity]] =
+  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition],
+                                   parentContext: RawlsRequestContext
+  ): Future[Traversable[Entity]] =
     batchUpdateEntitiesImpl(entityUpdates, upsert = true, parentContext)
 
   override def copyEntities(sourceWorkspaceContext: Workspace,
@@ -683,7 +701,9 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     dataSource.inTransaction { dataAccess =>
       val newAttributeName = attributeRenameRequest.newAttributeName
       for {
-        _ <- traceDBIOWithParent("validateNewAttributeName", parentContext) { _ => validateNewAttributeName(dataAccess, workspaceContext, entityType, newAttributeName) }
+        _ <- traceDBIOWithParent("validateNewAttributeName", parentContext) { _ =>
+          validateNewAttributeName(dataAccess, workspaceContext, entityType, newAttributeName)
+        }
         rowsUpdated <- traceDBIOWithParent("renameAttribute", parentContext) { _ =>
           dataAccess
             .entityAttributeShardQuery(workspaceContext)
@@ -694,12 +714,21 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     }
   }
 
-  override def renameEntity(entityType: EntityName, entityName: EntityName, newName: EntityName, parentContext: RawlsRequestContext): Future[Int] =
+  override def renameEntity(entityType: EntityName,
+                            entityName: EntityName,
+                            newName: EntityName,
+                            parentContext: RawlsRequestContext
+  ): Future[Int] =
     dataSource.inTransaction { dataAccess =>
       traceDBIOWithParent("withEntity", parentContext) { s =>
         withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
-          traceDBIOWithParent("checkNameConflict getEntity", s) { _ => dataAccess.entityQuery.get(workspaceContext, entity.entityType, newName) } flatMap {
-            case None => traceDBIOWithParent("renameEntity", s) { _ => dataAccess.entityQuery.rename(workspaceContext, entity.entityType, entity.name, newName) }
+          traceDBIOWithParent("checkNameConflict getEntity", s) { _ =>
+            dataAccess.entityQuery.get(workspaceContext, entity.entityType, newName)
+          } flatMap {
+            case None =>
+              traceDBIOWithParent("renameEntity", s) { _ =>
+                dataAccess.entityQuery.rename(workspaceContext, entity.entityType, entity.name, newName)
+              }
             case Some(_) =>
               throw new RawlsExceptionWithErrorReport(
                 errorReport =
@@ -710,7 +739,10 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
       }
     }
 
-  override def renameEntityType(oldName: EntityName, renameInfo: EntityTypeRename, parentContext: RawlsRequestContext): Future[Int] = {
+  override def renameEntityType(oldName: EntityName,
+                                renameInfo: EntityTypeRename,
+                                parentContext: RawlsRequestContext
+  ): Future[Int] = {
     def validateExistingType(dataAccess: DataAccess,
                              workspaceContext: Workspace,
                              oldName: String
@@ -763,7 +795,7 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
         withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
           val updateAction = Try {
             val updatedEntity = applyOperationsToEntity(entity, operations)
-            traceDBIOWithParent("saveEntity", s) { _ => dataAccess.entityQuery.save(workspaceContext, updatedEntity) }
+            traceDBIOWithParent("saveEntity", s)(_ => dataAccess.entityQuery.save(workspaceContext, updatedEntity))
           } match {
             case Success(result) => result
             case Failure(e: AttributeUpdateOperationException) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -58,7 +58,8 @@ import org.broadinstitute.dsde.rawls.util.{
   CollectionUtils,
   EntitySupport
 }
-import slick.jdbc.{ResultSetConcurrency, ResultSetType, TransactionIsolation}
+import slick.jdbc.{ResultSetConcurrency, ResultSetType}
+import slick.jdbc.TransactionIsolation.ReadCommitted
 
 import java.time.Duration
 import scala.concurrent.{ExecutionContext, Future}
@@ -105,69 +106,62 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
       )
 
       // start transaction
-      dataSource.inTransaction(
-        dataAccess =>
-          if (!useCache || !cacheEnabled) {
-            if (!cacheEnabled) {
+      dataSource.inTransaction(ReadCommitted) { dataAccess =>
+        if (!useCache || !cacheEnabled) {
+          if (!cacheEnabled) {
+            logger.info(
+              s"entity statistics cache: miss (cache disabled at system level) [${workspaceContext.workspaceIdAsUUID}]"
+            )
+          } else if (!useCache) {
+            logger.info(
+              s"entity statistics cache: miss (user request specified cache bypass) [${workspaceContext.workspaceIdAsUUID}]"
+            )
+          }
+          // retrieve metadata, bypassing cache
+          calculateMetadataResponse(dataAccess, countsFromCache = false, attributesFromCache = false, localContext)
+        } else {
+          // system and request both have cache enabled. Check for existence and staleness of cache
+          cacheStaleness(dataAccess, localContext).flatMap {
+            case None =>
+              // cache does not exist - return uncached
               logger.info(
-                s"entity statistics cache: miss (cache disabled at system level) [${workspaceContext.workspaceIdAsUUID}]"
+                s"entity statistics cache: miss (cache does not exist) [${workspaceContext.workspaceIdAsUUID}]"
               )
-            } else if (!useCache) {
-              logger.info(
-                s"entity statistics cache: miss (user request specified cache bypass) [${workspaceContext.workspaceIdAsUUID}]"
-              )
-            }
-            // retrieve metadata, bypassing cache
-            calculateMetadataResponse(dataAccess, countsFromCache = false, attributesFromCache = false, localContext)
-          } else {
-            // system and request both have cache enabled. Check for existence and staleness of cache
-            cacheStaleness(dataAccess, localContext).flatMap {
-              case None =>
-                // cache does not exist - return uncached
-                logger.info(
-                  s"entity statistics cache: miss (cache does not exist) [${workspaceContext.workspaceIdAsUUID}]"
-                )
+              calculateMetadataResponse(dataAccess, countsFromCache = false, attributesFromCache = false, localContext)
+            case Some(0) =>
+              // cache is up to date - return cached
+              logger.info(s"entity statistics cache: hit [${workspaceContext.workspaceIdAsUUID}]")
+              calculateMetadataResponse(dataAccess, countsFromCache = true, attributesFromCache = true, localContext)
+            case Some(stalenessSeconds) =>
+              // cache exists, but is out of date - check if this workspace has any always-cache feature flags set
+              cacheFeatureFlags(dataAccess, localContext).flatMap { flags =>
+                if (flags.alwaysCacheTypeCounts || flags.alwaysCacheAttributes) {
+                  setTraceSpanAttribute(localContext,
+                                        AttributeKey.booleanKey("alwaysCacheTypeCountsFeatureFlag"),
+                                        java.lang.Boolean.valueOf(flags.alwaysCacheTypeCounts)
+                  )
+                  setTraceSpanAttribute(localContext,
+                                        AttributeKey.booleanKey("alwaysCacheAttributesFeatureFlag"),
+                                        java.lang.Boolean.valueOf(flags.alwaysCacheAttributes)
+                  )
+                  logger.info(
+                    s"entity statistics cache: partial hit (alwaysCacheTypeCounts=${flags.alwaysCacheTypeCounts}, alwaysCacheAttributes=${flags.alwaysCacheAttributes}, staleness=$stalenessSeconds) [${workspaceContext.workspaceIdAsUUID}]"
+                  )
+                } else {
+                  logger.info(
+                    s"entity statistics cache: miss (cache is out of date, staleness=$stalenessSeconds) [${workspaceContext.workspaceIdAsUUID}]"
+                  )
+                  // and opportunistically save
+                }
                 calculateMetadataResponse(dataAccess,
-                                          countsFromCache = false,
-                                          attributesFromCache = false,
+                                          countsFromCache = flags.alwaysCacheTypeCounts,
+                                          attributesFromCache = flags.alwaysCacheAttributes,
                                           localContext
                 )
-              case Some(0) =>
-                // cache is up to date - return cached
-                logger.info(s"entity statistics cache: hit [${workspaceContext.workspaceIdAsUUID}]")
-                calculateMetadataResponse(dataAccess, countsFromCache = true, attributesFromCache = true, localContext)
-              case Some(stalenessSeconds) =>
-                // cache exists, but is out of date - check if this workspace has any always-cache feature flags set
-                cacheFeatureFlags(dataAccess, localContext).flatMap { flags =>
-                  if (flags.alwaysCacheTypeCounts || flags.alwaysCacheAttributes) {
-                    setTraceSpanAttribute(localContext,
-                                          AttributeKey.booleanKey("alwaysCacheTypeCountsFeatureFlag"),
-                                          java.lang.Boolean.valueOf(flags.alwaysCacheTypeCounts)
-                    )
-                    setTraceSpanAttribute(localContext,
-                                          AttributeKey.booleanKey("alwaysCacheAttributesFeatureFlag"),
-                                          java.lang.Boolean.valueOf(flags.alwaysCacheAttributes)
-                    )
-                    logger.info(
-                      s"entity statistics cache: partial hit (alwaysCacheTypeCounts=${flags.alwaysCacheTypeCounts}, alwaysCacheAttributes=${flags.alwaysCacheAttributes}, staleness=$stalenessSeconds) [${workspaceContext.workspaceIdAsUUID}]"
-                    )
-                  } else {
-                    logger.info(
-                      s"entity statistics cache: miss (cache is out of date, staleness=$stalenessSeconds) [${workspaceContext.workspaceIdAsUUID}]"
-                    )
-                    // and opportunistically save
-                  }
-                  calculateMetadataResponse(dataAccess,
-                                            countsFromCache = flags.alwaysCacheTypeCounts,
-                                            attributesFromCache = flags.alwaysCacheAttributes,
-                                            localContext
-                  )
-                } // end feature-flags lookup
-            } // end staleness lookup
-          } // end if useCache/cacheEnabled check
-        ,
-        TransactionIsolation.ReadCommitted
-      ) // end transaction
+              } // end feature-flags lookup
+          } // end staleness lookup
+        } // end if useCache/cacheEnabled check
+      } // end transaction
     } // end root trace
 
   override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] =
@@ -258,64 +252,60 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
                                   expression: EntityName,
                                   parentContext: RawlsRequestContext
   ): Future[Seq[AttributeValue]] =
-    dataSource.inTransaction(
-      dataAccess =>
-        traceDBIOWithParent("withSingleEntityRec", parentContext) { _ =>
-          withSingleEntityRec(entityType, entityName, workspaceContext, dataAccess) { entities =>
-            traceDBIOWithParent("withNewExpressionEvaluator", parentContext) { _ =>
-              ExpressionEvaluator.withNewExpressionEvaluator(dataAccess, Some(entities)) { evaluator =>
-                traceDBIOWithParent("evalFinalAttribute", parentContext) { _ =>
-                  evaluator.evalFinalAttribute(workspaceContext, expression).asTry map {
-                    // parsing failure
-                    case Failure(regret) =>
-                      throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regret))
-                    case Success(valuesByEntity) =>
-                      if (valuesByEntity.size != 1) {
-                        // wrong number of entities?!
-                        throw new RawlsException(
-                          s"Expression parsing should have returned a single entity for ${entityType}/$entityName $expression, but returned ${valuesByEntity.size} entities instead"
-                        )
-                      } else {
-                        assert(valuesByEntity.head._1 == entityName)
-                        valuesByEntity.head match {
-                          case (_, Success(result)) => result.toSeq
-                          case (_, Failure(regret)) =>
-                            throw new RawlsExceptionWithErrorReport(
-                              errorReport = ErrorReport(
-                                StatusCodes.BadRequest,
-                                "Unable to evaluate expression '${expression}' on ${entityType}/${entityName} in ${workspaceName}",
-                                ErrorReport(regret)
-                              )
+    dataSource.inTransaction(ReadCommitted) { dataAccess =>
+      traceDBIOWithParent("withSingleEntityRec", parentContext) { _ =>
+        withSingleEntityRec(entityType, entityName, workspaceContext, dataAccess) { entities =>
+          traceDBIOWithParent("withNewExpressionEvaluator", parentContext) { _ =>
+            ExpressionEvaluator.withNewExpressionEvaluator(dataAccess, Some(entities)) { evaluator =>
+              traceDBIOWithParent("evalFinalAttribute", parentContext) { _ =>
+                evaluator.evalFinalAttribute(workspaceContext, expression).asTry map {
+                  // parsing failure
+                  case Failure(regret) =>
+                    throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regret))
+                  case Success(valuesByEntity) =>
+                    if (valuesByEntity.size != 1) {
+                      // wrong number of entities?!
+                      throw new RawlsException(
+                        s"Expression parsing should have returned a single entity for ${entityType}/$entityName $expression, but returned ${valuesByEntity.size} entities instead"
+                      )
+                    } else {
+                      assert(valuesByEntity.head._1 == entityName)
+                      valuesByEntity.head match {
+                        case (_, Success(result)) => result.toSeq
+                        case (_, Failure(regret)) =>
+                          throw new RawlsExceptionWithErrorReport(
+                            errorReport = ErrorReport(
+                              StatusCodes.BadRequest,
+                              "Unable to evaluate expression '${expression}' on ${entityType}/${entityName} in ${workspaceName}",
+                              ErrorReport(regret)
                             )
-                        }
+                          )
                       }
-                  }
+                    }
                 }
               }
             }
           }
-        },
-      TransactionIsolation.ReadCommitted
-    )
+        }
+      }
+    }
 
   override def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext,
                                    gatherInputsResult: GatherInputsResult,
                                    workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]]
   ): Future[LazyList[SubmissionValidationEntityInputs]] =
-    dataSource.inTransaction(
-      dataAccess =>
-        withEntityRecsForExpressionEval(expressionEvaluationContext, workspaceContext, dataAccess) { jobEntityRecs =>
-          // Parse out the entity -> results map to a tuple of (successful, failed) SubmissionValidationEntityInputs
-          evaluateExpressionsInternal(workspaceContext,
-                                      gatherInputsResult.processableInputs,
-                                      jobEntityRecs,
-                                      dataAccess
-          ) map { valuesByEntity =>
-            createSubmissionValidationEntityInputs(valuesByEntity)
-          }
-        },
-      TransactionIsolation.ReadCommitted
-    )
+    dataSource.inTransaction(ReadCommitted) { dataAccess =>
+      withEntityRecsForExpressionEval(expressionEvaluationContext, workspaceContext, dataAccess) { jobEntityRecs =>
+        // Parse out the entity -> results map to a tuple of (successful, failed) SubmissionValidationEntityInputs
+        evaluateExpressionsInternal(workspaceContext,
+                                    gatherInputsResult.processableInputs,
+                                    jobEntityRecs,
+                                    dataAccess
+        ) map { valuesByEntity =>
+          createSubmissionValidationEntityInputs(valuesByEntity)
+        }
+      }
+    }
 
   override def expressionValidator: ExpressionValidator = new LocalEntityExpressionValidator
 
@@ -361,15 +351,13 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
   }
 
   override def getEntity(entityType: String, entityName: String, parentContext: RawlsRequestContext): Future[Entity] =
-    dataSource.inTransaction(
-      dataAccess =>
-        traceDBIOWithParent("withEntity", parentContext) { _ =>
-          withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
-            DBIO.successful(entity)
-          }
-        },
-      TransactionIsolation.ReadCommitted
-    )
+    dataSource.inTransaction(ReadCommitted) { dataAccess =>
+      traceDBIOWithParent("withEntity", parentContext) { _ =>
+        withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
+          DBIO.successful(entity)
+        }
+      }
+    }
 
   /*
    * Queries the db for a stream of entity attributes.
@@ -381,7 +369,7 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     val allAttrsStream = dataSource.dataAccess.entityQuery
       .streamActiveEntityAttributesOfType(workspaceContext, entityType)
       .transactionally
-      .withTransactionIsolation(TransactionIsolation.ReadCommitted)
+      .withTransactionIsolation(ReadCommitted)
       .withStatementParameters(rsType = ResultSetType.ForwardOnly,
                                rsConcurrency = ResultSetConcurrency.ReadOnly,
                                fetchSize = dataSource.dataAccess.fetchSize
@@ -429,10 +417,9 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     // if filtering by name, retrieve that entity directly, else do the full query:
     nameFilter match {
       case Some(entityName) =>
-        dataSource.inTransaction(
-          dataAccess => dataAccess.entityQuery.loadSingleEntityForPage(workspaceContext, entityType, entityName, query),
-          TransactionIsolation.ReadCommitted
-        ) map { case (unfilteredCount, filteredCount, entity) =>
+        dataSource.inTransaction(ReadCommitted) { dataAccess =>
+          dataAccess.entityQuery.loadSingleEntityForPage(workspaceContext, entityType, entityName, query)
+        } map { case (unfilteredCount, filteredCount, entity) =>
           val pageCount = if (entity.nonEmpty) 1 else 0
           val entitySource = if (entity.nonEmpty) Source.single(entity.head) else Source.empty
 
@@ -472,27 +459,25 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
                                query: EntityQuery,
                                parentContext: RawlsRequestContext
   ): Future[EntityQueryResultMetadata] =
-    dataSource.inTransaction(
-      dataAccess =>
-        for {
-          (unfilteredCount, filteredCount) <- dataAccess.entityQuery.loadEntityPageCounts(workspaceContext,
-                                                                                          entityType,
-                                                                                          query,
-                                                                                          parentContext
+    dataSource.inTransaction(ReadCommitted) { dataAccess =>
+      for {
+        (unfilteredCount, filteredCount) <- dataAccess.entityQuery.loadEntityPageCounts(workspaceContext,
+                                                                                        entityType,
+                                                                                        query,
+                                                                                        parentContext
+        )
+      } yield {
+        val pageCount: Int = Math.ceil(filteredCount.toFloat / query.pageSize).toInt
+        if (filteredCount > 0 && query.page > pageCount) {
+          throw new DataEntityException(
+            code = StatusCodes.BadRequest,
+            message = s"requested page ${query.page} is greater than the number of pages $pageCount"
           )
-        } yield {
-          val pageCount: Int = Math.ceil(filteredCount.toFloat / query.pageSize).toInt
-          if (filteredCount > 0 && query.page > pageCount) {
-            throw new DataEntityException(
-              code = StatusCodes.BadRequest,
-              message = s"requested page ${query.page} is greater than the number of pages $pageCount"
-            )
-          }
+        }
 
-          EntityQueryResultMetadata(unfilteredCount, filteredCount, pageCount)
-        },
-      TransactionIsolation.ReadCommitted
-    )
+        EntityQueryResultMetadata(unfilteredCount, filteredCount, pageCount)
+      }
+    }
 
   /**
    * generates a Source[Entity, _] representing the individual Entity results for the incoming query.
@@ -511,7 +496,7 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
       dataSource.dataAccess.entityQuery
         .loadEntityPageSource(workspaceContext, entityType, query, parentContext)
         .transactionally
-        .withTransactionIsolation(TransactionIsolation.ReadCommitted)
+        .withTransactionIsolation(ReadCommitted)
         .withStatementParameters(rsType = ResultSetType.ForwardOnly,
                                  rsConcurrency = ResultSetConcurrency.ReadOnly,
                                  fetchSize = dataSource.dataAccess.fetchSize

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -3,17 +3,15 @@ package org.broadinstitute.dsde.rawls.monitor
 import akka.actor._
 import akka.pattern.pipe
 import com.typesafe.scalalogging.LazyLogging
-import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue}
 import io.opentelemetry.api.common.AttributeKey
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
-import org.broadinstitute.dsde.rawls.dataaccess.slick.DataAccess
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.RawlsTracingContext
 import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor._
 import org.broadinstitute.dsde.rawls.util.TracingUtils._
 import slick.dbio.DBIO
-import slick.jdbc.TransactionIsolation
+import slick.jdbc.ResultSetConcurrency.ReadOnly
 import slick.jdbc.TransactionIsolation.ReadCommitted
 
 import java.sql.Timestamp
@@ -109,43 +107,37 @@ trait EntityStatisticsCacheMonitor extends LazyLogging with RawlsInstrumented {
   val workspaceCooldown: FiniteDuration
   val timeoutPerWorkspace: Duration
 
-  // default isolation level for queries in this trait
-  final val isolationLevel: TransactionIsolation = TransactionIsolation.ReadCommitted
-
   def sweep(): Future[EntityStatisticsCacheMessage] =
     traceFuture("EntityStatisticsCacheMonitor.sweep") { rootContext =>
-      dataSource.inTransaction(
-        { dataAccess =>
-          // calculate now - workspaceCooldown as the upper bound for workspace last_modified
-          val maxModifiedTime = nowMinus(workspaceCooldown)
+      dataSource.inTransaction(ReadOnly, ReadCommitted) { dataAccess =>
+        // calculate now - workspaceCooldown as the upper bound for workspace last_modified
+        val maxModifiedTime = nowMinus(workspaceCooldown)
 
-          dataAccess.entityCacheQuery
-            .findMostOutdatedEntityCachesAfter(MIN_CACHE_TIME, maxModifiedTime) flatMap { candidates =>
-            if (candidates.nonEmpty) {
-              // pick one of the candidates at random. This randomness ensures that we don't get stuck constantly trying
-              // and failing to update the same workspace - until all we have left as candidates are un-updatable workspaces
-              val (workspaceId, lastModified, cacheLastUpdated) =
-                candidates.toArray.apply(scala.util.Random.nextInt(candidates.size))
+        dataAccess.entityCacheQuery
+          .findMostOutdatedEntityCachesAfter(MIN_CACHE_TIME, maxModifiedTime) flatMap { candidates =>
+          if (candidates.nonEmpty) {
+            // pick one of the candidates at random. This randomness ensures that we don't get stuck constantly trying
+            // and failing to update the same workspace - until all we have left as candidates are un-updatable workspaces
+            val (workspaceId, lastModified, cacheLastUpdated) =
+              candidates.toArray.apply(scala.util.Random.nextInt(candidates.size))
 
-              setTraceSpanAttribute(rootContext, AttributeKey.stringKey("workspaceId"), workspaceId.toString)
-              logger.info(s"EntityStatisticsCacheMonitor starting update attempt for workspace $workspaceId.")
-              traceDBIOWithParent("updateStatisticsCache", rootContext) { innerSpan =>
-                DBIO.from(updateStatisticsCache(workspaceId, lastModified, innerSpan).map { _ =>
-                  val outDated = lastModified.getTime - cacheLastUpdated.getOrElse(MIN_CACHE_TIME).getTime
-                  logger.info(s"Updated entity cache for workspace $workspaceId. Cache was ${outDated}ms out of date.")
-                  Sweep
-                })
-              }
-            } else {
-              traceDBIOWithParent("nothing-to-update", rootContext) { _ =>
-                logger.info(s"All workspace entity caches are up to date. Sleeping for $standardPollInterval")
-                DBIO.successful(ScheduleDelayedSweep)
-              }
+            setTraceSpanAttribute(rootContext, AttributeKey.stringKey("workspaceId"), workspaceId.toString)
+            logger.info(s"EntityStatisticsCacheMonitor starting update attempt for workspace $workspaceId.")
+            traceDBIOWithParent("updateStatisticsCache", rootContext) { innerSpan =>
+              DBIO.from(updateStatisticsCache(workspaceId, lastModified, innerSpan).map { _ =>
+                val outDated = lastModified.getTime - cacheLastUpdated.getOrElse(MIN_CACHE_TIME).getTime
+                logger.info(s"Updated entity cache for workspace $workspaceId. Cache was ${outDated}ms out of date.")
+                Sweep
+              })
+            }
+          } else {
+            traceDBIOWithParent("nothing-to-update", rootContext) { _ =>
+              logger.info(s"All workspace entity caches are up to date. Sleeping for $standardPollInterval")
+              DBIO.successful(ScheduleDelayedSweep)
             }
           }
-        },
-        isolationLevel
-      )
+        }
+      }
     }
 
   private def updateStatisticsCache(workspaceId: UUID,
@@ -156,44 +148,39 @@ trait EntityStatisticsCacheMonitor extends LazyLogging with RawlsInstrumented {
     // note that other statements do not have timeouts and are unbounded.
     val attrNamesTimeout = (timeoutPerWorkspace * .8).toSeconds.toInt
 
-    val updateFuture = dataSource.inTransaction(
-      dataAccess =>
-        // TODO: beware contention on the approach of delete-all and batch-insert all below
-        // if we see contention we could move to encoding the entire metadata object as json
-        // and storing in a single column on WORKSPACE_ENTITY_CACHE
-        for {
-          // calculate entity statistics
-          entityTypesWithCounts <- traceDBIOWithParent("getEntityTypesWithCounts", parentSpan) { _ =>
-            dataAccess.entityQuery.getEntityTypesWithCounts(workspaceId)
-          }
-          // calculate entity attribute statistics
-          entityTypesWithAttrNames <- traceDBIOWithParent("getAttrNamesAndEntityTypes", parentSpan) { _ =>
-            dataAccess.entityQuery.getAttrNamesAndEntityTypes(workspaceId, attrNamesTimeout)
-          }
-          _ <- traceDBIOWithParent("saveEntityCache", parentSpan) { _ =>
-            dataAccess.entityCacheManagementQuery.saveEntityCache(workspaceId,
-                                                                  entityTypesWithCounts,
-                                                                  entityTypesWithAttrNames,
-                                                                  timestamp
-            )
-          }
-        } yield entityCacheSaveCounter.inc(),
-      isolationLevel
+    val updateFuture = dataSource.inTransaction(ReadCommitted)(dataAccess =>
+      // TODO: beware contention on the approach of delete-all and batch-insert all below
+      // if we see contention we could move to encoding the entire metadata object as json
+      // and storing in a single column on WORKSPACE_ENTITY_CACHE
+      for {
+        // calculate entity statistics
+        entityTypesWithCounts <- traceDBIOWithParent("getEntityTypesWithCounts", parentSpan) { _ =>
+          dataAccess.entityQuery.getEntityTypesWithCounts(workspaceId)
+        }
+        // calculate entity attribute statistics
+        entityTypesWithAttrNames <- traceDBIOWithParent("getAttrNamesAndEntityTypes", parentSpan) { _ =>
+          dataAccess.entityQuery.getAttrNamesAndEntityTypes(workspaceId, attrNamesTimeout)
+        }
+        _ <- traceDBIOWithParent("saveEntityCache", parentSpan) { _ =>
+          dataAccess.entityCacheManagementQuery.saveEntityCache(workspaceId,
+                                                                entityTypesWithCounts,
+                                                                entityTypesWithAttrNames,
+                                                                timestamp
+          )
+        }
+      } yield entityCacheSaveCounter.inc()
     )
 
     updateFuture.recover { case t: Throwable =>
       logger.error(s"Error updating statistics cache for workspaceId $workspaceId: ${t.getMessage}", t)
-      dataSource.inTransaction(
-        { dataAccess =>
-          logger.error(s"Workspace $workspaceId will be ignored by the entity cache monitor: ${t.getMessage}")
-          // We will set the cacheLastUpdated timestamp to the lowest possible value in MySQL.
-          // This is a "magic" value that allows the monitor to skip this problematic workspace
-          // so it does not get caught in a loop. These workspaces will require manual intervention.
-          val errMsg = s"${t.getMessage} ${ExceptionUtils.getStackTrace(t)}"
-          dataAccess.entityCacheQuery.updateCacheLastUpdated(workspaceId, MIN_CACHE_TIME, Some(errMsg))
-        },
-        isolationLevel
-      )
+      dataSource.inTransaction(ReadCommitted) { dataAccess =>
+        logger.error(s"Workspace $workspaceId will be ignored by the entity cache monitor: ${t.getMessage}")
+        // We will set the cacheLastUpdated timestamp to the lowest possible value in MySQL.
+        // This is a "magic" value that allows the monitor to skip this problematic workspace
+        // so it does not get caught in a loop. These workspaces will require manual intervention.
+        val errMsg = s"${t.getMessage} ${ExceptionUtils.getStackTrace(t)}"
+        dataAccess.entityCacheQuery.updateCacheLastUpdated(workspaceId, MIN_CACHE_TIME, Some(errMsg))
+      }
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/coordination/CoordinatedDataSourceActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/coordination/CoordinatedDataSourceActorSpec.scala
@@ -7,6 +7,7 @@ import akka.util.Timeout
 import org.broadinstitute.dsde.rawls.coordination.CoordinatedDataSourceActorSpec._
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
+import org.mockito.ArgumentMatchers.{any, eq => argeq}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
@@ -69,7 +70,7 @@ class CoordinatedDataSourceActorSpec
       val mockSlickDataSource = mock[SlickDataSource](RETURNS_SMART_NULLS)
       val mockDataAccessFunction = mock[DataAccess => ReadWriteAction[Any]](RETURNS_SMART_NULLS)
       val transactionIsolation = TransactionIsolation.RepeatableRead
-      when(mockSlickDataSource.inTransaction(mockDataAccessFunction, transactionIsolation))
+      when(mockSlickDataSource.inTransaction(argeq(mockDataAccessFunction), argeq(transactionIsolation), any()))
         .thenReturn(Future(function()))
       val future = testActor ?
         CoordinatedDataSourceActor.Run(
@@ -103,7 +104,7 @@ class CoordinatedDataSourceActorSpec
     val transactionIsolation = TransactionIsolation.RepeatableRead
 
     val quickening = new Quickening(individualSleep)
-    when(mockSlickDataSource.inTransaction(mockDataAccessFunction, transactionIsolation))
+    when(mockSlickDataSource.inTransaction(argeq(mockDataAccessFunction), argeq(transactionIsolation), any()))
       .thenAnswer(_ => Future(quickening.highlander()))
 
     val futures = (0 until numTested) map { _ =>
@@ -137,9 +138,9 @@ class CoordinatedDataSourceActorSpec
     val transactionIsolation = TransactionIsolation.RepeatableRead
 
     val quickening = new Quickening(individualSleep)
-    when(mockSlickDataSource.inTransaction(mockDataAccessFunction, transactionIsolation))
+    when(mockSlickDataSource.inTransaction(argeq(mockDataAccessFunction), argeq(transactionIsolation), any()))
       .thenAnswer(_ => Future(quickening.highlander()))
-    when(mockSlickDataSource.inTransaction(slowDataAccessFunction, transactionIsolation))
+    when(mockSlickDataSource.inTransaction(argeq(slowDataAccessFunction), argeq(transactionIsolation), any()))
       .thenAnswer(_ => Future(Thread.sleep(1.second.toMillis)))
 
     // Create the runs with short deadlines first

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/coordination/UncoordinatedDataSourceAccessSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/coordination/UncoordinatedDataSourceAccessSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.coordination
 
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
+import org.mockito.ArgumentMatchers.{any, eq => argeq}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
@@ -51,7 +52,7 @@ class UncoordinatedDataSourceAccessSpec
       val mockSlickDataSource = mock[SlickDataSource](RETURNS_SMART_NULLS)
       val mockDataAccessFunction = mock[DataAccess => ReadWriteAction[Any]](RETURNS_SMART_NULLS)
       val transactionIsolation = TransactionIsolation.RepeatableRead
-      when(mockSlickDataSource.inTransaction(mockDataAccessFunction, transactionIsolation))
+      when(mockSlickDataSource.inTransaction(argeq(mockDataAccessFunction), argeq(transactionIsolation), any()))
         .thenReturn(Future(function()))
       val testAccess = new UncoordinatedDataSourceAccess(mockSlickDataSource)
       val future = testAccess.inTransaction[Any](mockDataAccessFunction, transactionIsolation)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -896,7 +896,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val bpmDAO = mock[BillingProfileManagerDAO]
     when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
     val dataSource = mock[SlickDataSource]
-    when(dataSource.inTransaction[Option[BillingProjectSpendExport]](any(), any())).thenReturn(Future.successful(None))
+    when(dataSource.inTransaction[Option[BillingProjectSpendExport]](any(), any(), any()))
+      .thenReturn(Future.successful(None))
     val service = spy(
       new SpendReportingService(
         testContext,
@@ -926,7 +927,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
     when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
     val dataSource = mock[SlickDataSource]
-    when(dataSource.inTransaction[Option[BillingProjectSpendExport]](any(), any()))
+    when(dataSource.inTransaction[Option[BillingProjectSpendExport]](any(), any(), any()))
       .thenReturn(Future.failed(new RawlsException()))
     val service = new SpendReportingService(
       testContext,
@@ -2388,7 +2389,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       "test.rawls"
     )
 
-    when(mockDataSource.inTransaction[Option[BillingProjectSpendExport]](any(), any()))
+    when(mockDataSource.inTransaction[Option[BillingProjectSpendExport]](any(), any(), any()))
       .thenReturn(
         Future.successful(
           Some(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManagerUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManagerUnitTests.scala
@@ -59,7 +59,7 @@ class MultiCloudWorkspaceAclManagerUnitTests extends AnyFlatSpec with MockitoTes
     val billingProfileId = UUID.randomUUID()
 
     val mockDataSource = mock[SlickDataSource](RETURNS_SMART_NULLS)
-    when(mockDataSource.inTransaction[Option[RawlsBillingProject]](any(), any())).thenReturn(
+    when(mockDataSource.inTransaction[Option[RawlsBillingProject]](any(), any(), any())).thenReturn(
       Future.successful(
         Option(
           RawlsBillingProject(
@@ -120,7 +120,7 @@ class MultiCloudWorkspaceAclManagerUnitTests extends AnyFlatSpec with MockitoTes
     )
 
     val mockDataSource = mock[SlickDataSource](RETURNS_SMART_NULLS)
-    when(mockDataSource.inTransaction[Option[RawlsBillingProject]](any(), any())).thenReturn(
+    when(mockDataSource.inTransaction[Option[RawlsBillingProject]](any(), any(), any())).thenReturn(
       Future.successful(
         Option(
           RawlsBillingProject(
@@ -168,7 +168,7 @@ class MultiCloudWorkspaceAclManagerUnitTests extends AnyFlatSpec with MockitoTes
     )
 
     val mockDataSource = mock[SlickDataSource](RETURNS_SMART_NULLS)
-    when(mockDataSource.inTransaction[Option[RawlsBillingProject]](any(), any())).thenReturn(
+    when(mockDataSource.inTransaction[Option[RawlsBillingProject]](any(), any(), any())).thenReturn(
       Future.successful(
         None
       )


### PR DESCRIPTION
Ticket: CORE-362

Some prefactoring for the main changes in CORE-362.

This PR adds new, hopefully more readable, signatures for the `DataSource.inTransaction` method. This includes a new ability to specify the result set concurrency: `ReadOnly` vs. `Updatable`. See https://dev.mysql.com/doc/refman/8.4/en/innodb-performance-ro-txn.html for more info on the `ReadOnly` hint.

See `EntityStatisticsCacheMonitor` and `LocalEntityProvider` for example changes of how these new signatures look. The TL;DR is it changes the code from
```scala
dataSource.inTransaction{ … many lines of code … }, ReadCommitted
```
to
```scala
dataSource.inTransaction(ReadCommitted){ … many lines of code … }
```
