### PR TITLE
CORE-471: centralize toSql/fromSql methods for compact entities

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -2,11 +2,11 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeFormat, Entity}
+import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityUtils
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity}
 import slick.jdbc.MySQLProfile.api._
 import slick.jdbc._
-import spray.json.DefaultJsonProtocol._
+
 import spray.json._
 
 import java.util.UUID
@@ -18,12 +18,9 @@ trait CompactEntityComponent extends LazyLogging {
   object compactEntityQuery extends CompactEntityQuery(this)
 }
 
-class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery {
+class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery with CompactEntityUtils {
   override val driver = driverComponent.driver
   import driverComponent.uniqueResult
-
-  // json codec for entity attributes
-  implicit val attributeFormat: AttributeFormat = new AttributeFormat with CompactEntityAttributeListSerializer
 
   // read a json column from the db and translate into a JsValue
   implicit val GetJsValueResult: GetResult[JsValue] = GetResult(r => r.nextString().parseJson)
@@ -53,7 +50,7 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery {
     * `execution plan: single-row insert`
     */
   def createEntity(workspaceId: UUID, entity: Entity): ReadWriteAction[Int] = {
-    val attributesJson: JsValue = entity.attributes.toJson
+    val attributesJson: JsValue = toSql(entity.attributes)
 
     sqlu"""insert into ENTITY(name, entity_type, workspace_id, record_version, deleted, attributes)
           values (${entity.name}, ${entity.entityType}, $workspaceId, 0, 0, $attributesJson)"""

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
@@ -1,11 +1,9 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
+import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityUtils
 import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
-import org.broadinstitute.dsde.rawls.model.{AttributeFormat, Entity}
-import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+import org.broadinstitute.dsde.rawls.model.Entity
 
 import java.sql.Timestamp
 import java.util.UUID
@@ -27,12 +25,8 @@ case class CompactEntityRecord(id: Long,
                                deleted: Boolean,
                                attributes: Option[String]
 ) {
-
-  // json codec for entity attributes
-  implicit val attributeFormat: AttributeFormat = new AttributeFormat with CompactEntityAttributeListSerializer
-
   def toEntity: Entity = {
-    val attrs: AttributeMap = Try(attributes.getOrElse("{}").parseJson.convertTo[AttributeMap]) match {
+    val attrs: AttributeMap = Try(CompactEntityUtils.fromSql(attributes)) match {
       case Success(attrMap) => attrMap
       case Failure(ex)      =>
         // best-effort attempt to sanely truncate the error message and not include the entire payload

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityUtils.scala
@@ -1,0 +1,29 @@
+package org.broadinstitute.dsde.rawls.entities.compact
+
+import org.broadinstitute.dsde.rawls.dataaccess.slick.CompactEntityAttributeListSerializer
+import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
+import org.broadinstitute.dsde.rawls.model.AttributeFormat
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+// allow for static access to methods from classes that don't want to mix in the trait
+object CompactEntityUtils extends CompactEntityUtils
+
+/**
+  * Utilities for working with compact entities, including methods to serialize to/deserialize from the database
+  */
+trait CompactEntityUtils {
+
+  // serialization format for translating to/from SQL
+  implicit val attributeFormat: AttributeFormat = new AttributeFormat with CompactEntityAttributeListSerializer
+
+  // translate a AttributeMap into a JsValue suitable for persisting into the db
+  def toSql(attributes: AttributeMap): JsValue =
+    attributes.toJson
+
+  // translate a SQL column value back into an AttributeMap
+  def fromSql(attributes: Option[String]): AttributeMap =
+    attributes.getOrElse("{}").parseJson.convertTo[AttributeMap]
+
+}


### PR DESCRIPTION
Ticket: CORE-471

Inspired by CORE-471 but does not complete that ticket.

This PR creates new, centralized `toSql` and `fromSql` methods for compact entities. By centralizing, we can ensure that the serialization and deserialization functions are consistent and can be easily changed in the future.

For instance, future work might want to:
* add the equivalent of a [serialVersionUID](https://www.baeldung.com/java-serial-version-uid) to the data in the db to assist with future changes in the code
* revisit how we denormalize entity references

No new unit tests in this PR, since it is just code restructuring; existing unit tests cover this functionality already.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
