### PR TITLE
[CORE-421] Optionally delete set after submission

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5146,12 +5146,9 @@ components:
           minimum: 0.01
           maximum: 9999999999.99
           multipleOf: 0.01
-        deleteEntityType:
+        deleteEntity:
           type: string
-          description: Type of root entity to delete after submission.  If it matches the submission entity, will delete intermediate set entity created for submission.
-        deleteEntityName:
-          type: string
-          description: Name of root entity to delete after submission.  If it matches the submission entity, will delete intermediate set entity created for submission..
+          description: Root entity to delete after submission in the form [entityType]/[entityName].  If it matches the submission entity, will delete intermediate set entity created for submission.
       description: If the referenced method configuration takes no root entity, do
         not define `entityType`, `entityName` and `expression`.
     SubmissionValidationInput:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5146,10 +5146,12 @@ components:
           minimum: 0.01
           maximum: 9999999999.99
           multipleOf: 0.01
-        preserveSet:
-          type: boolean
-          default: true
-          description: Whether or not to retain the set created from input entities.  If false, will delete after submission.
+        deleteEntityType:
+          type: string
+          description: Type of root entity to delete after submission.  If it matches the submission entity, will delete intermediate set entity created for submission.
+        deleteEntityName:
+          type: string
+          description: Name of root entity to delete after submission.  If it matches the submission entity, will delete intermediate set entity created for submission..
       description: If the referenced method configuration takes no root entity, do
         not define `entityType`, `entityName` and `expression`.
     SubmissionValidationInput:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5192,6 +5192,10 @@ components:
           minimum: 0.01
           maximum: 9999999999.99
           multipleOf: 0.01
+        preserveSet:
+          type: boolean
+          default: true
+          description: Whether or not to retain the set created from input entities.  If false, will delete after submission.
       description: If the referenced method configuration takes no root entity, do
         not define `entityType`, `entityName` and `expression`.
     SubmissionValidationInput:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -460,6 +460,14 @@ object Boot extends IOApp with LazyLogging {
           workbenchMetricBaseName = metricsPrefix
         )
 
+      val entityServiceConstructor: RawlsRequestContext => EntityService = EntityService.constructor(
+        slickDataSource,
+        samDAO,
+        workbenchMetricBaseName = metricsPrefix,
+        entityManager,
+        appConfigManager.conf.getInt("entities.pageSizeLimit")
+      )
+
       val submissionsServiceConstructor: RawlsRequestContext => SubmissionsService = SubmissionsService.constructor(
         slickDataSource,
         entityManager,
@@ -476,15 +484,8 @@ object Boot extends IOApp with LazyLogging {
         genomicsServiceConstructor,
         workspaceServiceConfig,
         new WorkspaceRepository(slickDataSource),
-        new WorkspaceSettingRepository(slickDataSource)
-      )
-
-      val entityServiceConstructor: RawlsRequestContext => EntityService = EntityService.constructor(
-        slickDataSource,
-        samDAO,
-        workbenchMetricBaseName = metricsPrefix,
-        entityManager,
-        appConfigManager.conf.getInt("entities.pageSizeLimit")
+        new WorkspaceSettingRepository(slickDataSource),
+        entityServiceConstructor
       )
 
       val snapshotServiceConstructor: RawlsRequestContext => SnapshotService = SnapshotService.constructor(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -558,15 +558,6 @@ object Boot extends IOApp with LazyLogging {
                                     appDependencies.googleStorageService
         )(implicitly, IORuntime.global)
 
-      val entityServiceConstructor: RawlsRequestContext => EntityService = EntityService.constructor(
-        slickDataSource,
-        samDAO,
-        workbenchMetricBaseName = metricsPrefix,
-        entityManager,
-        appConfigManager.conf.getInt("entities.pageSizeLimit"),
-        Option(workspaceSettingServiceConstructor)
-      )
-
       val googleProjectRegistrationServiceConstructor: RawlsRequestContext => GoogleProjectRegistrationService =
         new GoogleProjectRegistrationService(_, samDAO, googleProjectRegRepo, billingRepository, gcsDAO)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -537,22 +537,17 @@ class SubmissionsService(
         ps.failureMode,
         ps.header
       )
-      _ <-
-        if (!submissionRequest.preserveSet) { // This has to be done after saving the submission so it can pull the data from the entity first
-          val setToDelete = AttributeEntityReference(submissionRequest.entityType.get, submissionRequest.entityName.get)
-
-          // TODO is there a way to avoid fetching the method config again?  another way to get an entityProvider?
-          for {
-            methodConfig <- dataSource.inTransaction { dataAccess =>
-              dataAccess.methodConfigurationQuery.get(ps.workspace,
-                                                      submissionRequest.methodConfigurationNamespace,
-                                                      submissionRequest.methodConfigurationName
-              )
+      _ <- getSetToDelete(submissionRequest)
+        .map { setToDelete =>
+          entityManager
+            .resolveProviderFuture(
+              EntityRequestArguments(ps.workspace, ctx, None, None)
+            )
+            .flatMap { entityProvider =>
+              entityProvider.deleteEntities(Seq(setToDelete), ctx)
             }
-            entityProvider <- getEntityProviderForMethodConfig(ps.workspace, methodConfig.get)
-            _ <- entityProvider.deleteEntities(Seq(setToDelete), ctx)
-          } yield ()
-        } else Future.successful(())
+        }
+        .getOrElse(Future.successful(()))
     } yield SubmissionReport(
       submissionRequest,
       submission.submissionId,
@@ -562,6 +557,17 @@ class SubmissionsService(
       ps.header,
       ps.inputs.filter(_.inputResolutions.forall(_.error.isEmpty))
     )
+
+  def getSetToDelete(submissionRequest: SubmissionRequest): Option[AttributeEntityReference] =
+    if (!submissionRequest.preserveSet) {
+      submissionRequest.entityType match {
+        case Some(value) if value.endsWith("_set") =>
+          Some(AttributeEntityReference(value, submissionRequest.entityName.get))
+        case _ => None
+      }
+    } else {
+      None
+    }
 
   @VisibleForTesting
   def validateCostCap(costCap: Option[BigDecimal]): Unit = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -537,6 +537,22 @@ class SubmissionsService(
         ps.failureMode,
         ps.header
       )
+      _ <-
+        if (!submissionRequest.preserveSet) { // This has to be done after saving the submission so it can pull the data from the entity first
+          val setToDelete = AttributeEntityReference(submissionRequest.entityType.get, submissionRequest.entityName.get)
+
+          // TODO is there a way to avoid fetching the method config again?  another way to get an entityProvider?
+          for {
+            methodConfig <- dataSource.inTransaction { dataAccess =>
+              dataAccess.methodConfigurationQuery.get(ps.workspace,
+                                                      submissionRequest.methodConfigurationNamespace,
+                                                      submissionRequest.methodConfigurationName
+              )
+            }
+            entityProvider <- getEntityProviderForMethodConfig(ps.workspace, methodConfig.get)
+            _ <- entityProvider.deleteEntities(Seq(setToDelete), ctx)
+          } yield ()
+        } else Future.successful(())
     } yield SubmissionReport(
       submissionRequest,
       submission.submissionId,
@@ -622,11 +638,6 @@ class SubmissionsService(
         workspaceExpressionResults
       )
       submissionPath <- submissionRootPath(workspaceContext, submissionId)
-      _ <-
-        if (!submissionRequest.preserveSet) {
-          val setToDelete = AttributeEntityReference(submissionRequest.entityType.get, submissionRequest.entityName.get)
-          entityProvider.deleteEntities(Seq(setToDelete), ctx)
-        } else Future.successful(())
     } yield PreparedSubmission(
       workspaceContext,
       submissionId,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -17,7 +17,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.{
   SubmissionCostService
 }
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.LookupExpression
-import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityRequestArguments}
+import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityRequestArguments, EntityService}
 import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, ExpressionEvaluationContext}
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
@@ -29,7 +29,9 @@ import org.broadinstitute.dsde.rawls.model.WorkflowFailureModes.WorkflowFailureM
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
 import org.broadinstitute.dsde.rawls.model.{
   ActiveSubmission,
+  AttributeBoolean,
   AttributeEntityReference,
+  AttributeName,
   AttributeString,
   AttributeValue,
   ErrorReport,
@@ -71,7 +73,8 @@ import org.broadinstitute.dsde.rawls.model.{
 }
 import org.broadinstitute.dsde.rawls.submissions.SubmissionsService.{
   extractOperationIdsFromCromwellMetadata,
-  getTerminalStatusDate
+  getTerminalStatusDate,
+  terraCreatedSetToDeleteAttribute
 }
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, RoleSupport, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
@@ -103,7 +106,8 @@ object SubmissionsService {
     genomicsServiceConstructor: RawlsRequestContext => GenomicsService,
     config: WorkspaceServiceConfig,
     workspaceRepository: WorkspaceRepository,
-    workspaceSettingRepository: WorkspaceSettingRepository
+    workspaceSettingRepository: WorkspaceSettingRepository,
+    entityServiceConstructor: RawlsRequestContext => EntityService
   )(
     ctx: RawlsRequestContext
   )(implicit executionContext: ExecutionContext): SubmissionsService =
@@ -124,8 +128,11 @@ object SubmissionsService {
       genomicsServiceConstructor,
       config,
       workspaceRepository,
-      workspaceSettingRepository
+      workspaceSettingRepository,
+      entityServiceConstructor
     )
+
+  final val terraCreatedSetToDeleteAttribute = AttributeName("default", "deleteTerraCreatedSet")
 
   def extractOperationIdsFromCromwellMetadata(metadataJson: JsObject): Iterable[String] = {
     case class Call(jobId: Option[String])
@@ -178,7 +185,8 @@ class SubmissionsService(
   val genomicsServiceConstructor: RawlsRequestContext => GenomicsService,
   config: WorkspaceServiceConfig,
   val workspaceRepository: WorkspaceRepository,
-  workspaceSettingRepository: WorkspaceSettingRepository
+  workspaceSettingRepository: WorkspaceSettingRepository,
+  entityServiceConstructor: RawlsRequestContext => EntityService
 )(implicit protected val executionContext: ExecutionContext)
     extends RoleSupport
     with FutureSupport
@@ -537,17 +545,10 @@ class SubmissionsService(
         ps.failureMode,
         ps.header
       )
-      _ <- getSetToDelete(submissionRequest)
-        .map { setToDelete =>
-          entityManager
-            .resolveProviderFuture(
-              EntityRequestArguments(ps.workspace, ctx, None, None)
-            )
-            .flatMap { entityProvider =>
-              entityProvider.deleteEntities(Seq(setToDelete), ctx)
-            }
+      _ <- getSetToDelete(workspaceName, submissionRequest)
+        .flatMap { setToDelete =>
+          entityServiceConstructor(ctx).deleteEntities(workspaceName, setToDelete.toSeq, None, None)
         }
-        .getOrElse(Future.successful(()))
     } yield SubmissionReport(
       submissionRequest,
       submission.submissionId,
@@ -558,15 +559,23 @@ class SubmissionsService(
       ps.inputs.filter(_.inputResolutions.forall(_.error.isEmpty))
     )
 
-  def getSetToDelete(submissionRequest: SubmissionRequest): Option[AttributeEntityReference] =
+  def getSetToDelete(workspaceName: WorkspaceName,
+                     submissionRequest: SubmissionRequest
+  ): Future[Option[AttributeEntityReference]] =
     if (!submissionRequest.preserveSet) {
-      submissionRequest.entityType match {
-        case Some(value) if value.endsWith("_set") =>
-          Some(AttributeEntityReference(value, submissionRequest.entityName.get))
-        case _ => None
+      entityServiceConstructor(ctx).getEntity(workspaceName,
+                                              submissionRequest.entityType.get,
+                                              submissionRequest.entityName.get,
+                                              None,
+                                              None
+      ) map { entity =>
+        entity.attributes.get(terraCreatedSetToDeleteAttribute) match {
+          case Some(AttributeBoolean(true)) => Some(entity.toReference)
+          case _                            => None
+        }
       }
     } else {
-      None
+      Future.successful(None)
     }
 
   @VisibleForTesting

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -29,9 +29,7 @@ import org.broadinstitute.dsde.rawls.model.WorkflowFailureModes.WorkflowFailureM
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
 import org.broadinstitute.dsde.rawls.model.{
   ActiveSubmission,
-  AttributeBoolean,
   AttributeEntityReference,
-  AttributeName,
   AttributeString,
   AttributeValue,
   ErrorReport,
@@ -73,8 +71,7 @@ import org.broadinstitute.dsde.rawls.model.{
 }
 import org.broadinstitute.dsde.rawls.submissions.SubmissionsService.{
   extractOperationIdsFromCromwellMetadata,
-  getTerminalStatusDate,
-  terraCreatedSetToDeleteAttribute
+  getTerminalStatusDate
 }
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, RoleSupport, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
@@ -131,8 +128,6 @@ object SubmissionsService {
       workspaceSettingRepository,
       entityServiceConstructor
     )
-
-  final val terraCreatedSetToDeleteAttribute = AttributeName("default", "deleteTerraCreatedSet")
 
   def extractOperationIdsFromCromwellMetadata(metadataJson: JsObject): Iterable[String] = {
     case class Call(jobId: Option[String])
@@ -545,10 +540,11 @@ class SubmissionsService(
         ps.failureMode,
         ps.header
       )
-      _ <- getSetToDelete(workspaceName, submissionRequest)
-        .flatMap { setToDelete =>
-          entityServiceConstructor(ctx).deleteEntities(workspaceName, setToDelete.toSeq, None, None)
+      _ <- getSetToDelete(submissionRequest)
+        .map { setToDelete =>
+          entityServiceConstructor(ctx).deleteEntities(workspaceName, Seq(setToDelete), None, None)
         }
+        .getOrElse(Future.successful(()))
     } yield SubmissionReport(
       submissionRequest,
       submission.submissionId,
@@ -559,23 +555,16 @@ class SubmissionsService(
       ps.inputs.filter(_.inputResolutions.forall(_.error.isEmpty))
     )
 
-  def getSetToDelete(workspaceName: WorkspaceName,
-                     submissionRequest: SubmissionRequest
-  ): Future[Option[AttributeEntityReference]] =
-    if (!submissionRequest.preserveSet) {
-      entityServiceConstructor(ctx).getEntity(workspaceName,
-                                              submissionRequest.entityType.get,
-                                              submissionRequest.entityName.get,
-                                              None,
-                                              None
-      ) map { entity =>
-        entity.attributes.get(terraCreatedSetToDeleteAttribute) match {
-          case Some(AttributeBoolean(true)) => Some(entity.toReference)
-          case _                            => None
+  def getSetToDelete(
+    submissionRequest: SubmissionRequest
+  ): Option[AttributeEntityReference] =
+    submissionRequest.deleteEntityType match {
+      case Some(value) if value == submissionRequest.entityType.get =>
+        submissionRequest.deleteEntityName match {
+          case Some(name) if name == submissionRequest.entityName.get => Some(AttributeEntityReference(value, name))
+          case _                                                      => None
         }
-      }
-    } else {
-      Future.successful(None)
+      case _ => None
     }
 
   @VisibleForTesting

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -542,7 +542,11 @@ class SubmissionsService(
       )
       _ <- getSetToDelete(submissionRequest)
         .map { setToDelete =>
-          entityServiceConstructor(ctx).deleteEntities(workspaceName, Seq(setToDelete), None, None)
+          entityServiceConstructor(ctx)
+            .deleteEntities(workspaceName, Seq(setToDelete), None, None)
+            .recover { case e =>
+              logger.error(s"Failed to delete entities: ", e)
+            }
         }
         .getOrElse(Future.successful(()))
     } yield SubmissionReport(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -622,6 +622,11 @@ class SubmissionsService(
         workspaceExpressionResults
       )
       submissionPath <- submissionRootPath(workspaceContext, submissionId)
+      _ <-
+        if (!submissionRequest.preserveSet) {
+          val setToDelete = AttributeEntityReference(submissionRequest.entityType.get, submissionRequest.entityName.get)
+          entityProvider.deleteEntities(Seq(setToDelete), ctx)
+        } else Future.successful(())
     } yield PreparedSubmission(
       workspaceContext,
       submissionId,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -558,12 +558,13 @@ class SubmissionsService(
   def getSetToDelete(
     submissionRequest: SubmissionRequest
   ): Option[AttributeEntityReference] =
-    submissionRequest.deleteEntityType match {
-      case Some(value) if value == submissionRequest.entityType.get =>
-        submissionRequest.deleteEntityName match {
-          case Some(name) if name == submissionRequest.entityName.get => Some(AttributeEntityReference(value, name))
-          case _                                                      => None
-        }
+    submissionRequest.deleteEntity match {
+      case Some(value) =>
+        for {
+          entityType <- submissionRequest.entityType
+          entityName <- submissionRequest.entityName
+          if value == s"$entityType/$entityName"
+        } yield AttributeEntityReference(entityType, entityName)
       case _ => None
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -812,7 +812,7 @@ class SubmissionSpec(_system: ActorSystem)
   it should "delete entity set if preserveSet is set to false" in withSubmissionsService { submissionsService =>
     val sset = Entity(
       "testset6",
-      "SampleSet",
+      "Sample_set",
       Map(
         AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
           Seq(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -765,6 +765,95 @@ class SubmissionSpec(_system: ActorSystem)
       assert(submission.workflows.forall(_.status == WorkflowStatuses.Queued))
   }
 
+  it should "keep entity set if preserveSet is not specified" in withSubmissionsService { submissionsService =>
+    val sset = Entity(
+      "testset6",
+      "SampleSet",
+      Map(
+        AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+          Seq(
+            AttributeEntityReference("Sample", "sample1"),
+            AttributeEntityReference("Sample", "sample2"),
+            AttributeEntityReference("Sample", "sample3"),
+            AttributeEntityReference("Sample", "sample4"),
+            AttributeEntityReference("Sample", "sample5"),
+            AttributeEntityReference("Sample", "sample6")
+          )
+        )
+      )
+    )
+
+    runAndWait(entityQuery.save(testData.workspace, sset))
+
+    val submissionRq = SubmissionRequest(
+      methodConfigurationNamespace = "dsde",
+      methodConfigurationName = "GoodMethodConfig",
+      entityType = Option(sset.entityType),
+      entityName = Option(sset.name),
+      expression = Option("this.samples"),
+      useCallCache = false,
+      deleteIntermediateOutputFiles = false
+    )
+    val newSubmissionReport =
+      Await.result(submissionsService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+
+    assert(newSubmissionReport.workflows.size == 6)
+
+    checkSubmissionStatus(submissionsService, newSubmissionReport.submissionId)
+
+    val submission = runAndWait(submissionQuery.loadSubmission(UUID.fromString(newSubmissionReport.submissionId))).get
+    assert(submission.workflows.forall(_.status == WorkflowStatuses.Queued))
+
+    assertResult(Some(sset)) {
+      runAndWait(entityQuery.get(testData.workspace, sset.entityType, sset.name))
+    }
+  }
+
+  it should "delete entity set if preserveSet is set to false" in withSubmissionsService { submissionsService =>
+    val sset = Entity(
+      "testset6",
+      "SampleSet",
+      Map(
+        AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+          Seq(
+            AttributeEntityReference("Sample", "sample1"),
+            AttributeEntityReference("Sample", "sample2"),
+            AttributeEntityReference("Sample", "sample3"),
+            AttributeEntityReference("Sample", "sample4"),
+            AttributeEntityReference("Sample", "sample5"),
+            AttributeEntityReference("Sample", "sample6")
+          )
+        )
+      )
+    )
+
+    runAndWait(entityQuery.save(testData.workspace, sset))
+
+    val submissionRq = SubmissionRequest(
+      methodConfigurationNamespace = "dsde",
+      methodConfigurationName = "GoodMethodConfig",
+      entityType = Option(sset.entityType),
+      entityName = Option(sset.name),
+      expression = Option("this.samples"),
+      useCallCache = false,
+      deleteIntermediateOutputFiles = false,
+      preserveSet = false
+    )
+    val newSubmissionReport =
+      Await.result(submissionsService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+
+    assert(newSubmissionReport.workflows.size == 6)
+
+    checkSubmissionStatus(submissionsService, newSubmissionReport.submissionId)
+
+    val submission = runAndWait(submissionQuery.loadSubmission(UUID.fromString(newSubmissionReport.submissionId))).get
+    assert(submission.workflows.forall(_.status == WorkflowStatuses.Queued))
+
+    assertResult(None) {
+      runAndWait(entityQuery.get(testData.workspace, sset.entityType, sset.name))
+    }
+  }
+
   it should "return a successful Submission when given an wdl struct entity expression that evaluates to a set of entities" in withSubmissionsService {
     submissionsService =>
       val sample1 = Entity(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -931,6 +931,63 @@ class SubmissionSpec(_system: ActorSystem)
       assert(oneSub.nonEmpty)
   }
 
+  it should "not fail if deleting deleteEntity fails" in withSubmissionsService { submissionsService =>
+    val sset = Entity(
+      "testset6",
+      "Sample_set",
+      Map(
+        AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+          Seq(
+            AttributeEntityReference("Sample", "sample1"),
+            AttributeEntityReference("Sample", "sample2"),
+            AttributeEntityReference("Sample", "sample3"),
+            AttributeEntityReference("Sample", "sample4"),
+            AttributeEntityReference("Sample", "sample5"),
+            AttributeEntityReference("Sample", "sample6")
+          )
+        )
+      )
+    )
+
+    // Creating an entity referring to the sample set is easier to set up than mocking the entity service to throw an error on delete
+    val referencingEntity = Entity(
+      "ref1",
+      "referrer",
+      Map(
+        AttributeName.withDefaultNS("sets") ->
+          AttributeEntityReference("Sample_set", "testset6")
+      )
+    )
+
+    runAndWait(entityQuery.save(testData.workspace, sset))
+    runAndWait(entityQuery.save(testData.workspace, referencingEntity))
+
+    val submissionRq = SubmissionRequest(
+      methodConfigurationNamespace = "dsde",
+      methodConfigurationName = "GoodMethodConfig",
+      entityType = Option(sset.entityType),
+      entityName = Option(sset.name),
+      expression = Option("this.samples"),
+      useCallCache = false,
+      deleteIntermediateOutputFiles = false,
+      deleteEntity = Option(sset.entityType + "/" + sset.name)
+    )
+    val newSubmissionReport =
+      Await.result(submissionsService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+
+    assert(newSubmissionReport.workflows.size == 6)
+
+    checkSubmissionStatus(submissionsService, newSubmissionReport.submissionId)
+
+    val submission = runAndWait(submissionQuery.loadSubmission(UUID.fromString(newSubmissionReport.submissionId))).get
+    assert(submission.workflows.forall(_.status == WorkflowStatuses.Queued))
+
+    // The sset would have failed to delete, but the submission succeeded
+    assertResult(Some(sset)) {
+      runAndWait(entityQuery.get(testData.workspace, sset.entityType, sset.name))
+    }
+  }
+
   it should "return a successful Submission when given an wdl struct entity expression that evaluates to a set of entities" in withSubmissionsService {
     submissionsService =>
       val sample1 = Entity(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -18,7 +18,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.dataaccess.resourcebuffer.ResourceBufferDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{TestData, TestDriverComponent}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.entities.EntityManager
+import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.entities.datarepo.DataRepoEntityProviderSpecSupport
 import org.broadinstitute.dsde.rawls.fastpass.FastPassServiceImpl
 import org.broadinstitute.dsde.rawls.genomics.GenomicsServiceImpl
@@ -30,6 +30,7 @@ import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferServiceImpl
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterServiceImpl
 import org.broadinstitute.dsde.rawls.submissions.SubmissionsService
+import org.broadinstitute.dsde.rawls.submissions.SubmissionsService.terraCreatedSetToDeleteAttribute
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceSettingRepository}
@@ -537,6 +538,9 @@ class SubmissionSpec(_system: ActorSystem)
         workbenchMetricBaseName
       )
 
+      val entityServiceConstructor =
+        EntityService.constructor(slickDataSource, samDAO, workbenchMetricBaseName = "test", entityManager, 1000) _
+
       val resourceBufferDAO: ResourceBufferDAO = new MockResourceBufferDAO
       val resourceBufferConfig = ResourceBufferConfig(testConf.getConfig("resourceBuffer"))
       val resourceBufferService = new ResourceBufferServiceImpl(resourceBufferDAO, resourceBufferConfig)
@@ -576,7 +580,8 @@ class SubmissionSpec(_system: ActorSystem)
         genomicsServiceConstructor,
         workspaceServiceConfig,
         new WorkspaceRepository(slickDataSource),
-        workspaceSettingRepository
+        workspaceSettingRepository,
+        entityServiceConstructor
       ) _
       lazy val submissionsService: SubmissionsService = submissionsServiceConstructor(testContext)
       try
@@ -823,7 +828,8 @@ class SubmissionSpec(_system: ActorSystem)
             AttributeEntityReference("Sample", "sample5"),
             AttributeEntityReference("Sample", "sample6")
           )
-        )
+        ),
+        terraCreatedSetToDeleteAttribute -> AttributeBoolean(true)
       )
     )
 
@@ -854,7 +860,7 @@ class SubmissionSpec(_system: ActorSystem)
     }
   }
 
-  it should "not delete entity if not a set even if preserveSet is set to false" in withSubmissionsService {
+  it should "not delete entity if terraCreatedSetToDeleteAttribute not set even if preserveSet is set to false" in withSubmissionsService {
     submissionsService =>
       val submissionRq = SubmissionRequest(
         methodConfigurationNamespace = "dsde",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -30,7 +30,6 @@ import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferServiceImpl
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterServiceImpl
 import org.broadinstitute.dsde.rawls.submissions.SubmissionsService
-import org.broadinstitute.dsde.rawls.submissions.SubmissionsService.terraCreatedSetToDeleteAttribute
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceSettingRepository}
@@ -828,8 +827,7 @@ class SubmissionSpec(_system: ActorSystem)
             AttributeEntityReference("Sample", "sample5"),
             AttributeEntityReference("Sample", "sample6")
           )
-        ),
-        terraCreatedSetToDeleteAttribute -> AttributeBoolean(true)
+        )
       )
     )
 
@@ -843,7 +841,8 @@ class SubmissionSpec(_system: ActorSystem)
       expression = Option("this.samples"),
       useCallCache = false,
       deleteIntermediateOutputFiles = false,
-      preserveSet = false
+      deleteEntityType = Option(sset.entityType),
+      deleteEntityName = Option(sset.name)
     )
     val newSubmissionReport =
       Await.result(submissionsService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
@@ -870,7 +869,8 @@ class SubmissionSpec(_system: ActorSystem)
         expression = None,
         useCallCache = false,
         deleteIntermediateOutputFiles = false,
-        preserveSet = false
+        deleteEntityType = Option("Sample"),
+        deleteEntityName = Option("sample1")
       )
       val newSubmissionReport =
         Await.result(submissionsService.createSubmission(testData.wsName, submissionRq), Duration.Inf)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -769,7 +769,7 @@ class SubmissionSpec(_system: ActorSystem)
       assert(submission.workflows.forall(_.status == WorkflowStatuses.Queued))
   }
 
-  it should "keep entity set if preserveSet is not specified" in withSubmissionsService { submissionsService =>
+  it should "keep entity set if deleteEntity is not specified" in withSubmissionsService { submissionsService =>
     val sset = Entity(
       "testset6",
       "SampleSet",
@@ -813,78 +813,122 @@ class SubmissionSpec(_system: ActorSystem)
     }
   }
 
-  it should "delete entity set if preserveSet is set to false" in withSubmissionsService { submissionsService =>
-    val sset = Entity(
-      "testset6",
-      "Sample_set",
-      Map(
-        AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
-          Seq(
-            AttributeEntityReference("Sample", "sample1"),
-            AttributeEntityReference("Sample", "sample2"),
-            AttributeEntityReference("Sample", "sample3"),
-            AttributeEntityReference("Sample", "sample4"),
-            AttributeEntityReference("Sample", "sample5"),
-            AttributeEntityReference("Sample", "sample6")
+  it should "delete entity set if deleteEntity is present and matches submission entity" in withSubmissionsService {
+    submissionsService =>
+      val sset = Entity(
+        "testset6",
+        "Sample_set",
+        Map(
+          AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+            Seq(
+              AttributeEntityReference("Sample", "sample1"),
+              AttributeEntityReference("Sample", "sample2"),
+              AttributeEntityReference("Sample", "sample3"),
+              AttributeEntityReference("Sample", "sample4"),
+              AttributeEntityReference("Sample", "sample5"),
+              AttributeEntityReference("Sample", "sample6")
+            )
           )
         )
       )
-    )
 
-    runAndWait(entityQuery.save(testData.workspace, sset))
+      runAndWait(entityQuery.save(testData.workspace, sset))
 
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option(sset.entityType),
-      entityName = Option(sset.name),
-      expression = Option("this.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false,
-      deleteEntityType = Option(sset.entityType),
-      deleteEntityName = Option(sset.name)
-    )
-    val newSubmissionReport =
-      Await.result(submissionsService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
-
-    assert(newSubmissionReport.workflows.size == 6)
-
-    checkSubmissionStatus(submissionsService, newSubmissionReport.submissionId)
-
-    val submission = runAndWait(submissionQuery.loadSubmission(UUID.fromString(newSubmissionReport.submissionId))).get
-    assert(submission.workflows.forall(_.status == WorkflowStatuses.Queued))
-
-    assertResult(None) {
-      runAndWait(entityQuery.get(testData.workspace, sset.entityType, sset.name))
-    }
-  }
-
-  it should "not delete entity if terraCreatedSetToDeleteAttribute not set even if preserveSet is set to false" in withSubmissionsService {
-    submissionsService =>
       val submissionRq = SubmissionRequest(
         methodConfigurationNamespace = "dsde",
         methodConfigurationName = "GoodMethodConfig",
-        entityType = Option("Sample"),
-        entityName = Option("sample1"),
-        expression = None,
+        entityType = Option(sset.entityType),
+        entityName = Option(sset.name),
+        expression = Option("this.samples"),
         useCallCache = false,
         deleteIntermediateOutputFiles = false,
-        deleteEntityType = Option("Sample"),
-        deleteEntityName = Option("sample1")
+        deleteEntity = Option(sset.entityType + "/" + sset.name)
       )
       val newSubmissionReport =
         Await.result(submissionsService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-      assert(newSubmissionReport.workflows.size == 1)
+      assert(newSubmissionReport.workflows.size == 6)
 
       checkSubmissionStatus(submissionsService, newSubmissionReport.submissionId)
 
       val submission = runAndWait(submissionQuery.loadSubmission(UUID.fromString(newSubmissionReport.submissionId))).get
       assert(submission.workflows.forall(_.status == WorkflowStatuses.Queued))
 
-      assertResult(Some(testData.sample1)) {
-        runAndWait(entityQuery.get(testData.workspace, "Sample", "sample1"))
+      assertResult(None) {
+        runAndWait(entityQuery.get(testData.workspace, sset.entityType, sset.name))
       }
+  }
+
+  it should "not delete entity if deleteEntity is present but does not match submission entity" in withSubmissionsService {
+    submissionsService =>
+      val sset = Entity(
+        "testset6",
+        "Sample_set",
+        Map(
+          AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+            Seq(
+              AttributeEntityReference("Sample", "sample1"),
+              AttributeEntityReference("Sample", "sample2"),
+              AttributeEntityReference("Sample", "sample3"),
+              AttributeEntityReference("Sample", "sample4"),
+              AttributeEntityReference("Sample", "sample5"),
+              AttributeEntityReference("Sample", "sample6")
+            )
+          )
+        )
+      )
+
+      runAndWait(entityQuery.save(testData.workspace, sset))
+
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option(sset.entityType),
+        entityName = Option(sset.name),
+        expression = Option("this.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false,
+        deleteEntity = Option(sset.entityType + "/" + "other")
+      )
+      val newSubmissionReport =
+        Await.result(submissionsService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+
+      assert(newSubmissionReport.workflows.size == 6)
+
+      checkSubmissionStatus(submissionsService, newSubmissionReport.submissionId)
+
+      val submission = runAndWait(submissionQuery.loadSubmission(UUID.fromString(newSubmissionReport.submissionId))).get
+      assert(submission.workflows.forall(_.status == WorkflowStatuses.Queued))
+
+      assertResult(Some(sset)) {
+        runAndWait(entityQuery.get(testData.workspace, sset.entityType, sset.name))
+      }
+  }
+
+  it should "not fail if deleteEntity is present but there is no root entity" in withSubmissionsService {
+    submissionsService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = testData.methodConfigEntityless.namespace,
+        methodConfigurationName = testData.methodConfigEntityless.name,
+        entityType = None,
+        entityName = None,
+        expression = None,
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false,
+        deleteEntity = Some("entityType/entityName")
+      )
+      val newSubmissionReport =
+        Await.result(submissionsService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+
+      assert(newSubmissionReport.workflows.size == 1)
+
+      val submissionData = checkSubmissionStatus(submissionsService, newSubmissionReport.submissionId)
+      assert(submissionData.workflows.size == 1)
+
+      val subList = Await.result(submissionsService.listSubmissions(testData.wsName, testContext), Duration.Inf)
+
+      val oneSub = subList.filter(s => s.submissionId == newSubmissionReport.submissionId)
+      assert(oneSub.nonEmpty)
   }
 
   it should "return a successful Submission when given an wdl struct entity expression that evaluates to a set of entities" in withSubmissionsService {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -854,6 +854,33 @@ class SubmissionSpec(_system: ActorSystem)
     }
   }
 
+  it should "not delete entity if not a set even if preserveSet is set to false" in withSubmissionsService {
+    submissionsService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("Sample"),
+        entityName = Option("sample1"),
+        expression = None,
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false,
+        preserveSet = false
+      )
+      val newSubmissionReport =
+        Await.result(submissionsService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+
+      assert(newSubmissionReport.workflows.size == 1)
+
+      checkSubmissionStatus(submissionsService, newSubmissionReport.submissionId)
+
+      val submission = runAndWait(submissionQuery.loadSubmission(UUID.fromString(newSubmissionReport.submissionId))).get
+      assert(submission.workflows.forall(_.status == WorkflowStatuses.Queued))
+
+      assertResult(Some(testData.sample1)) {
+        runAndWait(entityQuery.get(testData.workspace, "Sample", "sample1"))
+      }
+  }
+
   it should "return a successful Submission when given an wdl struct entity expression that evaluates to a set of entities" in withSubmissionsService {
     submissionsService =>
       val sample1 = Entity(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.dataaccess.resourcebuffer.ResourceBufferDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, TestDriverComponent}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.entities.EntityManager
+import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.fastpass.FastPassServiceImpl
 import org.broadinstitute.dsde.rawls.genomics.GenomicsServiceImpl
 import org.broadinstitute.dsde.rawls.google.MockGoogleAccessContextManagerDAO
@@ -23,7 +23,6 @@ import org.broadinstitute.dsde.rawls.jobexec.{SubmissionMonitorConfig, Submissio
 import org.broadinstitute.dsde.rawls.methods.MethodConfigurationService
 import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
 import org.broadinstitute.dsde.rawls.mock._
-import org.broadinstitute.dsde.rawls.model.WorkflowCostTypes.WorkflowCostType
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.{Running, Succeeded, WorkflowStatus}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
@@ -240,6 +239,9 @@ class SubmissionsServiceSpec
       workbenchMetricBaseName
     )
 
+    val entityServiceConstructor =
+      EntityService.constructor(slickDataSource, samDAO, workbenchMetricBaseName = "test", entityManager, 1000) _
+
     val resourceBufferDAO: ResourceBufferDAO = new MockResourceBufferDAO
     val resourceBufferConfig = ResourceBufferConfig(testConf.getConfig("resourceBuffer"))
     val resourceBufferService = spy(new ResourceBufferServiceImpl(resourceBufferDAO, resourceBufferConfig))
@@ -332,7 +334,8 @@ class SubmissionsServiceSpec
         genomicsServiceConstructor,
         workspaceServiceConfig,
         workspaceRepository,
-        workspaceSettingRepository
+        workspaceSettingRepository,
+        entityServiceConstructor
       ) _
 
     def cleanupSupervisor =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -323,6 +323,9 @@ trait ApiServiceSpec
       workbenchMetricBaseName
     )
 
+    val entityServiceConstructor =
+      EntityService.constructor(slickDataSource, samDAO, workbenchMetricBaseName = "test", entityManager, 1000) _
+
     val resourceBufferDAO: ResourceBufferDAO = new MockResourceBufferDAO
     val resourceBufferConfig = ResourceBufferConfig(testConf.getConfig("resourceBuffer"))
     val resourceBufferService = new ResourceBufferServiceImpl(resourceBufferDAO, resourceBufferConfig)
@@ -440,15 +443,8 @@ trait ApiServiceSpec
       genomicsServiceConstructor,
       workspaceServiceConfig,
       new WorkspaceRepository(slickDataSource),
-      new WorkspaceSettingRepository(slickDataSource)
-    ) _
-
-    override val entityServiceConstructor = EntityService.constructor(
-      slickDataSource,
-      samDAO,
-      workbenchMetricBaseName,
-      entityManager,
-      1000
+      new WorkspaceSettingRepository(slickDataSource),
+      entityServiceConstructor
     ) _
 
     override val googleProjectRegServiceConstructor =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -34,7 +34,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.resourcebuffer.ResourceBufferDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, TestDriverComponent}
 import org.broadinstitute.dsde.rawls.dataaccess.tps.TpsDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.entities.EntityManager
+import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.fastpass.FastPassServiceImpl
 import org.broadinstitute.dsde.rawls.genomics.GenomicsServiceImpl
 import org.broadinstitute.dsde.rawls.google.MockGoogleAccessContextManagerDAO
@@ -270,6 +270,9 @@ class WorkspaceServiceSpec
       workbenchMetricBaseName
     )
 
+    val entityServiceConstructor =
+      EntityService.constructor(slickDataSource, samDAO, workbenchMetricBaseName = "test", entityManager, 1000) _
+
     val resourceBufferDAO: ResourceBufferDAO = new MockResourceBufferDAO
     val resourceBufferConfig = ResourceBufferConfig(testConf.getConfig("resourceBuffer"))
     val resourceBufferService = Mockito.spy(new ResourceBufferServiceImpl(resourceBufferDAO, resourceBufferConfig))
@@ -362,7 +365,8 @@ class WorkspaceServiceSpec
         genomicsServiceConstructor,
         workspaceServiceConfig,
         workspaceRepository,
-        workspaceSettingRepository
+        workspaceSettingRepository,
+        entityServiceConstructor
       ) _
 
     def cleanupSupervisor =

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -38,8 +38,7 @@ case class SubmissionRequest(
   monitoringImage: Option[String] = None,
   monitoringImageScript: Option[String] = None,
   perWorkflowCostCap: Option[BigDecimal] = None,
-  deleteEntityType: Option[String] = None,
-  deleteEntityName: Option[String] = None
+  deleteEntity: Option[String] = None
 )
 
 // This class contains values from the submission REST request
@@ -430,8 +429,7 @@ trait ExecutionJsonSupport extends JsonSupport {
           Option("monitoringImage" -> obj.monitoringImage.toJson),
           Option("monitoringImageScript" -> obj.monitoringImageScript.toJson),
           obj.perWorkflowCostCap.map("perWorkflowCostCap" -> _.toJson),
-          obj.deleteEntityType.map("deleteEntityType" -> _.toJson),
-          obj.deleteEntityName.map("deleteEntityName" -> _.toJson)
+          obj.deleteEntity.map("deleteEntity" -> _.toJson)
         ).flatten: _*
       )
 
@@ -460,8 +458,7 @@ trait ExecutionJsonSupport extends JsonSupport {
         monitoringImage = fields.get("monitoringImage").flatMap(_.convertTo[Option[String]]),
         monitoringImageScript = fields.get("monitoringImageScript").flatMap(_.convertTo[Option[String]]),
         perWorkflowCostCap = fields.get("perWorkflowCostCap").map(_.convertTo[BigDecimal]),
-        deleteEntityType = fields.get("deleteEntityType").flatMap(_.convertTo[Option[String]]),
-        deleteEntityName = fields.get("deleteEntityName").flatMap(_.convertTo[Option[String]])
+        deleteEntity = fields.get("deleteEntity").flatMap(_.convertTo[Option[String]])
         // All new fields above this line MUST have defaults or be wrapped in Option[]!
       )
     }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -38,7 +38,8 @@ case class SubmissionRequest(
   monitoringImage: Option[String] = None,
   monitoringImageScript: Option[String] = None,
   perWorkflowCostCap: Option[BigDecimal] = None,
-  preserveSet: Boolean = true
+  deleteEntityType: Option[String] = None,
+  deleteEntityName: Option[String] = None
 )
 
 // This class contains values from the submission REST request
@@ -429,7 +430,8 @@ trait ExecutionJsonSupport extends JsonSupport {
           Option("monitoringImage" -> obj.monitoringImage.toJson),
           Option("monitoringImageScript" -> obj.monitoringImageScript.toJson),
           obj.perWorkflowCostCap.map("perWorkflowCostCap" -> _.toJson),
-          Option("preserveSet" -> obj.preserveSet.toJson)
+          obj.deleteEntityType.map("deleteEntityType" -> _.toJson),
+          obj.deleteEntityName.map("deleteEntityName" -> _.toJson)
         ).flatten: _*
       )
 
@@ -458,7 +460,8 @@ trait ExecutionJsonSupport extends JsonSupport {
         monitoringImage = fields.get("monitoringImage").flatMap(_.convertTo[Option[String]]),
         monitoringImageScript = fields.get("monitoringImageScript").flatMap(_.convertTo[Option[String]]),
         perWorkflowCostCap = fields.get("perWorkflowCostCap").map(_.convertTo[BigDecimal]),
-        preserveSet = fields.get("preserveSet").fold(true)(_.convertTo[Boolean])
+        deleteEntityType = fields.get("deleteEntityType").flatMap(_.convertTo[Option[String]]),
+        deleteEntityName = fields.get("deleteEntityName").flatMap(_.convertTo[Option[String]])
         // All new fields above this line MUST have defaults or be wrapped in Option[]!
       )
     }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -37,7 +37,8 @@ case class SubmissionRequest(
   monitoringScript: Option[String] = None,
   monitoringImage: Option[String] = None,
   monitoringImageScript: Option[String] = None,
-  perWorkflowCostCap: Option[BigDecimal] = None
+  perWorkflowCostCap: Option[BigDecimal] = None,
+  preserveSet: Boolean = true
 )
 
 // This class contains values from the submission REST request
@@ -427,7 +428,8 @@ trait ExecutionJsonSupport extends JsonSupport {
           Option("monitoringScript" -> obj.monitoringScript.toJson),
           Option("monitoringImage" -> obj.monitoringImage.toJson),
           Option("monitoringImageScript" -> obj.monitoringImageScript.toJson),
-          obj.perWorkflowCostCap.map("perWorkflowCostCap" -> _.toJson)
+          obj.perWorkflowCostCap.map("perWorkflowCostCap" -> _.toJson),
+          Option("preserveSet" -> obj.preserveSet.toJson)
         ).flatten: _*
       )
 
@@ -455,7 +457,8 @@ trait ExecutionJsonSupport extends JsonSupport {
         monitoringScript = fields.get("monitoringScript").flatMap(_.convertTo[Option[String]]),
         monitoringImage = fields.get("monitoringImage").flatMap(_.convertTo[Option[String]]),
         monitoringImageScript = fields.get("monitoringImageScript").flatMap(_.convertTo[Option[String]]),
-        perWorkflowCostCap = fields.get("perWorkflowCostCap").map(_.convertTo[BigDecimal])
+        perWorkflowCostCap = fields.get("perWorkflowCostCap").map(_.convertTo[BigDecimal]),
+        preserveSet = fields.get("preserveSet").fold(true)(_.convertTo[Boolean])
         // All new fields above this line MUST have defaults or be wrapped in Option[]!
       )
     }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-421
Adds a new parameter to a `SubmissionRequest`, `preserveSet`, that defaults to `true`.  If `true`, behavior remains the same, but if `false`, the entity set created for the submission will be deleted after it is submitted.
Note that I did not save this parameter to the `SUBMISSION` table.  This is just because that saves a lot of trouble, but it might be helpful to retain it for debugging so I am ready to include it if requested.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
