### PR TITLE
[PROD-1016] Fix workspace cloning

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
@@ -13,7 +13,7 @@ import org.glassfish.jersey.jnh.connector.JavaNetHttpConnectorProvider
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import scala.concurrent.{ExecutionContext, Future, blocking}
+import scala.concurrent.{blocking, ExecutionContext, Future}
 import scala.util.Try
 
 class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec: ExecutionContext) extends TpsDAO {
@@ -56,9 +56,9 @@ class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec:
   def getPao(objectId: UUID, ctx: RawlsRequestContext): Future[Option[TpsPaoGetResult]] = Future {
     blocking {
       val tpsApi = getTpsApi(ctx)
-      try {
+      try
         Option(tpsApi.getPao(objectId, false))
-      } catch {
+      catch {
         case ex: ApiException if ex.getCode == 404 => None
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
@@ -1,8 +1,8 @@
 package org.broadinstitute.dsde.rawls.dataaccess.tps
 
 import bio.terra.policy.api.TpsApi
-import bio.terra.policy.client.ApiClient
-import bio.terra.policy.model.{TpsPaoCreateRequest, TpsPaoSourceRequest}
+import bio.terra.policy.client.{ApiClient, ApiException}
+import bio.terra.policy.model.{TpsPaoCreateRequest, TpsPaoGetResult, TpsPaoSourceRequest}
 import jakarta.ws.rs.client.ClientBuilder
 import org.broadinstitute.dsde.rawls.credentials.RawlsCredential
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
@@ -13,7 +13,8 @@ import org.glassfish.jersey.jnh.connector.JavaNetHttpConnectorProvider
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import scala.concurrent.{blocking, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, blocking}
+import scala.util.Try
 
 class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec: ExecutionContext) extends TpsDAO {
   protected def getApiClient(ctx: RawlsRequestContext): ApiClient = {
@@ -49,6 +50,17 @@ class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec:
   def mergePao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[Unit] = Future {
     blocking {
       getTpsApi(ctx).mergePao(request, objectId)
+    }
+  }
+
+  def getPao(objectId: UUID, ctx: RawlsRequestContext): Future[Option[TpsPaoGetResult]] = Future {
+    blocking {
+      val tpsApi = getTpsApi(ctx)
+      try {
+        Option(tpsApi.getPao(objectId, false))
+      } catch {
+        case ex: ApiException if ex.getCode == 404 => None
+      }
     }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess.tps
 
-import bio.terra.policy.model.{TpsPaoCreateRequest, TpsPaoSourceRequest}
+import bio.terra.policy.model.{TpsPaoCreateRequest, TpsPaoGetResult, TpsPaoSourceRequest}
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
 
 import java.util.UUID
@@ -10,4 +10,6 @@ trait TpsDAO {
   def createPao(request: TpsPaoCreateRequest, ctx: RawlsRequestContext): Future[Unit]
 
   def mergePao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[Unit]
+
+  def getPao(objectId: UUID, ctx: RawlsRequestContext): Future[Option[TpsPaoGetResult]]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -1,6 +1,16 @@
 package org.broadinstitute.dsde.rawls.policy
 
-import bio.terra.policy.model.{TpsComponent, TpsObjectType, TpsPaoCreateRequest, TpsPaoGetResult, TpsPaoSourceRequest, TpsPolicyInput, TpsPolicyInputs, TpsPolicyPair, TpsUpdateMode}
+import bio.terra.policy.model.{
+  TpsComponent,
+  TpsObjectType,
+  TpsPaoCreateRequest,
+  TpsPaoGetResult,
+  TpsPaoSourceRequest,
+  TpsPolicyInput,
+  TpsPolicyInputs,
+  TpsPolicyPair,
+  TpsUpdateMode
+}
 import org.broadinstitute.dsde.rawls.dataaccess.tps.TpsDAO
 import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, TpsPolicies}
 import org.broadinstitute.dsde.rawls.model.{ManagedGroupRef, RawlsGroupName, RawlsRequestContext, WorkspaceRequest}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -1,15 +1,6 @@
 package org.broadinstitute.dsde.rawls.policy
 
-import bio.terra.policy.model.{
-  TpsComponent,
-  TpsObjectType,
-  TpsPaoCreateRequest,
-  TpsPaoSourceRequest,
-  TpsPolicyInput,
-  TpsPolicyInputs,
-  TpsPolicyPair,
-  TpsUpdateMode
-}
+import bio.terra.policy.model.{TpsComponent, TpsObjectType, TpsPaoCreateRequest, TpsPaoGetResult, TpsPaoSourceRequest, TpsPolicyInput, TpsPolicyInputs, TpsPolicyPair, TpsUpdateMode}
 import org.broadinstitute.dsde.rawls.dataaccess.tps.TpsDAO
 import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, TpsPolicies}
 import org.broadinstitute.dsde.rawls.model.{ManagedGroupRef, RawlsGroupName, RawlsRequestContext, WorkspaceRequest}
@@ -60,4 +51,6 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) {
     tpsDAO.mergePao(req, sourceWorkspaceId, ctx)
   }
 
+  def getPao(objectId: UUID, ctx: RawlsRequestContext): Future[Option[TpsPaoGetResult]] =
+    tpsDAO.getPao(objectId, ctx)
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -223,7 +223,7 @@ class WorkspaceService(
               newWorkspace <- createNewWorkspaceContext(workspaceRequest,
                                                         billingProject,
                                                         sourceBucketName = None,
-                                                        sourceWorkspaceId = None,
+                                                        sourceWorkspaceIdOpt = None,
                                                         dataAccess,
                                                         s
               )
@@ -740,7 +740,7 @@ class WorkspaceService(
                 ),
                 billingProject,
                 sourceBucketNameOption,
-                sourceWorkspaceId = Some(sourceWorkspaceContext.workspaceIdAsUUID),
+                sourceWorkspaceIdOpt = Some(sourceWorkspaceContext.workspaceIdAsUUID),
                 dataAccess,
                 s
               )
@@ -1955,7 +1955,7 @@ class WorkspaceService(
   private def createNewWorkspaceContext(workspaceRequest: WorkspaceRequest,
                                         billingProject: RawlsBillingProject,
                                         sourceBucketName: Option[String],
-                                        sourceWorkspaceId: Option[UUID],
+                                        sourceWorkspaceIdOpt: Option[UUID],
                                         dataAccess: DataAccess,
                                         parentContext: RawlsRequestContext
   ): ReadWriteAction[Workspace] = {
@@ -2025,11 +2025,17 @@ class WorkspaceService(
         )
       }
 
+      sourceWorkspacePaoOpt <- if (sourceWorkspaceIdOpt.isDefined) {
+        traceDBIOWithParent("getSourcePao", parentContext) { span =>
+          DBIO.from(policyService.getPao(sourceWorkspaceIdOpt.get, span))
+        }
+      } else DBIO.successful(None)
+
       _ <-
-        if (sourceWorkspaceId.isDefined) {
+        if (sourceWorkspacePaoOpt.isDefined) {
           traceDBIOWithParent("mergeSourcePaoIntoDestPao", parentContext) { span =>
             DBIO.from(
-              policyService.mergeWorkspacePao(sourceWorkspaceId.get, UUID.fromString(workspaceId), span)
+              policyService.mergeWorkspacePao(sourceWorkspaceIdOpt.get, UUID.fromString(workspaceId), span)
             )
           }
         } else DBIO.successful(())

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2025,11 +2025,12 @@ class WorkspaceService(
         )
       }
 
-      sourceWorkspacePaoOpt <- if (sourceWorkspaceIdOpt.isDefined) {
-        traceDBIOWithParent("getSourcePao", parentContext) { span =>
-          DBIO.from(policyService.getPao(sourceWorkspaceIdOpt.get, span))
-        }
-      } else DBIO.successful(None)
+      sourceWorkspacePaoOpt <-
+        if (sourceWorkspaceIdOpt.isDefined) {
+          traceDBIOWithParent("getSourcePao", parentContext) { span =>
+            DBIO.from(policyService.getPao(sourceWorkspaceIdOpt.get, span))
+          }
+        } else DBIO.successful(None)
 
       _ <-
         if (sourceWorkspacePaoOpt.isDefined) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
@@ -30,7 +30,13 @@ import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterServiceImp
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice._
-import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceAclManager, MultiCloudWorkspaceService, RawlsWorkspaceAclManager, WorkspaceService, WorkspaceSettingRepository}
+import org.broadinstitute.dsde.rawls.workspace.{
+  MultiCloudWorkspaceAclManager,
+  MultiCloudWorkspaceService,
+  RawlsWorkspaceAclManager,
+  WorkspaceService,
+  WorkspaceSettingRepository
+}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.fastpass
 import akka.actor.PoisonPill
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import bio.terra.policy.model.TpsPaoGetResult
 import cats.effect.IO
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsTestUtils}
@@ -29,13 +30,7 @@ import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterServiceImp
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice._
-import org.broadinstitute.dsde.rawls.workspace.{
-  MultiCloudWorkspaceAclManager,
-  MultiCloudWorkspaceService,
-  RawlsWorkspaceAclManager,
-  WorkspaceService,
-  WorkspaceSettingRepository
-}
+import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceAclManager, MultiCloudWorkspaceService, RawlsWorkspaceAclManager, WorkspaceService, WorkspaceSettingRepository}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
@@ -132,6 +127,7 @@ class FastPassMonitorSpec
     val policyService = mock[PolicyService](RETURNS_SMART_NULLS)
     when(policyService.createWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
     when(policyService.mergeWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
+    when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(new TpsPaoGetResult())))
 
     val notificationTopic = "test-notification-topic"
     val notificationDAO = Mockito.spy(new PubSubNotificationDAO(gpsDAO, notificationTopic))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.fastpass
 import akka.actor.PoisonPill
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import bio.terra.policy.model.TpsPaoGetResult
 import cats.effect.IO
 import com.google.api.services.iam.v1.model.Role
 import com.typesafe.config.ConfigFactory
@@ -30,13 +31,7 @@ import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice._
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService.BUCKET_GET_PERMISSION
-import org.broadinstitute.dsde.rawls.workspace.{
-  MultiCloudWorkspaceAclManager,
-  MultiCloudWorkspaceService,
-  RawlsWorkspaceAclManager,
-  WorkspaceService,
-  WorkspaceSettingRepository
-}
+import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceAclManager, MultiCloudWorkspaceService, RawlsWorkspaceAclManager, WorkspaceService, WorkspaceSettingRepository}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, RawlsTestUtils}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO.toProjectPolicy
@@ -56,7 +51,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{BeforeAndAfterAll, OneInstancePerTest, OptionValues}
 
 import java.sql.Timestamp
-import java.time.{Duration => JavaDuration, LocalDateTime, OffsetDateTime, ZoneOffset}
+import java.time.{LocalDateTime, OffsetDateTime, ZoneOffset, Duration => JavaDuration}
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters._
@@ -161,6 +156,7 @@ class FastPassServiceSpec
     val policyService = mock[PolicyService](RETURNS_SMART_NULLS)
     when(policyService.createWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
     when(policyService.mergeWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
+    when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(new TpsPaoGetResult())))
 
     val notificationTopic = "test-notification-topic"
     val notificationDAO = Mockito.spy(new PubSubNotificationDAO(gpsDAO, notificationTopic))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -31,7 +31,13 @@ import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice._
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService.BUCKET_GET_PERMISSION
-import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceAclManager, MultiCloudWorkspaceService, RawlsWorkspaceAclManager, WorkspaceService, WorkspaceSettingRepository}
+import org.broadinstitute.dsde.rawls.workspace.{
+  MultiCloudWorkspaceAclManager,
+  MultiCloudWorkspaceService,
+  RawlsWorkspaceAclManager,
+  WorkspaceService,
+  WorkspaceSettingRepository
+}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, RawlsTestUtils}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO.toProjectPolicy
@@ -51,7 +57,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{BeforeAndAfterAll, OneInstancePerTest, OptionValues}
 
 import java.sql.Timestamp
-import java.time.{LocalDateTime, OffsetDateTime, ZoneOffset, Duration => JavaDuration}
+import java.time.{Duration => JavaDuration, LocalDateTime, OffsetDateTime, ZoneOffset}
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters._

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -72,7 +72,7 @@ import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, Moc
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
-import org.mockito.{ArgumentMatcher, ArgumentMatchers}
+import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{spy, when, RETURNS_SMART_NULLS}
 import org.scalatest.concurrent.Eventually

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -31,12 +31,22 @@ import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.fastpass.FastPassServiceImpl
 import org.broadinstitute.dsde.rawls.genomics.GenomicsServiceImpl
 import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
-import org.broadinstitute.dsde.rawls.googleProject.{GoogleProjectRegistrationRepository, GoogleProjectRegistrationService}
+import org.broadinstitute.dsde.rawls.googleProject.{
+  GoogleProjectRegistrationRepository,
+  GoogleProjectRegistrationService
+}
 import org.broadinstitute.dsde.rawls.jobexec.{SubmissionMonitorConfig, SubmissionSupervisor}
 import org.broadinstitute.dsde.rawls.methods.MethodConfigurationService
 import org.broadinstitute.dsde.rawls.metrics.{InstrumentationDirectives, RawlsInstrumented, RawlsStatsDTestUtils}
 import org.broadinstitute.dsde.rawls.mock._
-import org.broadinstitute.dsde.rawls.model.{Agora, ApplicationVersion, Dockstore, GoogleProjectId, RawlsRequestContext, RawlsUser}
+import org.broadinstitute.dsde.rawls.model.{
+  Agora,
+  ApplicationVersion,
+  Dockstore,
+  GoogleProjectId,
+  RawlsRequestContext,
+  RawlsUser
+}
 import org.broadinstitute.dsde.rawls.monitor.HealthMonitor
 import org.broadinstitute.dsde.rawls.policy.PolicyService
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferServiceImpl
@@ -47,7 +57,16 @@ import org.broadinstitute.dsde.rawls.status.StatusService
 import org.broadinstitute.dsde.rawls.submissions.SubmissionsService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
-import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceAclManager, MultiCloudWorkspaceService, RawlsWorkspaceAclManager, WorkspaceAdminService, WorkspaceRepository, WorkspaceService, WorkspaceSettingRepository, WorkspaceSettingService}
+import org.broadinstitute.dsde.rawls.workspace.{
+  MultiCloudWorkspaceAclManager,
+  MultiCloudWorkspaceService,
+  RawlsWorkspaceAclManager,
+  WorkspaceAdminService,
+  WorkspaceRepository,
+  WorkspaceService,
+  WorkspaceSettingRepository,
+  WorkspaceSettingService
+}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
@@ -55,7 +74,7 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
 import org.mockito.{ArgumentMatcher, ArgumentMatchers}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, spy, when}
+import org.mockito.Mockito.{spy, when, RETURNS_SMART_NULLS}
 import org.scalatest.concurrent.Eventually
 import spray.json._
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.stream.ActorMaterializer
 import akka.testkit.{TestActors, TestKitBase}
+import bio.terra.policy.model.TpsPaoGetResult
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.typesafe.config.ConfigFactory
@@ -30,22 +31,12 @@ import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.fastpass.FastPassServiceImpl
 import org.broadinstitute.dsde.rawls.genomics.GenomicsServiceImpl
 import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
-import org.broadinstitute.dsde.rawls.googleProject.{
-  GoogleProjectRegistrationRepository,
-  GoogleProjectRegistrationService
-}
+import org.broadinstitute.dsde.rawls.googleProject.{GoogleProjectRegistrationRepository, GoogleProjectRegistrationService}
 import org.broadinstitute.dsde.rawls.jobexec.{SubmissionMonitorConfig, SubmissionSupervisor}
 import org.broadinstitute.dsde.rawls.methods.MethodConfigurationService
 import org.broadinstitute.dsde.rawls.metrics.{InstrumentationDirectives, RawlsInstrumented, RawlsStatsDTestUtils}
 import org.broadinstitute.dsde.rawls.mock._
-import org.broadinstitute.dsde.rawls.model.{
-  Agora,
-  ApplicationVersion,
-  Dockstore,
-  GoogleProjectId,
-  RawlsRequestContext,
-  RawlsUser
-}
+import org.broadinstitute.dsde.rawls.model.{Agora, ApplicationVersion, Dockstore, GoogleProjectId, RawlsRequestContext, RawlsUser}
 import org.broadinstitute.dsde.rawls.monitor.HealthMonitor
 import org.broadinstitute.dsde.rawls.policy.PolicyService
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferServiceImpl
@@ -56,24 +47,15 @@ import org.broadinstitute.dsde.rawls.status.StatusService
 import org.broadinstitute.dsde.rawls.submissions.SubmissionsService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
-import org.broadinstitute.dsde.rawls.workspace.{
-  MultiCloudWorkspaceAclManager,
-  MultiCloudWorkspaceService,
-  RawlsWorkspaceAclManager,
-  WorkspaceAdminService,
-  WorkspaceRepository,
-  WorkspaceService,
-  WorkspaceSettingRepository,
-  WorkspaceSettingService
-}
+import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceAclManager, MultiCloudWorkspaceService, RawlsWorkspaceAclManager, WorkspaceAdminService, WorkspaceRepository, WorkspaceService, WorkspaceSettingRepository, WorkspaceSettingService}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
-import org.mockito.ArgumentMatcher
+import org.mockito.{ArgumentMatcher, ArgumentMatchers}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{spy, when, RETURNS_SMART_NULLS}
+import org.mockito.Mockito.{RETURNS_SMART_NULLS, spy, when}
 import org.scalatest.concurrent.Eventually
 import spray.json._
 
@@ -205,6 +187,7 @@ trait ApiServiceSpec
     val policyService = mock[PolicyService](RETURNS_SMART_NULLS)
     when(policyService.createWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
     when(policyService.mergeWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
+    when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(new TpsPaoGetResult())))
 
     override val executionServiceCluster = MockShardedExecutionServiceCluster.fromDAO(
       new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -7,7 +7,15 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import bio.terra.policy.model.TpsPaoGetResult
 import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.client.ApiException
-import bio.terra.workspace.model.{AzureContext, GcpContext, WorkspaceDescription, WorkspaceStageModel, WsmPolicyInput, WsmPolicyInputs, WsmPolicyPair}
+import bio.terra.workspace.model.{
+  AzureContext,
+  GcpContext,
+  WorkspaceDescription,
+  WorkspaceStageModel,
+  WsmPolicyInput,
+  WsmPolicyInputs,
+  WsmPolicyPair
+}
 import cats.implicits.catsSyntaxOptionId
 import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonResponseException}
 import com.google.api.client.http.{HttpHeaders, HttpResponseException}
@@ -45,7 +53,12 @@ import org.broadinstitute.dsde.rawls.submissions.SubmissionsService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice._
-import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, RawlsTestUtils, TestExecutionContext}
+import org.broadinstitute.dsde.rawls.{
+  NoSuchWorkspaceException,
+  RawlsExceptionWithErrorReport,
+  RawlsTestUtils,
+  TestExecutionContext
+}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, IamPermission}
@@ -1942,28 +1955,28 @@ class WorkspaceServiceSpec
       )
   }
 
-  it should "still clone the workspace if the source workspace doesn't have a PAO" in withTestDataServices {
-    services =>
-      val baseWorkspace = testData.workspace
-      val workspaceRequest = WorkspaceRequest(baseWorkspace.namespace, "clone", Map.empty)
-      when(services.policyService.getPao(any(), any())).thenReturn(Future(None))
+  it should "still clone the workspace if the source workspace doesn't have a PAO" in withTestDataServices { services =>
+    val baseWorkspace = testData.workspace
+    val workspaceRequest = WorkspaceRequest(baseWorkspace.namespace, "clone", Map.empty)
+    when(services.policyService.getPao(any(), any())).thenReturn(Future(None))
 
-      val newlyClonedWs =
-        Await.result(services.mcWorkspaceService.cloneMultiCloudWorkspace(services.workspaceService,
-          baseWorkspace.toWorkspaceName,
-          workspaceRequest
-        ),
-          Duration.Inf
-        )
+    val newlyClonedWs =
+      Await.result(services.mcWorkspaceService.cloneMultiCloudWorkspace(services.workspaceService,
+                                                                        baseWorkspace.toWorkspaceName,
+                                                                        workspaceRequest
+                   ),
+                   Duration.Inf
+      )
 
-      verify(services.policyService).createWorkspacePao(ArgumentMatchers.eq(UUID.fromString(newlyClonedWs.workspaceId)),
-        any(),
-        any()
-      )
-      verify(services.policyService, never).mergeWorkspacePao(ArgumentMatchers.eq(baseWorkspace.workspaceIdAsUUID),
-        ArgumentMatchers.eq(UUID.fromString(newlyClonedWs.workspaceId)),
-        any()
-      )
+    verify(services.policyService).createWorkspacePao(ArgumentMatchers.eq(UUID.fromString(newlyClonedWs.workspaceId)),
+                                                      any(),
+                                                      any()
+    )
+    verify(services.policyService, never).mergeWorkspacePao(
+      ArgumentMatchers.eq(baseWorkspace.workspaceIdAsUUID),
+      ArgumentMatchers.eq(UUID.fromString(newlyClonedWs.workspaceId)),
+      any()
+    )
   }
 
   it should "fail with 400 if specified Namespace/Billing Project does not exist" in withTestDataServices { services =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -4,17 +4,10 @@ import akka.actor.PoisonPill
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import bio.terra.policy.model.TpsPaoGetResult
 import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.client.ApiException
-import bio.terra.workspace.model.{
-  AzureContext,
-  GcpContext,
-  WorkspaceDescription,
-  WorkspaceStageModel,
-  WsmPolicyInput,
-  WsmPolicyInputs,
-  WsmPolicyPair
-}
+import bio.terra.workspace.model.{AzureContext, GcpContext, WorkspaceDescription, WorkspaceStageModel, WsmPolicyInput, WsmPolicyInputs, WsmPolicyPair}
 import cats.implicits.catsSyntaxOptionId
 import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonResponseException}
 import com.google.api.client.http.{HttpHeaders, HttpResponseException}
@@ -52,12 +45,7 @@ import org.broadinstitute.dsde.rawls.submissions.SubmissionsService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice._
-import org.broadinstitute.dsde.rawls.{
-  NoSuchWorkspaceException,
-  RawlsExceptionWithErrorReport,
-  RawlsTestUtils,
-  TestExecutionContext
-}
+import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, RawlsTestUtils, TestExecutionContext}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, IamPermission}
@@ -162,6 +150,7 @@ class WorkspaceServiceSpec
     val policyService = mock[PolicyService](RETURNS_SMART_NULLS)
     when(policyService.createWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
     when(policyService.mergeWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
+    when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(new TpsPaoGetResult())))
 
     val notificationTopic = "test-notification-topic"
     val notificationDAO = Mockito.spy(new PubSubNotificationDAO(gpsDAO, notificationTopic))
@@ -1950,6 +1939,30 @@ class WorkspaceServiceSpec
       verify(services.policyService).mergeWorkspacePao(ArgumentMatchers.eq(baseWorkspace.workspaceIdAsUUID),
                                                        ArgumentMatchers.eq(UUID.fromString(newlyClonedWs.workspaceId)),
                                                        any()
+      )
+  }
+
+  it should "still clone the workspace if the source workspace doesn't have a PAO" in withTestDataServices {
+    services =>
+      val baseWorkspace = testData.workspace
+      val workspaceRequest = WorkspaceRequest(baseWorkspace.namespace, "clone", Map.empty)
+      when(services.policyService.getPao(any(), any())).thenReturn(Future(None))
+
+      val newlyClonedWs =
+        Await.result(services.mcWorkspaceService.cloneMultiCloudWorkspace(services.workspaceService,
+          baseWorkspace.toWorkspaceName,
+          workspaceRequest
+        ),
+          Duration.Inf
+        )
+
+      verify(services.policyService).createWorkspacePao(ArgumentMatchers.eq(UUID.fromString(newlyClonedWs.workspaceId)),
+        any(),
+        any()
+      )
+      verify(services.policyService, never).mergeWorkspacePao(ArgumentMatchers.eq(baseWorkspace.workspaceIdAsUUID),
+        ArgumentMatchers.eq(UUID.fromString(newlyClonedWs.workspaceId)),
+        any()
       )
   }
 


### PR DESCRIPTION
Ticket: [PROD-1016](https://broadworkbench.atlassian.net/browse/PROD-1016)
* https://github.com/broadinstitute/rawls/pull/3269 broke workspace cloning because it does not handle the case where a source workspace does not have a PAO. Most workspaces do not have PAOs, so this broke workspace cloning in most cases. We will eventually backfill all workspace PAOs, but until then we need to be resilient to them not existing.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[PROD-1016]: https://broadworkbench.atlassian.net/browse/PROD-1016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ