### PR TITLE
CORE-484: Quicksilver serialization versioning

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -139,4 +139,5 @@
     <include file="changesets/20250401_drop_cromwell_backend_column.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250331_drop_audit_workflow_and_submission_status_tables.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250401_entity_json_support.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20250425_entity_json_serdes_format.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250425_entity_json_serdes_format.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250425_entity_json_serdes_format.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
+
+
+    <!-- update the ENTITY triggers which populate ENTITY_KEYS to reflect the latest ENTITY.attributes format -->
+    <changeSet logicalFilePath="dummy" author="davidan" id="update_entity_keys_triggers_for_serdes">
+        <sql stripComments="true" endDelimiter="~">
+            DROP TRIGGER IF EXISTS after_entity_insert ~
+            DROP TRIGGER IF EXISTS after_entity_update ~
+
+            CREATE TRIGGER after_entity_insert AFTER INSERT ON ENTITY
+                FOR EACH ROW
+                -- if attributes is null, this is a legacy entity; ignore it
+                if new.attributes is not null then
+                    INSERT INTO ENTITY_KEYS
+                        (id, workspace_id, entity_type, attribute_keys, last_updated)
+                    VALUES
+                        (new.id, new.workspace_id, new.entity_type, JSON_KEYS(new.attributes, '$.attrs'), now(3));
+                end if ~
+
+            CREATE TRIGGER after_entity_update AFTER UPDATE ON ENTITY
+                FOR EACH ROW
+                BEGIN
+                    -- is this row soft-deleted?
+                    if old.deleted = 0 and new.deleted = 1 then
+                        DELETE FROM ENTITY_KEYS WHERE id = new.id;
+                    elseif new.attributes is not null then
+                        -- compare old keys to new keys; update the ENTITY_KEYS table only if they are different
+                        set @new_keys := JSON_KEYS(new.attributes, '$.attrs');
+                        set @old_keys := JSON_KEYS(old.attributes, '$.attrs');
+                        if JSON_LENGTH(@new_keys) != JSON_LENGTH(@old_keys) OR JSON_CONTAINS(@new_keys, @old_keys) = 0 then
+                            UPDATE ENTITY_KEYS SET attribute_keys=@new_keys, last_updated=now(3)
+                            WHERE id = new.id;
+                        end if;
+                    end if;
+                END ~
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityUtils
+import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
 import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity}
 import slick.jdbc.MySQLProfile.api._
 import slick.jdbc._
@@ -18,7 +18,7 @@ trait CompactEntityComponent extends LazyLogging {
   object compactEntityQuery extends CompactEntityQuery(this)
 }
 
-class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery with CompactEntityUtils {
+class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery with CompactEntitySerialization {
   override val driver = driverComponent.driver
   import driverComponent.uniqueResult
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
-import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityUtils
+import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
 import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.Entity
@@ -26,7 +26,7 @@ case class CompactEntityRecord(id: Long,
                                attributes: Option[String]
 ) {
   def toEntity: Entity = {
-    val attrs: AttributeMap = Try(CompactEntityUtils.fromSql(attributes)) match {
+    val attrs: AttributeMap = Try(CompactEntitySerialization.fromSql(attributes)) match {
       case Success(attrMap) => attrMap
       case Failure(ex)      =>
         // best-effort attempt to sanely truncate the error message and not include the entire payload

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.entities.compact
 
 import org.broadinstitute.dsde.rawls.dataaccess.slick.CompactEntityAttributeListSerializer
+import org.broadinstitute.dsde.rawls.entities.exceptions.CompactEntityDeserializationException
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.AttributeFormat
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
@@ -11,19 +12,102 @@ import spray.json._
 object CompactEntitySerialization extends CompactEntitySerialization
 
 /**
-  * Utilities for working with compact entities, including methods to serialize to/deserialize from the database
+  * Methods to serialize attributes to/deserialize attributes from the database
   */
 trait CompactEntitySerialization {
 
-  // serialization format for translating to/from SQL
+  // defines how list attributes are translated to/from JSON
   implicit val attributeFormat: AttributeFormat = new AttributeFormat with CompactEntityAttributeListSerializer
 
+  // json key for the version number
+  val VERSION_KEY: String = "v"
+  // json key for the attributes content. If this ever changes, make sure to also change the triggers
+  // on the `ENTITY` database table
+  val ATTRS_KEY: String = "attrs"
+
+  // the current serialization version
+  val CURRENT_VERSION: Int = 1
+
   // translate a AttributeMap into a JsValue suitable for persisting into the db
-  def toSql(attributes: AttributeMap): JsValue =
-    attributes.toJson
+  def toSql(attributes: AttributeMap): JsObject =
+    JsObject(
+      Map(
+        VERSION_KEY -> JsNumber(CURRENT_VERSION),
+        ATTRS_KEY -> attributes.toJson
+      )
+    )
 
   // translate a SQL column value back into an AttributeMap
   def fromSql(attributes: Option[String]): AttributeMap =
-    attributes.getOrElse("{}").parseJson.convertTo[AttributeMap]
+    attributes.getOrElse("{}").parseJson match {
+      case jso: JsObject => deserialize(jso)
+      case otherJsValue =>
+        throw new CompactEntityDeserializationException(
+          s"wanted a JsObject; found a ${otherJsValue.getClass.getName}"
+        )
+    }
+
+  // retrieve the version number from the database's JSON
+  private def getVersion(jso: JsObject): Int =
+    jso.fields.get(VERSION_KEY) match {
+      // when a version is embedded in the json, use it
+      case Some(n: JsNumber) => n.value.intValue
+      // when no version is embedded, assume version 0
+      case None => 0
+      // version could not be determined
+      case Some(otherJsValue) =>
+        throw new CompactEntityDeserializationException(
+          s"wanted a version number; found a ${otherJsValue.getClass.getName}"
+        )
+    }
+
+  // retrieve the attributes packet from the database's JSON
+  private def getAttrs(jso: JsObject): JsObject =
+    jso.fields.get(ATTRS_KEY) match {
+      case Some(jso: JsObject) => jso
+      case None =>
+        throw new CompactEntityDeserializationException(
+          s"wanted an attributes sub-object; found none"
+        )
+      // version could not be determined
+      case Some(otherJsValue) =>
+        throw new CompactEntityDeserializationException(
+          s"wanted an attributes sub-object; found a ${otherJsValue.getClass.getName}"
+        )
+    }
+
+  private def deserialize(jso: JsObject): AttributeMap =
+    getVersion(jso) match {
+
+      /*  version 0 stores the attribute map directly, with denormalized references:
+          {
+            "hello": "world",
+            "refs": [
+              {"entityName": "1", "entityType": "test"},
+              {"entityName": "2", "entityType": "test"}
+            ]
+          }
+       */
+      case 0 => jso.convertTo[AttributeMap]
+
+      /*  version 1 embeds the version number. References are denormalized:
+          {
+            "v": 1,
+            "attrs": {
+              "hello": "world",
+              "refs": [
+                {"entityName": "1", "entityType": "test"},
+                {"entityName": "2", "entityType": "test"}
+              ]
+            }
+          }
+       */
+      case 1 => getAttrs(jso).convertTo[AttributeMap]
+
+      case x =>
+        throw new CompactEntityDeserializationException(
+          s"found unexpected version number: $x"
+        )
+    }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
@@ -8,12 +8,12 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 // allow for static access to methods from classes that don't want to mix in the trait
-object CompactEntityUtils extends CompactEntityUtils
+object CompactEntitySerialization extends CompactEntitySerialization
 
 /**
   * Utilities for working with compact entities, including methods to serialize to/deserialize from the database
   */
-trait CompactEntityUtils {
+trait CompactEntitySerialization {
 
   // serialization format for translating to/from SQL
   implicit val attributeFormat: AttributeFormat = new AttributeFormat with CompactEntityAttributeListSerializer

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/CompactEntityDeserializationException.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/CompactEntityDeserializationException.scala
@@ -1,0 +1,8 @@
+package org.broadinstitute.dsde.rawls.entities.exceptions
+
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+
+class CompactEntityDeserializationException(message: String = null,
+                                            cause: Throwable = null,
+                                            override val code: StatusCode = StatusCodes.InternalServerError
+) extends DataEntityException(message, cause, code) {}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
@@ -1,0 +1,129 @@
+package org.broadinstitute.dsde.rawls.entities.compact
+
+import org.broadinstitute.dsde.rawls.entities.exceptions.CompactEntityDeserializationException
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  AttributeEntityReferenceList,
+  AttributeName,
+  AttributeNumber,
+  AttributeString,
+  Entity
+}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import spray.json.{JsNumber, JsObject}
+
+class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with CompactEntitySerialization {
+
+  private val emptyEntity = Entity("emptyEntity", "mytype", Map())
+  private val simpleEntity = Entity(
+    "simpleEntity",
+    "mytype",
+    Map(
+      AttributeName.fromDelimitedName("hello") -> AttributeString("world"),
+      AttributeName.fromDelimitedName("num") -> AttributeNumber(42)
+    )
+  )
+  private val refsEntity = Entity(
+    "refsEntity",
+    "mytype",
+    Map(
+      AttributeName.fromDelimitedName("hello") -> AttributeString("world"),
+      AttributeName.fromDelimitedName("singleref") -> AttributeEntityReference("targetType", "targetName1"),
+      AttributeName.fromDelimitedName("reflist") -> AttributeEntityReferenceList(
+        Seq(
+          AttributeEntityReference("targetType", "targetName2"),
+          AttributeEntityReference("targetType", "targetName3")
+        )
+      )
+    )
+  )
+
+  behavior of "Attribute serialization"
+
+  List(emptyEntity, simpleEntity, refsEntity) foreach { entity =>
+    it should s"include a version number for ${entity.name}" in {
+      val serialized = toSql(entity.attributes)
+      val actual = serialized.fields.get(VERSION_KEY)
+      actual should contain(JsNumber(CURRENT_VERSION))
+    }
+
+    it should s"include the attributes as a sub-object for ${entity.name}" in {
+      val serialized = toSql(entity.attributes)
+      val actual = serialized.fields.get(ATTRS_KEY)
+      actual should not be empty
+      actual.get shouldBe a[JsObject]
+      // this intentionally does not test the details of how the AttributeMap is serialized; that is done elsewhere.
+      // this only tests that the serialized AttributeMap is a sub-object located in an "attrs" key
+    }
+  }
+
+  behavior of "Attribute deserialization"
+
+  private val expectedAttrs = Map(
+    AttributeName.fromDelimitedName("hello") -> AttributeString("world"),
+    AttributeName.fromDelimitedName("reflist") -> AttributeEntityReferenceList(
+      Seq(
+        AttributeEntityReference("targetType", "targetName1")
+      )
+    )
+  )
+
+  it should "deserialize version 0" in {
+    val input = """{"hello": "world", "reflist": [{"entityName": "targetName1", "entityType": "targetType"}]}"""
+    val actual = fromSql(Option(input))
+    actual shouldBe expectedAttrs
+  }
+
+  it should "deserialize version 1" in {
+    val input =
+      """{ "v": 1, "attrs": {"hello": "world", "reflist": [{"entityName": "targetName1", "entityType": "targetType"}]} }"""
+    val actual = fromSql(Option(input))
+    actual shouldBe expectedAttrs
+  }
+
+  it should "return an empty map for input of None" in {
+    val input = None
+    val actual = fromSql(input)
+    actual shouldBe Map()
+  }
+
+  it should "return an empty map for input of {}" in {
+    val input = Some("{}")
+    val actual = fromSql(input)
+    actual shouldBe Map()
+  }
+
+  it should "throw if the version number is out of range" in {
+    val input =
+      """{ "v": 2, "attrs": {} }"""
+    intercept[CompactEntityDeserializationException] {
+      fromSql(Option(input))
+    }
+  }
+
+  it should "throw if the version number is an unexpected data type" in {
+    val input =
+      """{ "v": "v2.0.0", "attrs": {} }"""
+    intercept[CompactEntityDeserializationException] {
+      fromSql(Option(input))
+    }
+  }
+
+  it should "throw if the attributes sub-object is missing" in {
+    val input =
+      """{ "v": 1, "incorrect-key-for-attrs": {} }"""
+    intercept[CompactEntityDeserializationException] {
+      fromSql(Option(input))
+    }
+  }
+
+  it should "throw if the attributes sub-object is an unexpected data type" in {
+    val input =
+      """{ "v": 1, "attrs": false }"""
+    intercept[CompactEntityDeserializationException] {
+      fromSql(Option(input))
+    }
+  }
+
+}


### PR DESCRIPTION
Ticket: CORE-484

This changes how Quicksilver data tables store attributes in MySQL.

Before this PR, attributes were stored as:
```json
{ "foo": "bar", "num": 42 }
```

After this PR, attributes are stored as:
```json
{
  "v": 1,
  "attrs": {"foo": "bar", "num": 42 }
}
```

by embedding a version number - "1" as of this PR - we allow ourselves to rev the serialization format in the future. The packet will always contain information about which serialization technique it used. In the future, for instance, we might want to normalize entity references.
