### PR TITLE
CORE-382: remove admin list-all-workspaces API

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -907,52 +907,6 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-  /api/admin/workspaces:
-    get:
-      tags:
-        - admin
-        - workspaces
-      summary: list all workspaces
-      description: List all workspaces
-      operationId: listAllWorkspaces
-      parameters:
-        - name: attributeName
-          in: query
-          description: Optional workspace attribute to filter on
-          schema:
-            type: string
-        - name: valueString
-          in: query
-          description: attribute value (for String attributes)
-          schema:
-            type: string
-        - name: valueNumber
-          in: query
-          description: attribute value (for numerical attributes)
-          schema:
-            type: number
-        - name: valueBoolean
-          in: query
-          description: attribute value (for boolean attributes)
-          schema:
-            type: boolean
-      responses:
-        200:
-          description: Successful Request
-          content:
-            'application/json':
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/WorkspaceDetails'
-        403:
-          description: You must be an admin to list workspaces
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        500:
-          $ref: '#/components/responses/RawlsInternalError'
   /api/admin/workspaces/{workspaceId}:
     get:
       tags:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -506,16 +506,6 @@ trait AttributeComponent {
     def findByOwnerQuery(ownerIds: Seq[OWNER_ID]) =
       filter(_.ownerId inSetBind ownerIds)
 
-    def queryByAttribute(attrName: AttributeName, attrValue: AttributeValue) =
-      findByNameQuery(attrName).filter { rec =>
-        attrValue match {
-          case AttributeString(s)  => rec.valueString === s
-          case AttributeNumber(n)  => rec.valueNumber === n.doubleValue
-          case AttributeBoolean(b) => rec.valueBoolean === b
-          case _                   => throw new RawlsException("Unsupported attribute type")
-        }
-      }
-
     val caseSensitiveCollate = SimpleExpression.unary[Option[String], Option[String]] { (value, qb) =>
       qb.expr(value)
       qb.sqlBuilder += " collate utf8_bin"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -4,6 +4,7 @@ import cats.implicits.catsSyntaxOptionId
 import cats.instances.int._
 import cats.instances.option._
 import cats.{Monoid, MonoidK}
+import com.google.common.annotations.VisibleForTesting
 import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceState.WorkspaceState
@@ -255,6 +256,7 @@ trait WorkspaceComponent {
 
   object workspaceQuery extends TableQuery(new WorkspaceTable(_)) {
 
+    @VisibleForTesting
     def listAll(): ReadAction[Seq[Workspace]] =
       loadWorkspaces(workspaceQuery)
 
@@ -287,9 +289,6 @@ trait WorkspaceComponent {
         WorkspaceTag(rec._1, rec._2)
       })
     }
-
-    def listWithAttribute(attrName: AttributeName, attrValue: AttributeValue): ReadAction[Seq[Workspace]] =
-      loadWorkspaces(getWorkspacesWithAttribute(attrName, attrValue))
 
     /**
       * Creates or updates the provided Workspace.  First queries the database to see if a Workspace record already
@@ -444,22 +443,6 @@ trait WorkspaceComponent {
 
     def getV2WorkspaceId(workspaceName: WorkspaceName): ReadAction[Option[UUID]] =
       uniqueResult(workspaceQuery.findV2WorkspaceByNameQuery(workspaceName).result).map(x => x.map(_.id))
-
-    /**
-      * Lists all workspaces with a particular attribute name/value pair.
-      *
-      * ** Note: This is an inefficient query.  It performs a full scan of the attribute table since
-      *    there is no index on attribute name and/or value.  This method is only being used in one
-      *    place; if you find yourself needing this for other things, consider adding such an index.
-      * @param attrName
-      * @param attrValue
-      * @return
-      */
-    def getWorkspacesWithAttribute(attrName: AttributeName, attrValue: AttributeValue) =
-      for {
-        attribute <- workspaceAttributeQuery.queryByAttribute(attrName, attrValue)
-        workspace <- workspaceQuery if workspace.id === attribute.ownerId
-      } yield workspace
 
     def getWorkspacesInPerimeter(servicePerimeterName: ServicePerimeterName): ReadAction[Seq[Workspace]] = {
       val workspaces = for {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -8,9 +8,8 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
 import io.opentelemetry.context.Context
-import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.billing.BillingAdminService
-import org.broadinstitute.dsde.rawls.bucketMigration.{BucketMigrationService, BucketMigrationServiceImpl}
+import org.broadinstitute.dsde.rawls.bucketMigration.BucketMigrationService
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport._
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
@@ -88,39 +87,6 @@ trait AdminApiService extends UserInfoDirectives {
           get {
             complete {
               submissionsServiceConstructor(ctx).adminWorkflowQueueStatusByUser
-            }
-          }
-        } ~
-        path("admin" / "workspaces") {
-          get {
-            parameters('attributeName.?, 'valueString.?, 'valueNumber.?, 'valueBoolean.?) {
-              (nameOption, stringOption, numberOption, booleanOption) =>
-                val resultFuture = nameOption match {
-                  case None => workspaceAdminServiceConstructor(ctx).listAllWorkspaces()
-                  case Some(attributeName) =>
-                    val name = AttributeName.fromDelimitedName(attributeName)
-                    (stringOption, numberOption, booleanOption) match {
-                      case (Some(string), None, None) =>
-                        workspaceAdminServiceConstructor(ctx).adminListWorkspacesWithAttribute(name,
-                                                                                               AttributeString(string)
-                        )
-                      case (None, Some(number), None) =>
-                        workspaceAdminServiceConstructor(ctx).adminListWorkspacesWithAttribute(
-                          name,
-                          AttributeNumber(number.toDouble)
-                        )
-                      case (None, None, Some(boolean)) =>
-                        workspaceAdminServiceConstructor(ctx).adminListWorkspacesWithAttribute(
-                          name,
-                          AttributeBoolean(boolean.toBoolean)
-                        )
-                      case _ =>
-                        throw new RawlsException("Specify exactly one of valueString, valueNumber, or valueBoolean")
-                    }
-                }
-                complete {
-                  resultFuture
-                }
             }
           }
         } ~

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
@@ -8,15 +8,10 @@ import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.{
-  AttributeName,
-  AttributeValue,
   ErrorReport,
   ErrorReportSource,
-  ManagedGroupRef,
-  RawlsGroupName,
   RawlsRequestContext,
   SamResourceTypeAdminActions,
-  SamResourceTypeName,
   SamResourceTypeNames,
   Workspace,
   WorkspaceAdminResponse,
@@ -65,31 +60,6 @@ class WorkspaceAdminService(
     with WorkspaceSupport {
 
   implicit val errorReportSource: ErrorReportSource = ErrorReportSource("rawls")
-
-  // Admin endpoint, not limited to V2 workspaces
-  def listAllWorkspaces(): Future[Seq[WorkspaceDetails]] =
-    asFCAdmin {
-      dataSource.inTransaction { dataAccess =>
-        dataAccess.workspaceQuery.listAll().map(workspaces => workspaces.map(w => WorkspaceDetails(w, Set.empty)))
-      }
-    }
-
-  // Admin endpoint, not limited to V2 workspaces
-  def adminListWorkspacesWithAttribute(attributeName: AttributeName,
-                                       attributeValue: AttributeValue
-  ): Future[Seq[WorkspaceDetails]] =
-    asFCAdmin {
-      for {
-        workspaces <- dataSource.inTransaction { dataAccess =>
-          dataAccess.workspaceQuery.listWithAttribute(attributeName, attributeValue)
-        }
-        results <- Future.traverse(workspaces) { workspace =>
-          loadResourceAuthDomain(SamResourceTypeNames.workspace, workspace.workspaceId).map(
-            WorkspaceDetails(workspace, _)
-          )
-        }
-      } yield results
-    }
 
   // Admin endpoint, not limited to V2 workspaces
   def adminListWorkspaceFeatureFlags(workspaceName: WorkspaceName): Future[Seq[WorkspaceFeatureFlag]] =
@@ -147,12 +117,5 @@ class WorkspaceAdminService(
       case None            => throw NoSuchWorkspaceException(workspaceName)
       case Some(workspace) => op(workspace)
     }
-
-  private def loadResourceAuthDomain(resourceTypeName: SamResourceTypeName,
-                                     resourceId: String
-  ): Future[Set[ManagedGroupRef]] =
-    samDAO
-      .getResourceAuthDomain(resourceTypeName, resourceId, ctx)
-      .map(_.map(g => ManagedGroupRef(RawlsGroupName(g))).toSet)
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -11,8 +11,7 @@ import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.{
   ActiveSubmissionFormat,
   WorkflowQueueStatusByUserResponseFormat
 }
-import org.broadinstitute.dsde.rawls.model.UserAuthJsonSupport.RawlsBillingProjectTransferFormat
-import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{AttributeReferenceFormat, WorkspaceDetailsFormat}
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.AttributeReferenceFormat
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
@@ -142,43 +141,6 @@ class AdminApiServiceSpec extends ApiServiceSpec {
       sealRoute(services.adminRoutes()) ~>
       check {
         assertResult(StatusCodes.NotFound)(status)
-      }
-  }
-
-  it should "return 200 when listing all workspaces" in withTestDataApiServices { services =>
-    Get(s"/admin/workspaces") ~>
-      sealRoute(services.adminRoutes()) ~>
-      check {
-        assertResult(StatusCodes.OK)(status)
-        // TODO: why is this result returned out of order?
-        sortAndAssertWorkspaceResult(testData.allWorkspaces)(responseAs[Seq[WorkspaceDetails]].map(_.toWorkspace))
-      }
-  }
-
-  it should "return 200 when getting workspaces by a string attribute" in withConstantTestDataApiServices { services =>
-    Get(s"/admin/workspaces?attributeName=string&valueString=yep%2C%20it's%20a%20string") ~>
-      sealRoute(services.adminRoutes()) ~>
-      check {
-        assertResult(StatusCodes.OK)(status)
-        assertWorkspaceResult(Seq(constantData.workspace))(responseAs[Seq[WorkspaceDetails]].map(_.toWorkspace))
-      }
-  }
-
-  it should "return 200 when getting workspaces by a numeric attribute" in withConstantTestDataApiServices { services =>
-    Get(s"/admin/workspaces?attributeName=number&valueNumber=10") ~>
-      sealRoute(services.adminRoutes()) ~>
-      check {
-        assertResult(StatusCodes.OK)(status)
-        assertWorkspaceResult(Seq(constantData.workspace))(responseAs[Seq[WorkspaceDetails]].map(_.toWorkspace))
-      }
-  }
-
-  it should "return 200 when getting workspaces by a boolean attribute" in withTestDataApiServices { services =>
-    Get(s"/admin/workspaces?attributeName=library%3Apublished&valueBoolean=true") ~>
-      sealRoute(services.adminRoutes()) ~>
-      check {
-        assertResult(StatusCodes.OK)(status)
-        assertWorkspaceResult(Seq(testData.workspacePublished))(responseAs[Seq[WorkspaceDetails]].map(_.toWorkspace))
       }
   }
 


### PR DESCRIPTION
Ticket: CORE-382

The admin list-all-workspaces API was created to support Data Library. Data Library used it to reindex published workspaces if its index needed a full rebuild. With Data Library gone, this API is now unnecessary. Since it is a performance nightmare, potentially returning tens of thousands of results, I'm proposing we delete it.
