### PR TITLE
[CORE-438] Merge source workspace PAO into new workspace PAO when cloning

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.tps
 
 import bio.terra.policy.api.TpsApi
 import bio.terra.policy.client.ApiClient
-import bio.terra.policy.model.TpsPaoCreateRequest
+import bio.terra.policy.model.{TpsPaoCreateRequest, TpsPaoSourceRequest}
 import jakarta.ws.rs.client.ClientBuilder
 import org.broadinstitute.dsde.rawls.credentials.RawlsCredential
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
@@ -12,7 +12,8 @@ import org.glassfish.jersey.jnh.connector.JavaNetHttpConnectorProvider
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import scala.concurrent.{blocking, ExecutionContext, Future}
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future, blocking}
 
 class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec: ExecutionContext) extends TpsDAO {
   protected def getApiClient(ctx: RawlsRequestContext): ApiClient = {
@@ -42,6 +43,12 @@ class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec:
   def createPao(request: TpsPaoCreateRequest, ctx: RawlsRequestContext): Future[Unit] = Future {
     blocking {
       getTpsApi(ctx).createPao(request)
+    }
+  }
+
+  def mergePao(request: TpsPaoSourceRequest, destPaoId: UUID, ctx: RawlsRequestContext): Future[Unit] = Future {
+    blocking {
+      getTpsApi(ctx).mergePao(request, destPaoId)
     }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
@@ -13,7 +13,7 @@ import org.glassfish.jersey.jnh.connector.JavaNetHttpConnectorProvider
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import scala.concurrent.{ExecutionContext, Future, blocking}
+import scala.concurrent.{blocking, ExecutionContext, Future}
 
 class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec: ExecutionContext) extends TpsDAO {
   protected def getApiClient(ctx: RawlsRequestContext): ApiClient = {
@@ -46,9 +46,9 @@ class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec:
     }
   }
 
-  def mergePao(request: TpsPaoSourceRequest, destPaoId: UUID, ctx: RawlsRequestContext): Future[Unit] = Future {
+  def mergePao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[Unit] = Future {
     blocking {
-      getTpsApi(ctx).mergePao(request, destPaoId)
+      getTpsApi(ctx).mergePao(request, objectId)
     }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
@@ -1,10 +1,13 @@
 package org.broadinstitute.dsde.rawls.dataaccess.tps
 
-import bio.terra.policy.model.TpsPaoCreateRequest
+import bio.terra.policy.model.{TpsPaoCreateRequest, TpsPaoSourceRequest}
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
 
+import java.util.UUID
 import scala.concurrent.Future
 
 trait TpsDAO {
   def createPao(request: TpsPaoCreateRequest, ctx: RawlsRequestContext): Future[Unit]
+
+  def mergePao(request: TpsPaoSourceRequest, destPaoId: UUID, ctx: RawlsRequestContext): Future[Unit]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
@@ -9,5 +9,5 @@ import scala.concurrent.Future
 trait TpsDAO {
   def createPao(request: TpsPaoCreateRequest, ctx: RawlsRequestContext): Future[Unit]
 
-  def mergePao(request: TpsPaoSourceRequest, destPaoId: UUID, ctx: RawlsRequestContext): Future[Unit]
+  def mergePao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[Unit]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -1,13 +1,6 @@
 package org.broadinstitute.dsde.rawls.policy
 
-import bio.terra.policy.model.{
-  TpsComponent,
-  TpsObjectType,
-  TpsPaoCreateRequest,
-  TpsPolicyInput,
-  TpsPolicyInputs,
-  TpsPolicyPair
-}
+import bio.terra.policy.model.{TpsComponent, TpsObjectType, TpsPaoCreateRequest, TpsPaoSourceRequest, TpsPolicyInput, TpsPolicyInputs, TpsPolicyPair, TpsUpdateMode}
 import org.broadinstitute.dsde.rawls.dataaccess.tps.TpsDAO
 import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, TpsPolicies}
 import org.broadinstitute.dsde.rawls.model.{ManagedGroupRef, RawlsGroupName, RawlsRequestContext, WorkspaceRequest}
@@ -46,4 +39,14 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) {
 
     tpsDAO.createPao(req, ctx)
   }
+
+  def mergeWorkspacePao(sourceWorkspaceId: UUID,
+                        destWorkspaceId: UUID,
+                        ctx: RawlsRequestContext): Future[Unit] = {
+    val req = new TpsPaoSourceRequest().sourceObjectId(sourceWorkspaceId).updateMode(TpsUpdateMode.FAIL_ON_CONFLICT)
+
+
+    tpsDAO.mergePao(req, destWorkspaceId, ctx)
+  }
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -50,9 +50,9 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) {
   }
 
   /**
-    * Despite what the documentation and naming in TPS would have you believe, the mergePao endpoint
-    * will merge the policies from the PAO of the specified object id into the PAO of the source
-    * object id.
+    * The documentation for this TPS API is misleading. It will merge the target PAO into the source
+    * PAO, NOT the other way around. While it might be confusing to see the destination workspace id
+    * used as the `sourceObjectId`, this is the correct way to call the TPS API.
     */
   def mergeWorkspacePao(sourceWorkspaceId: UUID, destWorkspaceId: UUID, ctx: RawlsRequestContext): Future[Unit] = {
     val req = new TpsPaoSourceRequest().sourceObjectId(destWorkspaceId).updateMode(TpsUpdateMode.FAIL_ON_CONFLICT)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -1,6 +1,15 @@
 package org.broadinstitute.dsde.rawls.policy
 
-import bio.terra.policy.model.{TpsComponent, TpsObjectType, TpsPaoCreateRequest, TpsPaoSourceRequest, TpsPolicyInput, TpsPolicyInputs, TpsPolicyPair, TpsUpdateMode}
+import bio.terra.policy.model.{
+  TpsComponent,
+  TpsObjectType,
+  TpsPaoCreateRequest,
+  TpsPaoSourceRequest,
+  TpsPolicyInput,
+  TpsPolicyInputs,
+  TpsPolicyPair,
+  TpsUpdateMode
+}
 import org.broadinstitute.dsde.rawls.dataaccess.tps.TpsDAO
 import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, TpsPolicies}
 import org.broadinstitute.dsde.rawls.model.{ManagedGroupRef, RawlsGroupName, RawlsRequestContext, WorkspaceRequest}
@@ -40,13 +49,15 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) {
     tpsDAO.createPao(req, ctx)
   }
 
-  def mergeWorkspacePao(sourceWorkspaceId: UUID,
-                        destWorkspaceId: UUID,
-                        ctx: RawlsRequestContext): Future[Unit] = {
-    val req = new TpsPaoSourceRequest().sourceObjectId(sourceWorkspaceId).updateMode(TpsUpdateMode.FAIL_ON_CONFLICT)
+  /**
+    * Despite what the documentation and naming in TPS would have you believe, the mergePao endpoint
+    * will merge the policies from the PAO of the specified object id into the PAO of the source
+    * object id.
+    */
+  def mergeWorkspacePao(sourceWorkspaceId: UUID, destWorkspaceId: UUID, ctx: RawlsRequestContext): Future[Unit] = {
+    val req = new TpsPaoSourceRequest().sourceObjectId(destWorkspaceId).updateMode(TpsUpdateMode.FAIL_ON_CONFLICT)
 
-
-    tpsDAO.mergePao(req, destWorkspaceId, ctx)
+    tpsDAO.mergePao(req, sourceWorkspaceId, ctx)
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -222,7 +222,7 @@ class WorkspaceService(
               newWorkspace <- createNewWorkspaceContext(workspaceRequest,
                                                         billingProject,
                                                         sourceBucketName = None,
-                sourceWorkspaceId = None,
+                                                        sourceWorkspaceId = None,
                                                         dataAccess,
                                                         s
               )
@@ -2024,11 +2024,14 @@ class WorkspaceService(
         )
       }
 
-      _ <- if (sourceWorkspaceId.isDefined) { traceDBIOWithParent("mergeSourcePaoIntoDestPao", parentContext) { span =>
-          DBIO.from(
-            policyService.mergeWorkspacePao(sourceWorkspaceId.get, UUID.fromString(workspaceId), span)
-          )
-        }} else DBIO.successful(())
+      _ <-
+        if (sourceWorkspaceId.isDefined) {
+          traceDBIOWithParent("mergeSourcePaoIntoDestPao", parentContext) { span =>
+            DBIO.from(
+              policyService.mergeWorkspacePao(sourceWorkspaceId.get, UUID.fromString(workspaceId), span)
+            )
+          }
+        } else DBIO.successful(())
 
       resource <- createWorkspaceResourceInSam(workspaceId,
                                                billingProjectOwnerPolicyEmail,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -222,6 +222,7 @@ class WorkspaceService(
               newWorkspace <- createNewWorkspaceContext(workspaceRequest,
                                                         billingProject,
                                                         sourceBucketName = None,
+                sourceWorkspaceId = None,
                                                         dataAccess,
                                                         s
               )
@@ -738,6 +739,7 @@ class WorkspaceService(
                 ),
                 billingProject,
                 sourceBucketNameOption,
+                sourceWorkspaceId = Some(sourceWorkspaceContext.workspaceIdAsUUID),
                 dataAccess,
                 s
               )
@@ -1952,6 +1954,7 @@ class WorkspaceService(
   private def createNewWorkspaceContext(workspaceRequest: WorkspaceRequest,
                                         billingProject: RawlsBillingProject,
                                         sourceBucketName: Option[String],
+                                        sourceWorkspaceId: Option[UUID],
                                         dataAccess: DataAccess,
                                         parentContext: RawlsRequestContext
   ): ReadWriteAction[Workspace] = {
@@ -2020,6 +2023,12 @@ class WorkspaceService(
           policyService.createWorkspacePao(UUID.fromString(workspaceId), workspaceRequest, span)
         )
       }
+
+      _ <- if (sourceWorkspaceId.isDefined) { traceDBIOWithParent("mergeSourcePaoIntoDestPao", parentContext) { span =>
+          DBIO.from(
+            policyService.mergeWorkspacePao(sourceWorkspaceId.get, UUID.fromString(workspaceId), span)
+          )
+        }} else DBIO.successful(())
 
       resource <- createWorkspaceResourceInSam(workspaceId,
                                                billingProjectOwnerPolicyEmail,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
@@ -131,6 +131,7 @@ class FastPassMonitorSpec
     val leonardoDAO: LeonardoDAO = new MockLeonardoDAO()
     val policyService = mock[PolicyService](RETURNS_SMART_NULLS)
     when(policyService.createWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
+    when(policyService.mergeWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
 
     val notificationTopic = "test-notification-topic"
     val notificationDAO = Mockito.spy(new PubSubNotificationDAO(gpsDAO, notificationTopic))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -160,6 +160,7 @@ class FastPassServiceSpec
     val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO(mockServer.mockServerBaseUrl)
     val policyService = mock[PolicyService](RETURNS_SMART_NULLS)
     when(policyService.createWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
+    when(policyService.mergeWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
 
     val notificationTopic = "test-notification-topic"
     val notificationDAO = Mockito.spy(new PubSubNotificationDAO(gpsDAO, notificationTopic))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/policy/PolicyServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/policy/PolicyServiceSpec.scala
@@ -4,9 +4,11 @@ import bio.terra.policy.model.{
   TpsComponent,
   TpsObjectType,
   TpsPaoCreateRequest,
+  TpsPaoSourceRequest,
   TpsPolicyInput,
   TpsPolicyInputs,
-  TpsPolicyPair
+  TpsPolicyPair,
+  TpsUpdateMode
 }
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.tps.TpsDAO
@@ -107,5 +109,26 @@ class PolicyServiceSpec extends AnyFlatSpec {
     )
 
     verify(tpsDAO).createPao(mockitoEq(expectedPaoRequest), any())
+  }
+
+  behavior of "mergeWorkspacePao"
+
+  it should "call mergePao with the correct parameters" in {
+    val sourceWorkspaceId = UUID.randomUUID()
+    val destWorkspaceId = UUID.randomUUID()
+
+    val tpsDAO = mock[TpsDAO](RETURNS_SMART_NULLS)
+    when(tpsDAO.mergePao(any(), any(), any())).thenReturn(Future.unit)
+    val policyService = new PolicyService(tpsDAO)
+
+    val expectedPaoRequest = new TpsPaoSourceRequest()
+      .sourceObjectId(destWorkspaceId)
+      .updateMode(TpsUpdateMode.FAIL_ON_CONFLICT)
+
+    Await.result(policyService.mergeWorkspacePao(sourceWorkspaceId, destWorkspaceId, mock[RawlsRequestContext]),
+                 Duration.Inf
+    )
+
+    verify(tpsDAO).mergePao(mockitoEq(expectedPaoRequest), mockitoEq(sourceWorkspaceId), any())
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -204,6 +204,7 @@ trait ApiServiceSpec
 
     val policyService = mock[PolicyService](RETURNS_SMART_NULLS)
     when(policyService.createWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
+    when(policyService.mergeWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
 
     override val executionServiceCluster = MockShardedExecutionServiceCluster.fromDAO(
       new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -160,6 +160,7 @@ class WorkspaceServiceSpec
     val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO(mockServer.mockServerBaseUrl)
     val policyService = mock[PolicyService](RETURNS_SMART_NULLS)
     when(policyService.createWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
+    when(policyService.mergeWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
 
     val notificationTopic = "test-notification-topic"
     val notificationDAO = Mockito.spy(new PubSubNotificationDAO(gpsDAO, notificationTopic))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -1779,6 +1779,18 @@ class WorkspaceServiceSpec
       workspace.bucketName should startWith(s"${services.workspaceServiceConfig.workspaceBucketNamePrefix}-secure")
   }
 
+  it should "create a new PAO for the workspace" in withTestDataServices { services =>
+    val workspaceRequest = WorkspaceRequest(testData.workspace.namespace, "paoWs", Map.empty)
+
+    val newWs = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+
+    verify(services.policyService).createWorkspacePao(ArgumentMatchers.eq(UUID.fromString(newWs.workspaceId)),
+                                                      any(),
+                                                      any()
+    )
+    verify(services.policyService, never()).mergeWorkspacePao(any(), any(), any())
+  }
+
   // There is another test in WorkspaceComponentSpec that gets into more scenarios for selecting the right Workspaces
   // that should be within a Service Perimeter
   "creating a Workspace in a Service Perimeter" should "attempt to overwrite the correct Service Perimeter" in withTestDataServices {
@@ -1915,6 +1927,29 @@ class WorkspaceServiceSpec
     mergedAttributes.get(AttributeName.withDefaultNS("string")).value should be(AttributeString("destination string"))
     // from source attributes
     mergedAttributes.get(AttributeName.withDefaultNS("number")).value should be(AttributeNumber(10))
+  }
+
+  it should "create a new PAO and merge the source workspace's PAO into the destination workspace's PAO" in withTestDataServices {
+    services =>
+      val baseWorkspace = testData.workspace
+      val workspaceRequest = WorkspaceRequest(baseWorkspace.namespace, "clone", Map.empty)
+
+      val newlyClonedWs =
+        Await.result(services.mcWorkspaceService.cloneMultiCloudWorkspace(services.workspaceService,
+                                                                          baseWorkspace.toWorkspaceName,
+                                                                          workspaceRequest
+                     ),
+                     Duration.Inf
+        )
+
+      verify(services.policyService).createWorkspacePao(ArgumentMatchers.eq(UUID.fromString(newlyClonedWs.workspaceId)),
+                                                        any(),
+                                                        any()
+      )
+      verify(services.policyService).mergeWorkspacePao(ArgumentMatchers.eq(baseWorkspace.workspaceIdAsUUID),
+                                                       ArgumentMatchers.eq(UUID.fromString(newlyClonedWs.workspaceId)),
+                                                       any()
+      )
   }
 
   it should "fail with 400 if specified Namespace/Billing Project does not exist" in withTestDataServices { services =>


### PR DESCRIPTION
Ticket: [CORE-438](https://broadworkbench.atlassian.net/browse/CORE-438)
* If Rawls is cloning a workspace, it will merge the source workspace's PAO into the destination workspace's PAO.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[CORE-438]: https://broadworkbench.atlassian.net/browse/CORE-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ