### PR TITLE
[CORE-440] v3 Snapshot API

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4041,7 +4041,7 @@ paths:
       description: Add references to snapshots in the Terra Data Repo
       operationId: createSnapshotsByWorkspaceName
       requestBody:
-        description: Reference to the Data Repo snapshot
+        description: References to the Data Repo snapshot
         content:
           'application/json':
             schema:
@@ -4072,7 +4072,7 @@ paths:
       description: Add references to snapshots in the Terra Data Repo
       operationId: createSnapshotsByWorkspaceId
       requestBody:
-        description: Reference to the Data Repo snapshot
+        description: References to the Data Repo snapshot
         content:
           'application/json':
             schema:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3791,6 +3791,7 @@ paths:
       summary: List snapshots
       description: Enumerate references to snapshots in the Terra Data Repo, or return only those that reference a given TDR snapshot id
       operationId: enumerateDataRepoSnapshot_v2
+      deprecated: true
       parameters:
         - name: offset
           in: query
@@ -3834,6 +3835,7 @@ paths:
       summary: Create a snapshot
       description: Add a reference to a snapshot in the Terra Data Repo
       operationId: createDataRepoSnapshot_v2
+      deprecated: true
       requestBody:
         description: Reference to the Data Repo snapshot
         content:
@@ -3867,6 +3869,7 @@ paths:
       summary: Get a snapshot
       description: Get a reference to a snapshot in the Terra Data Repo
       operationId: getDataRepoSnapshot_v2
+      deprecated: true
       responses:
         200:
           description: OK
@@ -3885,6 +3888,7 @@ paths:
     patch:
       summary: Update name or description of a reference to a snapshot in the Terra Data Repo.
       operationId: updateDataRepoSnapshot_v2
+      deprecated: true
       tags:
         - snapshots_v2
       requestBody:
@@ -3911,6 +3915,7 @@ paths:
       description: Delete a workspace's reference to a snapshot in the Terra Data
         Repo
       operationId: deleteDataRepoSnapshot_v2
+      deprecated: true
       responses:
         204:
           description: Successful Request
@@ -3933,6 +3938,7 @@ paths:
       summary: Get a snapshot by name
       description: Get a reference to a snapshot in the Terra Data Repo by its name
       operationId: getDataRepoSnapshotByName_v2
+      deprecated: true
       responses:
         200:
           description: OK
@@ -3957,6 +3963,7 @@ paths:
       summary: List snapshots
       description: Enumerate references to snapshots in the Terra Data Repo, or return only those that reference a given TDR snapshot id
       operationId: enumerateDataRepoSnapshotByWorkspaceId
+      deprecated: true
       parameters:
         - name: offset
           in: query
@@ -4000,6 +4007,7 @@ paths:
       summary: Create a snapshot
       description: Add a reference to a snapshot in the Terra Data Repo
       operationId: createDataRepoSnapshotByWorkspaceId
+      deprecated: true
       requestBody:
         description: Reference to the Data Repo snapshot
         content:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -18,6 +18,7 @@ tags:
   - name: notifications
   - name: servicePerimeters
   - name: snapshots_v2
+  - name: snapshots_v3
   - name: status
   - name: submissions
   - name: users
@@ -4013,6 +4014,69 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/DataRepoSnapshotResource'
+        404:
+          description: Workspace or snapshot not found
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v3:
+    parameters:
+      - $ref: '#/components/parameters/workspaceNamespacePathParam'
+      - $ref: '#/components/parameters/workspaceNamePathParam'
+    post:
+      tags:
+        - snapshots_v3
+      summary: Add references to snapshots in the Terra Data Repo
+      description: Add references to snapshots in the Terra Data Repo
+      operationId: createSnapshotsByWorkspaceName
+      requestBody:
+        description: Reference to the Data Repo snapshot
+        content:
+          'application/json':
+            schema:
+              type: array
+              description: List of snapshot IDs to add to the workspace
+              items:
+                type: string
+                format: uuid
+        required: true
+      responses:
+        204:
+          description: Created
+        404:
+          description: Workspace or snapshot not found
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+  /api/workspaces/{workspaceId}/snapshots/v3:
+    parameters:
+      - $ref: '#/components/parameters/workspaceIdPathParam'
+    post:
+      tags:
+        - snapshots_v3
+      summary: Add references to snapshots in the Terra Data Repo
+      description: Add references to snapshots in the Terra Data Repo
+      operationId: createSnapshotsByWorkspaceId
+      requestBody:
+        description: Reference to the Data Repo snapshot
+        content:
+          'application/json':
+            schema:
+              type: array
+              description: List of snapshot IDs to add to the workspace
+              items:
+                type: string
+                format: uuid
+        required: true
+      responses:
+        204:
+          description: Created
         404:
           description: Workspace or snapshot not found
           content:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -490,7 +490,9 @@ object Boot extends IOApp with LazyLogging {
         samDAO,
         workspaceManagerDAO,
         appConfigManager.conf.getString("dataRepo.terraInstanceName"),
-        dataRepoDAO
+        dataRepoDAO,
+        workspaceServiceConstructor,
+        policyService
       )
 
       val spendReportingBigQueryService = appDependencies.bigQueryServiceFactory.getServiceFromJson(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -485,8 +485,12 @@ object Boot extends IOApp with LazyLogging {
         appConfigManager.conf.getInt("entities.pageSizeLimit")
       )
 
+      val billingRepository = new BillingRepository(slickDataSource)
+      val workspaceRepository = new WorkspaceRepository(slickDataSource)
+      val googleProjectRegRepo = new GoogleProjectRegistrationRepository(slickDataSource)
+
       val snapshotServiceConstructor: RawlsRequestContext => SnapshotService = SnapshotService.constructor(
-        slickDataSource,
+        workspaceRepository,
         samDAO,
         workspaceManagerDAO,
         appConfigManager.conf.getString("dataRepo.terraInstanceName"),
@@ -508,9 +512,7 @@ object Boot extends IOApp with LazyLogging {
       )
 
       val workspaceManagerResourceMonitorRecordDao = new WorkspaceManagerResourceMonitorRecordDao(slickDataSource)
-      val billingRepository = new BillingRepository(slickDataSource)
-      val workspaceRepository = new WorkspaceRepository(slickDataSource)
-      val googleProjectRegRepo = new GoogleProjectRegistrationRepository(slickDataSource)
+
       val billingProjectDeletion = new BillingProjectDeletion(samDAO, billingRepository, billingProfileManagerDAO)
       val billingProjectOrchestratorConstructor: RawlsRequestContext => BillingProjectOrchestrator =
         BillingProjectOrchestrator.constructor(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
@@ -63,4 +63,14 @@ class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec:
       getTpsApi(ctx).deletePao(objectId)
     }
   }
+   /**
+      * Unlike mergePao, linkPao works as described by the documentation. It will link the source PAO
+      * to the target PAO, meaning that future changes to the source PAO will propagate to the target
+      * PAO. Changes to the target PAO will not propagate up the link to the source PAO.
+      */
+  def linkPao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[Unit] = Future {
+    blocking {
+      getTpsApi(ctx).linkPao(request, objectId)
+    }
+  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
@@ -17,8 +17,7 @@ import java.util.UUID
 import scala.concurrent.{blocking, ExecutionContext, Future}
 
 class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec: ExecutionContext)
-    extends TpsDAO
-    with LazyLogging {
+    extends TpsDAO {
   protected def getApiClient(ctx: RawlsRequestContext): ApiClient = {
     val client: ApiClient = new ApiClient()
 
@@ -67,11 +66,6 @@ class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec:
     }
   }
 
-  /**
-      * Unlike mergePao, linkPao works as described by the documentation. It will link the source PAO
-      * to the target PAO, meaning that future changes to the source PAO will propagate to the target
-      * PAO. Changes to the target PAO will not propagate up the link to the source PAO.
-      */
   def linkPao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[TpsPaoUpdateResult] =
     Future {
       blocking {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
@@ -14,9 +14,11 @@ import org.glassfish.jersey.jnh.connector.JavaNetHttpConnectorProvider
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import scala.concurrent.{ExecutionContext, Future, blocking}
+import scala.concurrent.{blocking, ExecutionContext, Future}
 
-class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec: ExecutionContext) extends TpsDAO with LazyLogging {
+class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec: ExecutionContext)
+    extends TpsDAO
+    with LazyLogging {
   protected def getApiClient(ctx: RawlsRequestContext): ApiClient = {
     val client: ApiClient = new ApiClient()
 
@@ -64,14 +66,16 @@ class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec:
       getTpsApi(ctx).deletePao(objectId)
     }
   }
-   /**
+
+  /**
       * Unlike mergePao, linkPao works as described by the documentation. It will link the source PAO
       * to the target PAO, meaning that future changes to the source PAO will propagate to the target
       * PAO. Changes to the target PAO will not propagate up the link to the source PAO.
       */
-  def linkPao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[TpsPaoUpdateResult] = Future {
-    blocking {
-      getTpsApi(ctx).linkPao(request, objectId)
+  def linkPao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[TpsPaoUpdateResult] =
+    Future {
+      blocking {
+        getTpsApi(ctx).linkPao(request, objectId)
+      }
     }
-  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.dataaccess.tps
 
 import bio.terra.policy.api.TpsApi
-import bio.terra.policy.client.{ApiClient, ApiException}
+import bio.terra.policy.client.ApiClient
 import bio.terra.policy.model.{TpsPaoCreateRequest, TpsPaoGetResult, TpsPaoSourceRequest}
 import jakarta.ws.rs.client.ClientBuilder
 import org.broadinstitute.dsde.rawls.credentials.RawlsCredential
@@ -52,14 +52,9 @@ class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec:
     }
   }
 
-  def getPao(objectId: UUID, ctx: RawlsRequestContext): Future[Option[TpsPaoGetResult]] = Future {
+  def getPao(objectId: UUID, ctx: RawlsRequestContext): Future[TpsPaoGetResult] = Future {
     blocking {
-      val tpsApi = getTpsApi(ctx)
-      try
-        Option(tpsApi.getPao(objectId, false))
-      catch {
-        case ex: ApiException if ex.getCode == 404 => None
-      }
+      getTpsApi(ctx).getPao(objectId, false)
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
@@ -2,7 +2,8 @@ package org.broadinstitute.dsde.rawls.dataaccess.tps
 
 import bio.terra.policy.api.TpsApi
 import bio.terra.policy.client.ApiClient
-import bio.terra.policy.model.{TpsPaoCreateRequest, TpsPaoGetResult, TpsPaoSourceRequest}
+import bio.terra.policy.model.{TpsPaoCreateRequest, TpsPaoGetResult, TpsPaoSourceRequest, TpsPaoUpdateResult}
+import com.typesafe.scalalogging.LazyLogging
 import jakarta.ws.rs.client.ClientBuilder
 import org.broadinstitute.dsde.rawls.credentials.RawlsCredential
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
@@ -13,9 +14,9 @@ import org.glassfish.jersey.jnh.connector.JavaNetHttpConnectorProvider
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import scala.concurrent.{blocking, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, blocking}
 
-class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec: ExecutionContext) extends TpsDAO {
+class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec: ExecutionContext) extends TpsDAO with LazyLogging {
   protected def getApiClient(ctx: RawlsRequestContext): ApiClient = {
     val client: ApiClient = new ApiClient()
 
@@ -68,7 +69,7 @@ class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec:
       * to the target PAO, meaning that future changes to the source PAO will propagate to the target
       * PAO. Changes to the target PAO will not propagate up the link to the source PAO.
       */
-  def linkPao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[Unit] = Future {
+  def linkPao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[TpsPaoUpdateResult] = Future {
     blocking {
       getTpsApi(ctx).linkPao(request, objectId)
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
@@ -14,4 +14,6 @@ trait TpsDAO {
   def getPao(objectId: UUID, ctx: RawlsRequestContext): Future[TpsPaoGetResult]
 
   def deletePao(objectId: UUID, ctx: RawlsRequestContext): Future[Unit]
+
+  def linkPao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[Unit]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess.tps
 
-import bio.terra.policy.model.{TpsPaoCreateRequest, TpsPaoGetResult, TpsPaoSourceRequest}
+import bio.terra.policy.model.{TpsPaoCreateRequest, TpsPaoGetResult, TpsPaoSourceRequest, TpsPaoUpdateResult}
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
 
 import java.util.UUID
@@ -15,5 +15,5 @@ trait TpsDAO {
 
   def deletePao(objectId: UUID, ctx: RawlsRequestContext): Future[Unit]
 
-  def linkPao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[Unit]
+  def linkPao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[TpsPaoUpdateResult]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
@@ -11,7 +11,7 @@ trait TpsDAO {
 
   def mergePao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[Unit]
 
-  def getPao(objectId: UUID, ctx: RawlsRequestContext): Future[Option[TpsPaoGetResult]]
+  def getPao(objectId: UUID, ctx: RawlsRequestContext): Future[TpsPaoGetResult]
 
   def deletePao(objectId: UUID, ctx: RawlsRequestContext): Future[Unit]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/TpsModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/TpsModel.scala
@@ -19,5 +19,11 @@ object TpsModel {
       override val additionalDataKey: String =
         "" // protected-data policies do not pass additional data and therefore do not need keys
     }
+
+    // Rawls doesn't set up this policy, but it can cause conflicts when combining PAOs. This is here so we can check for its existence and try to avoid conflicts.
+    case object RegionConstraint extends TpsPolicy {
+      override val name: String = "region-constraint"
+      override val additionalDataKey: String = "region-name"
+    }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -1,21 +1,12 @@
 package org.broadinstitute.dsde.rawls.policy
 
 import bio.terra.policy.client.ApiException
-import bio.terra.policy.model.{
-  TpsComponent,
-  TpsObjectType,
-  TpsPaoCreateRequest,
-  TpsPaoGetResult,
-  TpsPaoSourceRequest,
-  TpsPolicyInput,
-  TpsPolicyInputs,
-  TpsPolicyPair,
-  TpsUpdateMode
-}
+import bio.terra.policy.model.{TpsComponent, TpsObjectType, TpsPaoCreateRequest, TpsPaoGetResult, TpsPaoSourceRequest, TpsPolicyInput, TpsPolicyInputs, TpsPolicyPair, TpsUpdateMode}
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.tps.TpsDAO
 import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, TpsPolicies}
-import org.broadinstitute.dsde.rawls.model.{ManagedGroupRef, RawlsGroupName, RawlsRequestContext, WorkspaceRequest}
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, ManagedGroupRef, RawlsGroupName, RawlsRequestContext, WorkspaceRequest}
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
@@ -69,6 +60,27 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) extends L
         None
     }
 
+  /**
+    * Retrieves the snapshot PAO for the given snapshotId. If it does not exist, it creates a new one with no policies.
+    */
+  def getOrCreateSnapshotPao(snapshotId: UUID, ctx: RawlsRequestContext): Future[TpsPaoGetResult] = {
+    for {
+      snapshotPaoOpt <- getPao(snapshotId, ctx)
+      snapshotPao <- if (snapshotPaoOpt.isEmpty) {
+        logger.info(s"pao not found, creating new one [snapshotId: $snapshotId]")
+        val req = new TpsPaoCreateRequest()
+          .objectType(TpsObjectType.SNAPSHOT)
+          .objectId(snapshotId)
+          .component(TpsComponent.TDR)
+
+        tpsDAO.createPao(req, ctx).flatMap(_ => tpsDAO.getPao(snapshotId, ctx))
+      } else {
+        Future.successful(snapshotPaoOpt.get)
+      }
+    } yield snapshotPao
+  }
+
+
   def deleteWorkspacePao(workspaceId: UUID, ctx: RawlsRequestContext): Future[Unit] =
     tpsDAO.deletePao(workspaceId, ctx).recover { case ex: ApiException =>
       logger.error(s"Exception occurred while deleting PAO: ${ex.getMessage}", ex)
@@ -78,10 +90,20 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) extends L
   def linkSnapshotPaoToWorkspacePao(
     snapshotId: UUID,
     workspaceId: UUID,
+    dryRun: Boolean,
     ctx: RawlsRequestContext
   ): Future[Unit] = {
-    val req = new TpsPaoSourceRequest().sourceObjectId(snapshotId).updateMode(TpsUpdateMode.FAIL_ON_CONFLICT)
+    val req = new TpsPaoSourceRequest().sourceObjectId(snapshotId)
 
-    tpsDAO.linkPao(req, workspaceId, ctx)
+    if (dryRun)
+      req.setUpdateMode(TpsUpdateMode.DRY_RUN)
+    else
+      req.setUpdateMode(TpsUpdateMode.FAIL_ON_CONFLICT)
+
+    tpsDAO.linkPao(req, workspaceId, ctx).map { res =>
+      if (res.getConflicts.asScala.nonEmpty) {
+        throw new RawlsExceptionWithErrorReport(ErrorReport(s"${if (dryRun) "Dry run" else "Link"} failed: ${res.getConflicts.asScala.mkString(",")}"))
+      }
+    }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -84,7 +84,6 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) extends L
       snapshotPaoOpt <- getPao(snapshotId, ctx)
       snapshotPao <-
         if (snapshotPaoOpt.isEmpty) {
-          logger.info(s"pao not found, creating new one [snapshotId: $snapshotId]")
           val req = new TpsPaoCreateRequest()
             .objectType(TpsObjectType.SNAPSHOT)
             .objectId(snapshotId)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -101,6 +101,11 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) extends L
     // Ignore any exception
     }
 
+  /**
+    * Unlike mergePao, linkPao works as described by the documentation. It will link the source PAO
+    * to the target PAO, meaning that future changes to the source PAO will propagate to the target
+    * PAO. Changes to the target PAO will not propagate up the link to the source PAO.
+    */
   def linkSnapshotPaoToWorkspacePao(
     snapshotId: UUID,
     workspaceId: UUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -74,4 +74,14 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) extends L
       logger.error(s"Exception occurred while deleting PAO: ${ex.getMessage}", ex)
     // Ignore any exception
     }
+
+  def linkSnapshotPaoToWorkspacePao(
+    snapshotId: UUID,
+    workspaceId: UUID,
+    ctx: RawlsRequestContext
+  ): Future[Unit] = {
+    val req = new TpsPaoSourceRequest().sourceObjectId(snapshotId).updateMode(TpsUpdateMode.FAIL_ON_CONFLICT)
+
+    tpsDAO.linkPao(req, workspaceId, ctx)
+  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -64,7 +64,10 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) extends L
   }
 
   def getPao(objectId: UUID, ctx: RawlsRequestContext): Future[Option[TpsPaoGetResult]] =
-    tpsDAO.getPao(objectId, ctx)
+    tpsDAO.getPao(objectId, ctx).map(Option.apply).recover {
+      case ex: ApiException if ex.getCode == 404 =>
+        None
+    }
 
   def deleteWorkspacePao(workspaceId: UUID, ctx: RawlsRequestContext): Future[Unit] =
     tpsDAO.deletePao(workspaceId, ctx).recover { case ex: ApiException =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -1,17 +1,7 @@
 package org.broadinstitute.dsde.rawls.policy
 
 import bio.terra.policy.client.ApiException
-import bio.terra.policy.model.{
-  TpsComponent,
-  TpsObjectType,
-  TpsPaoCreateRequest,
-  TpsPaoGetResult,
-  TpsPaoSourceRequest,
-  TpsPolicyInput,
-  TpsPolicyInputs,
-  TpsPolicyPair,
-  TpsUpdateMode
-}
+import bio.terra.policy.model._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.tps.TpsDAO

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -1,12 +1,28 @@
 package org.broadinstitute.dsde.rawls.policy
 
 import bio.terra.policy.client.ApiException
-import bio.terra.policy.model.{TpsComponent, TpsObjectType, TpsPaoCreateRequest, TpsPaoGetResult, TpsPaoSourceRequest, TpsPolicyInput, TpsPolicyInputs, TpsPolicyPair, TpsUpdateMode}
+import bio.terra.policy.model.{
+  TpsComponent,
+  TpsObjectType,
+  TpsPaoCreateRequest,
+  TpsPaoGetResult,
+  TpsPaoSourceRequest,
+  TpsPolicyInput,
+  TpsPolicyInputs,
+  TpsPolicyPair,
+  TpsUpdateMode
+}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.tps.TpsDAO
 import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, TpsPolicies}
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, ManagedGroupRef, RawlsGroupName, RawlsRequestContext, WorkspaceRequest}
+import org.broadinstitute.dsde.rawls.model.{
+  ErrorReport,
+  ManagedGroupRef,
+  RawlsGroupName,
+  RawlsRequestContext,
+  WorkspaceRequest
+}
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
@@ -63,23 +79,22 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) extends L
   /**
     * Retrieves the snapshot PAO for the given snapshotId. If it does not exist, it creates a new one with no policies.
     */
-  def getOrCreateSnapshotPao(snapshotId: UUID, ctx: RawlsRequestContext): Future[TpsPaoGetResult] = {
+  def getOrCreateSnapshotPao(snapshotId: UUID, ctx: RawlsRequestContext): Future[TpsPaoGetResult] =
     for {
       snapshotPaoOpt <- getPao(snapshotId, ctx)
-      snapshotPao <- if (snapshotPaoOpt.isEmpty) {
-        logger.info(s"pao not found, creating new one [snapshotId: $snapshotId]")
-        val req = new TpsPaoCreateRequest()
-          .objectType(TpsObjectType.SNAPSHOT)
-          .objectId(snapshotId)
-          .component(TpsComponent.TDR)
+      snapshotPao <-
+        if (snapshotPaoOpt.isEmpty) {
+          logger.info(s"pao not found, creating new one [snapshotId: $snapshotId]")
+          val req = new TpsPaoCreateRequest()
+            .objectType(TpsObjectType.SNAPSHOT)
+            .objectId(snapshotId)
+            .component(TpsComponent.TDR)
 
-        tpsDAO.createPao(req, ctx).flatMap(_ => tpsDAO.getPao(snapshotId, ctx))
-      } else {
-        Future.successful(snapshotPaoOpt.get)
-      }
+          tpsDAO.createPao(req, ctx).flatMap(_ => tpsDAO.getPao(snapshotId, ctx))
+        } else {
+          Future.successful(snapshotPaoOpt.get)
+        }
     } yield snapshotPao
-  }
-
 
   def deleteWorkspacePao(workspaceId: UUID, ctx: RawlsRequestContext): Future[Unit] =
     tpsDAO.deletePao(workspaceId, ctx).recover { case ex: ApiException =>
@@ -102,7 +117,9 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) extends L
 
     tpsDAO.linkPao(req, workspaceId, ctx).map { res =>
       if (res.getConflicts.asScala.nonEmpty) {
-        throw new RawlsExceptionWithErrorReport(ErrorReport(s"${if (dryRun) "Dry run" else "Link"} failed: ${res.getConflicts.asScala.mkString(",")}"))
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(s"${if (dryRun) "Dry run" else "Link"} failed: ${res.getConflicts.asScala.mkString(",")}")
+        )
       }
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyUtilities.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyUtilities.scala
@@ -1,0 +1,29 @@
+package org.broadinstitute.dsde.rawls.policy
+
+import bio.terra.policy.model.TpsPaoGetResult
+import org.broadinstitute.dsde.rawls.model.TpsModel.TpsPolicies.TpsPolicy
+import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, TpsPolicies}
+
+import scala.jdk.CollectionConverters._
+
+object PolicyUtilities {
+
+  def containsProtectedDataPolicy(tpsPaoGetResult: TpsPaoGetResult): Boolean =
+      containsPolicy(tpsPaoGetResult, TpsPolicies.ProtectedData)
+
+  def getGroupConstraintGroups(tpsPaoGetResult: TpsPaoGetResult): Set[String] =
+        tpsPaoGetResult.getEffectiveAttributes.getInputs.asScala
+          .find(p => p.getNamespace == TERRA_POLICY_NAMESPACE && p.getName == TpsPolicies.GroupConstraint.name)
+          .map { groupConstraintPolicy =>
+            groupConstraintPolicy.getAdditionalData.asScala.map(_.getValue).toSet
+          }
+
+      .getOrElse(Set.empty)
+
+  def containsRegionConstraintPolicy(tpsPaoGetResult: TpsPaoGetResult): Boolean = containsPolicy(tpsPaoGetResult, TpsPolicies.RegionConstraint)
+
+
+  private def containsPolicy(tpsPaoGetResult: TpsPaoGetResult, tpsPolicy: TpsPolicy): Boolean = {
+    tpsPaoGetResult.getEffectiveAttributes.getInputs.asScala.exists(_.getName == tpsPolicy.name)
+  }
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyUtilities.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyUtilities.scala
@@ -9,21 +9,19 @@ import scala.jdk.CollectionConverters._
 object PolicyUtilities {
 
   def containsProtectedDataPolicy(tpsPaoGetResult: TpsPaoGetResult): Boolean =
-      containsPolicy(tpsPaoGetResult, TpsPolicies.ProtectedData)
+    containsPolicy(tpsPaoGetResult, TpsPolicies.ProtectedData)
 
   def getGroupConstraintGroups(tpsPaoGetResult: TpsPaoGetResult): Set[String] =
-        tpsPaoGetResult.getEffectiveAttributes.getInputs.asScala
-          .find(p => p.getNamespace == TERRA_POLICY_NAMESPACE && p.getName == TpsPolicies.GroupConstraint.name)
-          .map { groupConstraintPolicy =>
-            groupConstraintPolicy.getAdditionalData.asScala.map(_.getValue).toSet
-          }
-
+    tpsPaoGetResult.getEffectiveAttributes.getInputs.asScala
+      .find(p => p.getNamespace == TERRA_POLICY_NAMESPACE && p.getName == TpsPolicies.GroupConstraint.name)
+      .map { groupConstraintPolicy =>
+        groupConstraintPolicy.getAdditionalData.asScala.map(_.getValue).toSet
+      }
       .getOrElse(Set.empty)
 
-  def containsRegionConstraintPolicy(tpsPaoGetResult: TpsPaoGetResult): Boolean = containsPolicy(tpsPaoGetResult, TpsPolicies.RegionConstraint)
+  def containsRegionConstraintPolicy(tpsPaoGetResult: TpsPaoGetResult): Boolean =
+    containsPolicy(tpsPaoGetResult, TpsPolicies.RegionConstraint)
 
-
-  private def containsPolicy(tpsPaoGetResult: TpsPaoGetResult, tpsPolicy: TpsPolicy): Boolean = {
+  private def containsPolicy(tpsPaoGetResult: TpsPaoGetResult, tpsPolicy: TpsPolicy): Boolean =
     tpsPaoGetResult.getEffectiveAttributes.getInputs.asScala.exists(_.getName == tpsPolicy.name)
-  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyUtilities.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyUtilities.scala
@@ -7,10 +7,6 @@ import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, Tps
 import scala.jdk.CollectionConverters._
 
 object PolicyUtilities {
-
-  def containsProtectedDataPolicy(tpsPaoGetResult: TpsPaoGetResult): Boolean =
-    containsPolicy(tpsPaoGetResult, TpsPolicies.ProtectedData)
-
   def getGroupConstraintGroups(tpsPaoGetResult: TpsPaoGetResult): Set[String] =
     tpsPaoGetResult.getEffectiveAttributes.getInputs.asScala
       .find(p => p.getNamespace == TERRA_POLICY_NAMESPACE && p.getName == TpsPolicies.GroupConstraint.name)
@@ -19,9 +15,6 @@ object PolicyUtilities {
       }
       .getOrElse(Set.empty)
 
-  def containsRegionConstraintPolicy(tpsPaoGetResult: TpsPaoGetResult): Boolean =
-    containsPolicy(tpsPaoGetResult, TpsPolicies.RegionConstraint)
-
-  private def containsPolicy(tpsPaoGetResult: TpsPaoGetResult, tpsPolicy: TpsPolicy): Boolean =
+  def containsPolicy(tpsPaoGetResult: TpsPaoGetResult, tpsPolicy: TpsPolicy): Boolean =
     tpsPaoGetResult.getEffectiveAttributes.getInputs.asScala.exists(_.getName == tpsPolicy.name)
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -8,7 +8,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
 import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, TpsPolicies}
 import org.broadinstitute.dsde.rawls.model.{
   DataReferenceName,
@@ -18,7 +18,6 @@ import org.broadinstitute.dsde.rawls.model.{
   SamResourceTypeNames,
   SamWorkspaceActions,
   SnapshotListResponse,
-  SnapshotListResponseV3,
   Workspace,
   WorkspaceAttributeSpecs,
   WorkspaceCloudPlatform,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -205,11 +205,16 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
         )
       )
 
-      snapshotPaos <- Future.traverse(snapshotsFromDataRepo) { snapshot =>
+      // filter out any snapshots that are already linked to the workspace
+      unlinkedSnapshots = snapshotsFromDataRepo.filterNot(snapshot =>
+        workspacePao.getSourcesObjectIds.asScala.toSet.contains(snapshot.getId)
+      )
+
+      snapshotPaos <- Future.traverse(unlinkedSnapshots) { snapshot =>
         policyService.getOrCreateSnapshotPao(snapshot.getId, ctx)
       }
 
-      _ <- Future.traverse(snapshotsFromDataRepo) { snapshot =>
+      _ <- Future.traverse(unlinkedSnapshots) { snapshot =>
         policyService.linkSnapshotPaoToWorkspacePao(snapshot.getId,
                                                     rawlsWorkspace.workspaceIdAsUUID,
                                                     dryRun = true,
@@ -245,7 +250,7 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
           workspaceServiceConstructor(ctx).addAuthDomainGroups(rawlsWorkspace.toWorkspaceName, newWorkspaceGroups, ctx)
         } else Future.unit
 
-      _ <- Future.traverse(snapshotsFromDataRepo) { snapshot =>
+      _ <- Future.traverse(unlinkedSnapshots) { snapshot =>
         policyService.linkSnapshotPaoToWorkspacePao(snapshot.getId,
                                                     rawlsWorkspace.workspaceIdAsUUID,
                                                     dryRun = false,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.snapshot
 
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.datarepo.client.ApiException
+import bio.terra.datarepo.model.SnapshotModel
 import bio.terra.workspace.model._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
@@ -254,26 +255,10 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
       }
     } yield ()
 
-  private def getSnapshotFromDataRepo(snapshotIdentifiers: NamedDataRepoSnapshot) =
-    Try(dataRepoDAO.getSnapshot(snapshotIdentifiers.snapshotId, ctx.userInfo.accessToken)) match {
-      case Success(snapshot) => snapshot
-      // if snapshot not found in TDR, this is a bad request
-      case Failure(ex: ApiException) if ex.getCode == StatusCodes.NotFound.intValue =>
-        throw new RawlsExceptionWithErrorReport(
-          ErrorReport(StatusCodes.BadRequest, s"Snapshot ${snapshotIdentifiers.snapshotId} not found.")
-        )
-      // on some other TDR API exception, strip the stack trace and propagate
-      case Failure(ex: ApiException) =>
-        throw new RawlsExceptionWithErrorReport(
-          ErrorReport(ex.getCode, ex.getMessage)
-        )
-      // else, propagate by wrapping in an error report
-      case Failure(other) =>
-        logger.warn(s"Unexpected error when retrieving snapshot: ${other.getMessage}", other)
-        throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, other.getMessage))
-    }
+  private def getSnapshotFromDataRepo(snapshotIdentifiers: NamedDataRepoSnapshot): SnapshotModel =
+    getSnapshotFromDataRepoWithId(snapshotIdentifiers.snapshotId)
 
-  private def getSnapshotFromDataRepoWithId(snapshotId: UUID) =
+  private def getSnapshotFromDataRepoWithId(snapshotId: UUID): SnapshotModel =
     Try(dataRepoDAO.getSnapshot(snapshotId, ctx.userInfo.accessToken)) match {
       case Success(snapshot) => snapshot
       // if snapshot not found in TDR, this is a bad request

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -9,10 +9,28 @@ import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, TpsPolicies}
-import org.broadinstitute.dsde.rawls.model.{DataReferenceName, ErrorReport, NamedDataRepoSnapshot, RawlsRequestContext, SamResourceTypeNames, SamWorkspaceActions, SnapshotListResponse, SnapshotListResponseV3, Workspace, WorkspaceAttributeSpecs, WorkspaceCloudPlatform, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model.{
+  DataReferenceName,
+  ErrorReport,
+  NamedDataRepoSnapshot,
+  RawlsRequestContext,
+  SamResourceTypeNames,
+  SamWorkspaceActions,
+  SnapshotListResponse,
+  SnapshotListResponseV3,
+  Workspace,
+  WorkspaceAttributeSpecs,
+  WorkspaceCloudPlatform,
+  WorkspaceName
+}
 import org.broadinstitute.dsde.rawls.policy.{PolicyService, PolicyUtilities}
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
-import org.broadinstitute.dsde.rawls.workspace.{AggregateWorkspaceNotFoundException, AggregatedWorkspaceService, WorkspaceRepository, WorkspaceService}
+import org.broadinstitute.dsde.rawls.workspace.{
+  AggregateWorkspaceNotFoundException,
+  AggregatedWorkspaceService,
+  WorkspaceRepository,
+  WorkspaceService
+}
 
 import java.util.UUID
 import scala.annotation.tailrec
@@ -29,13 +47,14 @@ object SnapshotService {
                   workspaceServiceConstructor: RawlsRequestContext => WorkspaceService,
                   policyService: PolicyService
   )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): SnapshotService =
-    new SnapshotService(ctx,
-                        dataSource,
-                        samDAO,
-                        workspaceManagerDAO,
-                        terraDataRepoUrl,
-                        dataRepoDAO,
-                        new AggregatedWorkspaceService(workspaceManagerDAO),
+    new SnapshotService(
+      ctx,
+      dataSource,
+      samDAO,
+      workspaceManagerDAO,
+      terraDataRepoUrl,
+      dataRepoDAO,
+      new AggregatedWorkspaceService(workspaceManagerDAO),
       workspaceServiceConstructor,
       policyService
     )
@@ -159,9 +178,7 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
     }
 
   // Finds a workspace using the workspaceId then calls the createSnapshot method
-  def createSnapshotsByWorkspaceIdV3(workspaceId: String,
-                                     snapshotIds: Set[UUID]
-  ): Future[Unit] =
+  def createSnapshotsByWorkspaceIdV3(workspaceId: String, snapshotIds: Set[UUID]): Future[Unit] =
     getV2WorkspaceContextAndPermissionsById(workspaceId,
                                             SamWorkspaceActions.write,
                                             Some(WorkspaceAttributeSpecs(all = false))
@@ -170,26 +187,25 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
     }
 
   // Find a workspace using the workspaceName then calls the createSnapshot method
-  def createSnapshotsByWorkspaceNameV3(workspaceName: WorkspaceName,
-                                       snapshotIds: Set[UUID]
-  ): Future[Unit] =
+  def createSnapshotsByWorkspaceNameV3(workspaceName: WorkspaceName, snapshotIds: Set[UUID]): Future[Unit] =
     getV2WorkspaceContextAndPermissions(workspaceName,
                                         SamWorkspaceActions.write,
                                         Some(WorkspaceAttributeSpecs(all = false))
     ).flatMap(rawlsWorkspace => createSnapshots(rawlsWorkspace, snapshotIds))
 
-
   // Link the snapshot pao to the workspace pao
-  private def createSnapshots(rawlsWorkspace: Workspace,
-                               snapshotIds: Set[UUID]
-  ): Future[Unit] =
+  private def createSnapshots(rawlsWorkspace: Workspace, snapshotIds: Set[UUID]): Future[Unit] =
     for {
       snapshotsFromDataRepo <- Future {
         snapshotIds.map(getSnapshotFromDataRepoWithId)
       }
       workspacePaoOpt <- policyService.getPao(rawlsWorkspace.workspaceIdAsUUID, ctx)
-      workspacePao = workspacePaoOpt.getOrElse(throw new RawlsExceptionWithErrorReport(
-        ErrorReport(StatusCodes.NotFound, s"Workspace PAO not found for workspace ${rawlsWorkspace.workspaceIdAsUUID}"))
+      workspacePao = workspacePaoOpt.getOrElse(
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.NotFound,
+                      s"Workspace PAO not found for workspace ${rawlsWorkspace.workspaceIdAsUUID}"
+          )
+        )
       )
 
       snapshotPaos <- Future.traverse(snapshotsFromDataRepo) { snapshot =>
@@ -197,11 +213,18 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
       }
 
       _ <- Future.traverse(snapshotsFromDataRepo) { snapshot =>
-        policyService.linkSnapshotPaoToWorkspacePao(snapshot.getId, rawlsWorkspace.workspaceIdAsUUID, dryRun = true, ctx)
+        policyService.linkSnapshotPaoToWorkspacePao(snapshot.getId,
+                                                    rawlsWorkspace.workspaceIdAsUUID,
+                                                    dryRun = true,
+                                                    ctx
+        )
       }
 
       // if any snapshots contain protected data, the workspace must be protected
-      _ = if (snapshotPaos.exists(PolicyUtilities.containsProtectedDataPolicy) && !PolicyUtilities.containsProtectedDataPolicy(workspacePao)) {
+      _ = if (
+        snapshotPaos.exists(PolicyUtilities.containsProtectedDataPolicy) && !PolicyUtilities
+          .containsProtectedDataPolicy(workspacePao)
+      ) {
         throw new ProtectedDataException("Unable to add protected snapshot to unprotected workspace.")
       }
 
@@ -220,15 +243,19 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
         PolicyUtilities.getGroupConstraintGroups(snapshotPao)
       }
       newWorkspaceGroups = snapshotGroups -- PolicyUtilities.getGroupConstraintGroups(workspacePao)
-      _ <- if (newWorkspaceGroups.nonEmpty) {
-        workspaceServiceConstructor(ctx).addAuthDomainGroups(rawlsWorkspace.toWorkspaceName, newWorkspaceGroups, ctx)
-      } else Future.unit
+      _ <-
+        if (newWorkspaceGroups.nonEmpty) {
+          workspaceServiceConstructor(ctx).addAuthDomainGroups(rawlsWorkspace.toWorkspaceName, newWorkspaceGroups, ctx)
+        } else Future.unit
 
       _ <- Future.traverse(snapshotsFromDataRepo) { snapshot =>
-        policyService.linkSnapshotPaoToWorkspacePao(snapshot.getId, rawlsWorkspace.workspaceIdAsUUID, dryRun = false, ctx)
+        policyService.linkSnapshotPaoToWorkspacePao(snapshot.getId,
+                                                    rawlsWorkspace.workspaceIdAsUUID,
+                                                    dryRun = false,
+                                                    ctx
+        )
       }
     } yield ()
-
 
   private def getSnapshotFromDataRepo(snapshotIdentifiers: NamedDataRepoSnapshot) =
     Try(dataRepoDAO.getSnapshot(snapshotIdentifiers.snapshotId, ctx.userInfo.accessToken)) match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -219,8 +219,8 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
 
       // if any snapshots contain protected data, the workspace must be protected
       _ = if (
-        snapshotPaos.exists(PolicyUtilities.containsProtectedDataPolicy) && !PolicyUtilities
-          .containsProtectedDataPolicy(workspacePao)
+        snapshotPaos.exists(PolicyUtilities.containsPolicy(_, TpsPolicies.ProtectedData)) && !PolicyUtilities
+          .containsPolicy(workspacePao, TpsPolicies.ProtectedData)
       ) {
         throw new ProtectedDataException("Unable to add protected snapshot to unprotected workspace.")
       }
@@ -230,7 +230,7 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
       // that all of the snapshot PAOs will combine together cleanly when they're all linked to
       // the same workspace. Snapshots shouldn't have region constraint policies, but throw here
       // just in case.
-      _ = if (snapshotPaos.exists(PolicyUtilities.containsRegionConstraintPolicy)) {
+      _ = if (snapshotPaos.exists(PolicyUtilities.containsPolicy(_, TpsPolicies.RegionConstraint))) {
         throw new RawlsExceptionWithErrorReport(
           ErrorReport(StatusCodes.BadRequest, "Unable to add snapshot with region constraint to workspace.")
         )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -9,25 +9,10 @@ import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, TpsPolicies}
-import org.broadinstitute.dsde.rawls.model.{
-  DataReferenceName,
-  ErrorReport,
-  NamedDataRepoSnapshot,
-  RawlsRequestContext,
-  SamResourceTypeNames,
-  SamWorkspaceActions,
-  SnapshotListResponse,
-  Workspace,
-  WorkspaceAttributeSpecs,
-  WorkspaceCloudPlatform,
-  WorkspaceName
-}
+import org.broadinstitute.dsde.rawls.model.{DataReferenceName, ErrorReport, NamedDataRepoSnapshot, RawlsRequestContext, SamResourceTypeNames, SamWorkspaceActions, SnapshotListResponse, Workspace, WorkspaceAttributeSpecs, WorkspaceCloudPlatform, WorkspaceName}
+import org.broadinstitute.dsde.rawls.policy.{PolicyService, PolicyUtilities}
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
-import org.broadinstitute.dsde.rawls.workspace.{
-  AggregateWorkspaceNotFoundException,
-  AggregatedWorkspaceService,
-  WorkspaceRepository
-}
+import org.broadinstitute.dsde.rawls.workspace.{AggregateWorkspaceNotFoundException, AggregatedWorkspaceService, WorkspaceRepository, WorkspaceService}
 
 import java.util.UUID
 import scala.annotation.tailrec
@@ -40,7 +25,9 @@ object SnapshotService {
                   samDAO: SamDAO,
                   workspaceManagerDAO: WorkspaceManagerDAO,
                   terraDataRepoUrl: String,
-                  dataRepoDAO: DataRepoDAO
+                  dataRepoDAO: DataRepoDAO,
+                  workspaceServiceConstructor: RawlsRequestContext => WorkspaceService,
+                  policyService: PolicyService
   )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): SnapshotService =
     new SnapshotService(ctx,
                         dataSource,
@@ -48,7 +35,9 @@ object SnapshotService {
                         workspaceManagerDAO,
                         terraDataRepoUrl,
                         dataRepoDAO,
-                        new AggregatedWorkspaceService(workspaceManagerDAO)
+                        new AggregatedWorkspaceService(workspaceManagerDAO),
+      workspaceServiceConstructor,
+      policyService
     )
 }
 
@@ -58,7 +47,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
                       workspaceManagerDAO: WorkspaceManagerDAO,
                       terraDataRepoInstanceName: String,
                       dataRepoDAO: DataRepoDAO,
-                      aggregatedWorkspaceService: AggregatedWorkspaceService
+                      aggregatedWorkspaceService: AggregatedWorkspaceService,
+                      workspaceServiceConstructor: RawlsRequestContext => WorkspaceService,
+                      policyService: PolicyService
 )(implicit protected val executionContext: ExecutionContext)
     extends FutureSupport
     with WorkspaceSupport
@@ -167,6 +158,51 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
         )
     }
 
+  // Finds a workspace using the workspaceId then calls the createSnapshot method
+  def createSnapshotByWorkspaceIdV3(workspaceId: String,
+                                    snapshotId: UUID
+  ): Future[Unit] =
+    getV2WorkspaceContextAndPermissionsById(workspaceId,
+                                            SamWorkspaceActions.write,
+                                            Some(WorkspaceAttributeSpecs(all = false))
+    ).flatMap { rawlsWorkspace =>
+      createSnapshotV3(rawlsWorkspace, snapshotId)
+    }
+
+  // Find a workspace using the workspaceName then calls the createSnapshot method
+  def createSnapshotByWorkspaceNameV3(workspaceName: WorkspaceName,
+                                      snapshotId: UUID
+  ): Future[Unit] =
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
+    ).flatMap(rawlsWorkspace => createSnapshotV3(rawlsWorkspace, snapshotId))
+
+
+  // Link the snapshot pao to the workspace pao
+  private def createSnapshotV3(rawlsWorkspace: Workspace,
+                               snapshotId: UUID
+  ): Future[Unit] =
+    for {
+      snapshotFromDataRepo <- Future {
+        getSnapshotFromDataRepoWithId(snapshotId)
+      }
+      workspacePao <- policyService.getPao(rawlsWorkspace.workspaceIdAsUUID, ctx)
+      snapshotPao <- policyService.getPao(snapshotFromDataRepo.getId, ctx)
+
+      _ = if (PolicyUtilities.containsProtectedDataPolicy(snapshotPao) && !PolicyUtilities.containsProtectedDataPolicy(workspacePao)) { // todo: this still needs to do the right thing if there is no workspace or snapshot pao
+        throw new ProtectedDataException("Unable to add protected snapshot to unprotected workspace.")
+      }
+
+      newWorkspaceGroups = PolicyUtilities.getGroupConstraintGroups(snapshotPao) -- PolicyUtilities.getGroupConstraintGroups(workspacePao)
+      _ <- if (newWorkspaceGroups.nonEmpty) {
+        workspaceServiceConstructor(ctx).addAuthDomainGroups(rawlsWorkspace.toWorkspaceName, newWorkspaceGroups, ctx)
+      } else Future.unit
+
+      _ <- policyService.linkSnapshotPaoToWorkspacePao(snapshotFromDataRepo.getId, rawlsWorkspace.workspaceIdAsUUID, ctx)
+    } yield ()
+
+
   private def getSnapshotFromDataRepo(snapshotIdentifiers: NamedDataRepoSnapshot) =
     Try(dataRepoDAO.getSnapshot(snapshotIdentifiers.snapshotId, ctx.userInfo.accessToken)) match {
       case Success(snapshot) => snapshot
@@ -174,6 +210,25 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
       case Failure(ex: ApiException) if ex.getCode == StatusCodes.NotFound.intValue =>
         throw new RawlsExceptionWithErrorReport(
           ErrorReport(StatusCodes.BadRequest, s"Snapshot ${snapshotIdentifiers.snapshotId} not found.")
+        )
+      // on some other TDR API exception, strip the stack trace and propagate
+      case Failure(ex: ApiException) =>
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(ex.getCode, ex.getMessage)
+        )
+      // else, propagate by wrapping in an error report
+      case Failure(other) =>
+        logger.warn(s"Unexpected error when retrieving snapshot: ${other.getMessage}", other)
+        throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, other.getMessage))
+    }
+
+  private def getSnapshotFromDataRepoWithId(snapshotId: UUID) =
+    Try(dataRepoDAO.getSnapshot(snapshotId, ctx.userInfo.accessToken)) match {
+      case Success(snapshot) => snapshot
+      // if snapshot not found in TDR, this is a bad request
+      case Failure(ex: ApiException) if ex.getCode == StatusCodes.NotFound.intValue =>
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, s"Snapshot ${snapshotId} not found.")
         )
       // on some other TDR API exception, strip the stack trace and propagate
       case Failure(ex: ApiException) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -9,7 +9,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, TpsPolicies}
-import org.broadinstitute.dsde.rawls.model.{DataReferenceName, ErrorReport, NamedDataRepoSnapshot, RawlsRequestContext, SamResourceTypeNames, SamWorkspaceActions, SnapshotListResponse, Workspace, WorkspaceAttributeSpecs, WorkspaceCloudPlatform, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model.{DataReferenceName, ErrorReport, NamedDataRepoSnapshot, RawlsRequestContext, SamResourceTypeNames, SamWorkspaceActions, SnapshotListResponse, SnapshotListResponseV3, Workspace, WorkspaceAttributeSpecs, WorkspaceCloudPlatform, WorkspaceName}
 import org.broadinstitute.dsde.rawls.policy.{PolicyService, PolicyUtilities}
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.{AggregateWorkspaceNotFoundException, AggregatedWorkspaceService, WorkspaceRepository, WorkspaceService}
@@ -159,47 +159,74 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
     }
 
   // Finds a workspace using the workspaceId then calls the createSnapshot method
-  def createSnapshotByWorkspaceIdV3(workspaceId: String,
-                                    snapshotId: UUID
+  def createSnapshotsByWorkspaceIdV3(workspaceId: String,
+                                     snapshotIds: Set[UUID]
   ): Future[Unit] =
     getV2WorkspaceContextAndPermissionsById(workspaceId,
                                             SamWorkspaceActions.write,
                                             Some(WorkspaceAttributeSpecs(all = false))
     ).flatMap { rawlsWorkspace =>
-      createSnapshotV3(rawlsWorkspace, snapshotId)
+      createSnapshots(rawlsWorkspace, snapshotIds)
     }
 
   // Find a workspace using the workspaceName then calls the createSnapshot method
-  def createSnapshotByWorkspaceNameV3(workspaceName: WorkspaceName,
-                                      snapshotId: UUID
+  def createSnapshotsByWorkspaceNameV3(workspaceName: WorkspaceName,
+                                       snapshotIds: Set[UUID]
   ): Future[Unit] =
     getV2WorkspaceContextAndPermissions(workspaceName,
                                         SamWorkspaceActions.write,
                                         Some(WorkspaceAttributeSpecs(all = false))
-    ).flatMap(rawlsWorkspace => createSnapshotV3(rawlsWorkspace, snapshotId))
+    ).flatMap(rawlsWorkspace => createSnapshots(rawlsWorkspace, snapshotIds))
 
 
   // Link the snapshot pao to the workspace pao
-  private def createSnapshotV3(rawlsWorkspace: Workspace,
-                               snapshotId: UUID
+  private def createSnapshots(rawlsWorkspace: Workspace,
+                               snapshotIds: Set[UUID]
   ): Future[Unit] =
     for {
-      snapshotFromDataRepo <- Future {
-        getSnapshotFromDataRepoWithId(snapshotId)
+      snapshotsFromDataRepo <- Future {
+        snapshotIds.map(getSnapshotFromDataRepoWithId)
       }
-      workspacePao <- policyService.getPao(rawlsWorkspace.workspaceIdAsUUID, ctx)
-      snapshotPao <- policyService.getPao(snapshotFromDataRepo.getId, ctx)
+      workspacePaoOpt <- policyService.getPao(rawlsWorkspace.workspaceIdAsUUID, ctx)
+      workspacePao = workspacePaoOpt.getOrElse(throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.NotFound, s"Workspace PAO not found for workspace ${rawlsWorkspace.workspaceIdAsUUID}"))
+      )
 
-      _ = if (PolicyUtilities.containsProtectedDataPolicy(snapshotPao) && !PolicyUtilities.containsProtectedDataPolicy(workspacePao)) { // todo: this still needs to do the right thing if there is no workspace or snapshot pao
+      snapshotPaos <- Future.traverse(snapshotsFromDataRepo) { snapshot =>
+        policyService.getOrCreateSnapshotPao(snapshot.getId, ctx)
+      }
+
+      _ <- Future.traverse(snapshotsFromDataRepo) { snapshot =>
+        policyService.linkSnapshotPaoToWorkspacePao(snapshot.getId, rawlsWorkspace.workspaceIdAsUUID, dryRun = true, ctx)
+      }
+
+      // if any snapshots contain protected data, the workspace must be protected
+      _ = if (snapshotPaos.exists(PolicyUtilities.containsProtectedDataPolicy) && !PolicyUtilities.containsProtectedDataPolicy(workspacePao)) {
         throw new ProtectedDataException("Unable to add protected snapshot to unprotected workspace.")
       }
 
-      newWorkspaceGroups = PolicyUtilities.getGroupConstraintGroups(snapshotPao) -- PolicyUtilities.getGroupConstraintGroups(workspacePao)
+      // Region constraints can cause conflicts when combining PAOs. We check that no individual
+      // snapshot PAO will conflict with the workspace PAO above, but there's no easy way to check
+      // that all of the snapshot PAOs will combine together cleanly when they're all linked to
+      // the same workspace. Snapshots shouldn't have region constraint policies, but throw here
+      // just in case.
+      _ = if (snapshotPaos.exists(PolicyUtilities.containsRegionConstraintPolicy)) {
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, "Unable to add snapshot with region constraint to workspace.")
+        )
+      }
+
+      snapshotGroups = snapshotPaos.flatMap { snapshotPao =>
+        PolicyUtilities.getGroupConstraintGroups(snapshotPao)
+      }
+      newWorkspaceGroups = snapshotGroups -- PolicyUtilities.getGroupConstraintGroups(workspacePao)
       _ <- if (newWorkspaceGroups.nonEmpty) {
         workspaceServiceConstructor(ctx).addAuthDomainGroups(rawlsWorkspace.toWorkspaceName, newWorkspaceGroups, ctx)
       } else Future.unit
 
-      _ <- policyService.linkSnapshotPaoToWorkspacePao(snapshotFromDataRepo.getId, rawlsWorkspace.workspaceIdAsUUID, ctx)
+      _ <- Future.traverse(snapshotsFromDataRepo) { snapshot =>
+        policyService.linkSnapshotPaoToWorkspacePao(snapshot.getId, rawlsWorkspace.workspaceIdAsUUID, dryRun = false, ctx)
+      }
     } yield ()
 
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -39,7 +39,7 @@ import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 object SnapshotService {
-  def constructor(dataSource: SlickDataSource,
+  def constructor(workspaceRepository: WorkspaceRepository,
                   samDAO: SamDAO,
                   workspaceManagerDAO: WorkspaceManagerDAO,
                   terraDataRepoUrl: String,
@@ -49,7 +49,7 @@ object SnapshotService {
   )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): SnapshotService =
     new SnapshotService(
       ctx,
-      dataSource,
+      workspaceRepository,
       samDAO,
       workspaceManagerDAO,
       terraDataRepoUrl,
@@ -61,7 +61,7 @@ object SnapshotService {
 }
 
 class SnapshotService(protected val ctx: RawlsRequestContext,
-                      val dataSource: SlickDataSource,
+                      val workspaceRepository: WorkspaceRepository,
                       val samDAO: SamDAO,
                       workspaceManagerDAO: WorkspaceManagerDAO,
                       terraDataRepoInstanceName: String,
@@ -73,9 +73,6 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
     extends FutureSupport
     with WorkspaceSupport
     with LazyLogging {
-
-  // used by WorkspaceSupport - in future refactoring, this can be moved into the constructor for better mocking
-  val workspaceRepository: WorkspaceRepository = new WorkspaceRepository(dataSource)
 
   // Finds a workspace using the workspaceId then calls the createSnapshot method
   def createSnapshotByWorkspaceId(workspaceId: String,
@@ -212,6 +209,7 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
         policyService.getOrCreateSnapshotPao(snapshot.getId, ctx)
       }
 
+      // todo: this doesn't seem worth the time. we may not see any conflicts here
       _ <- Future.traverse(snapshotsFromDataRepo) { snapshot =>
         policyService.linkSnapshotPaoToWorkspacePao(snapshot.getId,
                                                     rawlsWorkspace.workspaceIdAsUUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -209,7 +209,6 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
         policyService.getOrCreateSnapshotPao(snapshot.getId, ctx)
       }
 
-      // todo: this doesn't seem worth the time. we may not see any conflicts here
       _ <- Future.traverse(snapshotsFromDataRepo) { snapshot =>
         policyService.linkSnapshotPaoToWorkspacePao(snapshot.getId,
                                                     rawlsWorkspace.workspaceIdAsUUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -7,18 +7,11 @@ import akka.http.scaladsl.server.Directives._
 import io.opentelemetry.context.Context
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
-import org.broadinstitute.dsde.rawls.model.{
-  NamedDataRepoSnapshot,
-  RawlsRequestContext,
-  UserInfo,
-  Workspace,
-  WorkspaceFieldSpecs,
-  WorkspaceName,
-  WorkspaceResponse
-}
+import org.broadinstitute.dsde.rawls.model.{NamedDataRepoSnapshot, RawlsRequestContext, UserInfo, Workspace, WorkspaceFieldSpecs, WorkspaceName, WorkspaceResponse}
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
 import org.broadinstitute.dsde.rawls.snapshot.SnapshotService
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
+import spray.json.DefaultJsonProtocol._
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext
@@ -32,6 +25,28 @@ trait SnapshotApiService extends UserInfoDirectives {
   def snapshotRoutes(otelContext: Context = Context.root()): server.Route =
     requireUserInfo(Option(otelContext)) { userInfo =>
       val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+      path("workspaces" / Segment / Segment / "snapshots" / "v3") { (workspaceNamespace, workspaceName) =>
+        post {
+          entity(as[Set[String]]) { snapshotIds =>
+            complete {
+              snapshotServiceConstructor(ctx)
+                .createSnapshotsByWorkspaceNameV3(WorkspaceName(workspaceNamespace, workspaceName), snapshotIds.map(UUID.fromString))
+                .map(_ => StatusCodes.NoContent)
+            }
+          }
+        }
+      } ~
+        path("workspaces" / Segment / "snapshots" / "v3") { (workspaceId) =>
+          post {
+            entity(as[Set[String]]) { snapshotIds =>
+              complete {
+                snapshotServiceConstructor(ctx)
+                  .createSnapshotsByWorkspaceIdV3(workspaceId, snapshotIds.map(UUID.fromString))
+                  .map(_ => StatusCodes.NoContent)
+              }
+            }
+          }
+        } ~
       path("workspaces" / Segment / Segment / "snapshots" / "v2") { (workspaceNamespace, workspaceName) =>
         post {
           entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>
@@ -125,53 +140,27 @@ trait SnapshotApiService extends UserInfoDirectives {
               }
             }
         } ~
-        path("workspaces" / Segment / Segment / "snapshots" / "v3" / Segment) { (workspaceNamespace, workspaceName, snapshotId) =>
+        path("workspaces" / Segment / Segment / "snapshots" / "v3") { (workspaceNamespace, workspaceName) =>
           post {
-            complete {
-              snapshotServiceConstructor(ctx)
-                .createSnapshotByWorkspaceNameV3(WorkspaceName(workspaceNamespace, workspaceName), UUID.fromString(snapshotId))
-                .map(_ => StatusCodes.NoContent)
-            }
-          } ~
-            get { // todo: convert to use paos to find snapshots
-              // N.B. the "as[UUID]" delegates to SnapshotService.validateSnapshotId, which is in scope;
-              // that method provides a 400 Bad Request response and nice error message
-              parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) {
-                (offset, limit, referencedSnapshotId) =>
-                  complete {
-                    snapshotServiceConstructor(ctx).enumerateSnapshotsByWorkspaceName(WorkspaceName(workspaceNamespace,
-                      workspaceName
-                    ),
-                      offset,
-                      limit,
-                      referencedSnapshotId
-                    )
-                  }
+            entity(as[Set[String]]) { snapshotIds =>
+              complete {
+                snapshotServiceConstructor(ctx)
+                  .createSnapshotsByWorkspaceNameV3(WorkspaceName(workspaceNamespace, workspaceName), snapshotIds.map(UUID.fromString))
+                  .map(_ => StatusCodes.NoContent)
               }
             }
+          }
         } ~
-        path("workspaces" / Segment / "snapshots" / "v3" / Segment) { (workspaceId, snapshotId) =>
+        path("workspaces" / Segment / "snapshots" / "v3") { (workspaceId) =>
           post {
-            complete {
-              snapshotServiceConstructor(ctx)
-                .createSnapshotByWorkspaceIdV3(workspaceId, UUID.fromString(snapshotId))
-                .map(_ => StatusCodes.NoContent)
-            }
-          } ~
-            get { // todo: convert to use paos to find snapshots
-              // N.B. the "as[UUID]" delegates to SnapshotService.validateSnapshotId, which is in scope;
-              // that method provides a 400 Bad Request response and nice error message
-              parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) {
-                (offset, limit, referencedSnapshotId) =>
-                  complete {
-                    snapshotServiceConstructor(ctx).enumerateSnapshotsById(workspaceId,
-                      offset,
-                      limit,
-                      referencedSnapshotId
-                    )
-                  }
+            entity(as[Set[String]]) { snapshotIds =>
+              complete {
+                snapshotServiceConstructor(ctx)
+                  .createSnapshotsByWorkspaceIdV3(workspaceId, snapshotIds.map(UUID.fromString))
+                  .map(_ => StatusCodes.NoContent)
               }
             }
+          }
         }
     }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -124,6 +124,54 @@ trait SnapshotApiService extends UserInfoDirectives {
                   }
               }
             }
+        } ~
+        path("workspaces" / Segment / Segment / "snapshots" / "v3" / Segment) { (workspaceNamespace, workspaceName, snapshotId) =>
+          post {
+            complete {
+              snapshotServiceConstructor(ctx)
+                .createSnapshotByWorkspaceNameV3(WorkspaceName(workspaceNamespace, workspaceName), UUID.fromString(snapshotId))
+                .map(_ => StatusCodes.NoContent)
+            }
+          } ~
+            get { // todo: convert to use paos to find snapshots
+              // N.B. the "as[UUID]" delegates to SnapshotService.validateSnapshotId, which is in scope;
+              // that method provides a 400 Bad Request response and nice error message
+              parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) {
+                (offset, limit, referencedSnapshotId) =>
+                  complete {
+                    snapshotServiceConstructor(ctx).enumerateSnapshotsByWorkspaceName(WorkspaceName(workspaceNamespace,
+                      workspaceName
+                    ),
+                      offset,
+                      limit,
+                      referencedSnapshotId
+                    )
+                  }
+              }
+            }
+        } ~
+        path("workspaces" / Segment / "snapshots" / "v3" / Segment) { (workspaceId, snapshotId) =>
+          post {
+            complete {
+              snapshotServiceConstructor(ctx)
+                .createSnapshotByWorkspaceIdV3(workspaceId, UUID.fromString(snapshotId))
+                .map(_ => StatusCodes.NoContent)
+            }
+          } ~
+            get { // todo: convert to use paos to find snapshots
+              // N.B. the "as[UUID]" delegates to SnapshotService.validateSnapshotId, which is in scope;
+              // that method provides a 400 Bad Request response and nice error message
+              parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) {
+                (offset, limit, referencedSnapshotId) =>
+                  complete {
+                    snapshotServiceConstructor(ctx).enumerateSnapshotsById(workspaceId,
+                      offset,
+                      limit,
+                      referencedSnapshotId
+                    )
+                  }
+              }
+            }
         }
     }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -7,7 +7,15 @@ import akka.http.scaladsl.server.Directives._
 import io.opentelemetry.context.Context
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
-import org.broadinstitute.dsde.rawls.model.{NamedDataRepoSnapshot, RawlsRequestContext, UserInfo, Workspace, WorkspaceFieldSpecs, WorkspaceName, WorkspaceResponse}
+import org.broadinstitute.dsde.rawls.model.{
+  NamedDataRepoSnapshot,
+  RawlsRequestContext,
+  UserInfo,
+  Workspace,
+  WorkspaceFieldSpecs,
+  WorkspaceName,
+  WorkspaceResponse
+}
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
 import org.broadinstitute.dsde.rawls.snapshot.SnapshotService
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
@@ -30,13 +38,15 @@ trait SnapshotApiService extends UserInfoDirectives {
           entity(as[Set[String]]) { snapshotIds =>
             complete {
               snapshotServiceConstructor(ctx)
-                .createSnapshotsByWorkspaceNameV3(WorkspaceName(workspaceNamespace, workspaceName), snapshotIds.map(UUID.fromString))
+                .createSnapshotsByWorkspaceNameV3(WorkspaceName(workspaceNamespace, workspaceName),
+                                                  snapshotIds.map(UUID.fromString)
+                )
                 .map(_ => StatusCodes.NoContent)
             }
           }
         }
       } ~
-        path("workspaces" / Segment / "snapshots" / "v3") { (workspaceId) =>
+        path("workspaces" / Segment / "snapshots" / "v3") { workspaceId =>
           post {
             entity(as[Set[String]]) { snapshotIds =>
               complete {
@@ -47,33 +57,35 @@ trait SnapshotApiService extends UserInfoDirectives {
             }
           }
         } ~
-      path("workspaces" / Segment / Segment / "snapshots" / "v2") { (workspaceNamespace, workspaceName) =>
-        post {
-          entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>
-            complete {
-              snapshotServiceConstructor(ctx)
-                .createSnapshotByWorkspaceName(WorkspaceName(workspaceNamespace, workspaceName), namedDataRepoSnapshot)
-                .map(StatusCodes.Created -> _)
-            }
-          }
-        } ~
-          get {
-            // N.B. the "as[UUID]" delegates to SnapshotService.validateSnapshotId, which is in scope;
-            // that method provides a 400 Bad Request response and nice error message
-            parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) {
-              (offset, limit, referencedSnapshotId) =>
-                complete {
-                  snapshotServiceConstructor(ctx).enumerateSnapshotsByWorkspaceName(WorkspaceName(workspaceNamespace,
-                                                                                                  workspaceName
-                                                                                    ),
-                                                                                    offset,
-                                                                                    limit,
-                                                                                    referencedSnapshotId
+        path("workspaces" / Segment / Segment / "snapshots" / "v2") { (workspaceNamespace, workspaceName) =>
+          post {
+            entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>
+              complete {
+                snapshotServiceConstructor(ctx)
+                  .createSnapshotByWorkspaceName(WorkspaceName(workspaceNamespace, workspaceName),
+                                                 namedDataRepoSnapshot
                   )
-                }
+                  .map(StatusCodes.Created -> _)
+              }
             }
-          }
-      } ~
+          } ~
+            get {
+              // N.B. the "as[UUID]" delegates to SnapshotService.validateSnapshotId, which is in scope;
+              // that method provides a 400 Bad Request response and nice error message
+              parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) {
+                (offset, limit, referencedSnapshotId) =>
+                  complete {
+                    snapshotServiceConstructor(ctx).enumerateSnapshotsByWorkspaceName(WorkspaceName(workspaceNamespace,
+                                                                                                    workspaceName
+                                                                                      ),
+                                                                                      offset,
+                                                                                      limit,
+                                                                                      referencedSnapshotId
+                    )
+                  }
+              }
+            }
+        } ~
         path("workspaces" / Segment / Segment / "snapshots" / "v2" / Segment) {
           (workspaceNamespace, workspaceName, snapshotId) =>
             get {
@@ -145,13 +157,15 @@ trait SnapshotApiService extends UserInfoDirectives {
             entity(as[Set[String]]) { snapshotIds =>
               complete {
                 snapshotServiceConstructor(ctx)
-                  .createSnapshotsByWorkspaceNameV3(WorkspaceName(workspaceNamespace, workspaceName), snapshotIds.map(UUID.fromString))
+                  .createSnapshotsByWorkspaceNameV3(WorkspaceName(workspaceNamespace, workspaceName),
+                                                    snapshotIds.map(UUID.fromString)
+                  )
                   .map(_ => StatusCodes.NoContent)
               }
             }
           }
         } ~
-        path("workspaces" / Segment / "snapshots" / "v3") { (workspaceId) =>
+        path("workspaces" / Segment / "snapshots" / "v3") { workspaceId =>
           post {
             entity(as[Set[String]]) { snapshotIds =>
               complete {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -151,30 +151,6 @@ trait SnapshotApiService extends UserInfoDirectives {
                   }
               }
             }
-        } ~
-        path("workspaces" / Segment / Segment / "snapshots" / "v3") { (workspaceNamespace, workspaceName) =>
-          post {
-            entity(as[Set[String]]) { snapshotIds =>
-              complete {
-                snapshotServiceConstructor(ctx)
-                  .createSnapshotsByWorkspaceNameV3(WorkspaceName(workspaceNamespace, workspaceName),
-                                                    snapshotIds.map(UUID.fromString)
-                  )
-                  .map(_ => StatusCodes.NoContent)
-              }
-            }
-          }
-        } ~
-        path("workspaces" / Segment / "snapshots" / "v3") { workspaceId =>
-          post {
-            entity(as[Set[String]]) { snapshotIds =>
-              complete {
-                snapshotServiceConstructor(ctx)
-                  .createSnapshotsByWorkspaceIdV3(workspaceId, snapshotIds.map(UUID.fromString))
-                  .map(_ => StatusCodes.NoContent)
-              }
-            }
-          }
         }
     }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/policy/PolicyServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/policy/PolicyServiceSpec.scala
@@ -4,19 +4,22 @@ import bio.terra.policy.client.ApiException
 import bio.terra.policy.model.{
   TpsComponent,
   TpsObjectType,
+  TpsPaoConflict,
   TpsPaoCreateRequest,
+  TpsPaoGetResult,
   TpsPaoSourceRequest,
+  TpsPaoUpdateResult,
   TpsPolicyInput,
   TpsPolicyInputs,
   TpsPolicyPair,
   TpsUpdateMode
 }
-import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecutionContext}
 import org.broadinstitute.dsde.rawls.dataaccess.tps.TpsDAO
 import org.broadinstitute.dsde.rawls.model.TpsModel.{TERRA_POLICY_NAMESPACE, TpsPolicies}
 import org.broadinstitute.dsde.rawls.model.{ManagedGroupRef, RawlsGroupName, RawlsRequestContext, WorkspaceRequest}
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
-import org.mockito.Mockito.{verify, when, RETURNS_SMART_NULLS}
+import org.mockito.Mockito.{never, verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatest.matchers.should.Matchers._
@@ -157,5 +160,175 @@ class PolicyServiceSpec extends AnyFlatSpec {
 
     noException should be thrownBy
       Await.result(policyService.deleteWorkspacePao(workspaceId, mock[RawlsRequestContext]), Duration.Inf)
+  }
+
+  behavior of "getPao"
+
+  it should "wrap the PAO TPS returns in an Option" in {
+    val workspaceId = UUID.randomUUID
+    val emptyPao = new TpsPaoGetResult()
+
+    val tpsDAO = mock[TpsDAO](RETURNS_SMART_NULLS)
+    when(tpsDAO.getPao(mockitoEq(workspaceId), any())).thenReturn(Future.successful(emptyPao))
+    val policyService = new PolicyService(tpsDAO)
+
+    val res = Await.result(policyService.getPao(workspaceId, mock[RawlsRequestContext]), Duration.Inf)
+    res shouldBe Option(emptyPao)
+  }
+
+  it should "return None if TPS returns a 404" in {
+    val workspaceId = UUID.randomUUID
+
+    val tpsDAO = mock[TpsDAO](RETURNS_SMART_NULLS)
+    when(tpsDAO.getPao(mockitoEq(workspaceId), any())).thenReturn(Future.failed(new ApiException(404, "pao not found")))
+    val policyService = new PolicyService(tpsDAO)
+
+    val res = Await.result(policyService.getPao(workspaceId, mock[RawlsRequestContext]), Duration.Inf)
+    res shouldBe None
+  }
+
+  it should "throw for other TPS exceptions" in {
+    val workspaceId = UUID.randomUUID
+
+    val tpsDAO = mock[TpsDAO](RETURNS_SMART_NULLS)
+    when(tpsDAO.getPao(mockitoEq(workspaceId), any())).thenReturn(Future.failed(new ApiException(500, "disaster")))
+    val policyService = new PolicyService(tpsDAO)
+
+    val exception = intercept[ApiException] {
+      Await.result(policyService.getPao(workspaceId, mock[RawlsRequestContext]), Duration.Inf)
+    }
+    exception.getCode shouldBe 500
+  }
+
+  behavior of "getOrCreateSnapshotPao"
+
+  it should "return existing PAOs" in {
+    val snapshotId = UUID.randomUUID
+    val emptyPao = new TpsPaoGetResult()
+
+    val tpsDAO = mock[TpsDAO](RETURNS_SMART_NULLS)
+    when(tpsDAO.getPao(mockitoEq(snapshotId), any())).thenReturn(Future.successful(emptyPao))
+    val policyService = new PolicyService(tpsDAO)
+
+    val res = Await.result(policyService.getOrCreateSnapshotPao(snapshotId, mock[RawlsRequestContext]), Duration.Inf)
+    res shouldBe emptyPao
+    verify(tpsDAO, never).createPao(any(), any())
+  }
+
+  it should "create an empty PAO if the snapshot doesn't have a PAO already" in {
+    val snapshotId = UUID.randomUUID
+    val emptyPao = new TpsPaoGetResult()
+
+    val expectedCreateRequest =
+      new TpsPaoCreateRequest().objectType(TpsObjectType.SNAPSHOT).component(TpsComponent.TDR).objectId(snapshotId)
+
+    val tpsDAO = mock[TpsDAO](RETURNS_SMART_NULLS)
+    when(tpsDAO.getPao(mockitoEq(snapshotId), any()))
+      .thenReturn(Future.failed(new ApiException(404, "pao not found")))
+      .thenReturn(Future.successful(emptyPao))
+    when(tpsDAO.createPao(mockitoEq(expectedCreateRequest), any())).thenReturn(Future.unit)
+    val policyService = new PolicyService(tpsDAO)
+
+    val res = Await.result(policyService.getOrCreateSnapshotPao(snapshotId, mock[RawlsRequestContext]), Duration.Inf)
+    res shouldBe emptyPao
+    verify(tpsDAO).createPao(mockitoEq(expectedCreateRequest), any())
+  }
+
+  behavior of "linkSnapshotPaoToWorkspacePao"
+
+  it should "support dry runs" in {
+    val snapshotId = UUID.randomUUID
+    val workspaceId = UUID.randomUUID
+
+    val expectedUpdateRequest = new TpsPaoSourceRequest().sourceObjectId(snapshotId).updateMode(TpsUpdateMode.DRY_RUN)
+    val tpsDAO = mock[TpsDAO](RETURNS_SMART_NULLS)
+    when(tpsDAO.linkPao(mockitoEq(expectedUpdateRequest), mockitoEq(workspaceId), any())).thenReturn(
+      Future.successful(
+        new TpsPaoUpdateResult()
+          .updateApplied(false)
+          .resultingPao(new TpsPaoGetResult())
+          .conflicts(List.empty[TpsPaoConflict].asJava)
+      )
+    )
+    val policyService = new PolicyService(tpsDAO)
+
+    Await.result(policyService.linkSnapshotPaoToWorkspacePao(snapshotId, workspaceId, true, mock[RawlsRequestContext]),
+                 Duration.Inf
+    )
+    verify(tpsDAO).linkPao(mockitoEq(expectedUpdateRequest), mockitoEq(workspaceId), any())
+  }
+
+  it should "link PAOs" in {
+    val snapshotId = UUID.randomUUID
+    val workspaceId = UUID.randomUUID
+
+    val expectedUpdateRequest =
+      new TpsPaoSourceRequest().sourceObjectId(snapshotId).updateMode(TpsUpdateMode.FAIL_ON_CONFLICT)
+    val tpsDAO = mock[TpsDAO](RETURNS_SMART_NULLS)
+    when(tpsDAO.linkPao(mockitoEq(expectedUpdateRequest), mockitoEq(workspaceId), any())).thenReturn(
+      Future.successful(
+        new TpsPaoUpdateResult()
+          .updateApplied(true)
+          .resultingPao(new TpsPaoGetResult())
+          .conflicts(List.empty[TpsPaoConflict].asJava)
+      )
+    )
+    val policyService = new PolicyService(tpsDAO)
+
+    Await.result(policyService.linkSnapshotPaoToWorkspacePao(snapshotId, workspaceId, false, mock[RawlsRequestContext]),
+                 Duration.Inf
+    )
+    verify(tpsDAO).linkPao(mockitoEq(expectedUpdateRequest), mockitoEq(workspaceId), any())
+  }
+
+  it should "throw if there are any conflicts during a dry run" in {
+    val snapshotId = UUID.randomUUID
+    val workspaceId = UUID.randomUUID
+
+    val expectedUpdateRequest = new TpsPaoSourceRequest().sourceObjectId(snapshotId).updateMode(TpsUpdateMode.DRY_RUN)
+    val tpsDAO = mock[TpsDAO](RETURNS_SMART_NULLS)
+    when(tpsDAO.linkPao(mockitoEq(expectedUpdateRequest), mockitoEq(workspaceId), any())).thenReturn(
+      Future.successful(
+        new TpsPaoUpdateResult()
+          .updateApplied(false)
+          .resultingPao(new TpsPaoGetResult())
+          .conflicts(List(new TpsPaoConflict()).asJava)
+      )
+    )
+    val policyService = new PolicyService(tpsDAO)
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        policyService.linkSnapshotPaoToWorkspacePao(snapshotId, workspaceId, true, mock[RawlsRequestContext]),
+        Duration.Inf
+      )
+    }
+    verify(tpsDAO).linkPao(mockitoEq(expectedUpdateRequest), mockitoEq(workspaceId), any())
+  }
+
+  it should "throw if there are any conflicts when linking" in {
+    val snapshotId = UUID.randomUUID
+    val workspaceId = UUID.randomUUID
+
+    val expectedUpdateRequest =
+      new TpsPaoSourceRequest().sourceObjectId(snapshotId).updateMode(TpsUpdateMode.FAIL_ON_CONFLICT)
+    val tpsDAO = mock[TpsDAO](RETURNS_SMART_NULLS)
+    when(tpsDAO.linkPao(mockitoEq(expectedUpdateRequest), mockitoEq(workspaceId), any())).thenReturn(
+      Future.successful(
+        new TpsPaoUpdateResult()
+          .updateApplied(true)
+          .resultingPao(new TpsPaoGetResult())
+          .conflicts(List(new TpsPaoConflict()).asJava)
+      )
+    )
+    val policyService = new PolicyService(tpsDAO)
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        policyService.linkSnapshotPaoToWorkspacePao(snapshotId, workspaceId, false, mock[RawlsRequestContext]),
+        Duration.Inf
+      )
+    }
+    verify(tpsDAO).linkPao(mockitoEq(expectedUpdateRequest), mockitoEq(workspaceId), any())
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -1435,6 +1435,46 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       )
     }
 
+    "create multiple snapshot references when called with a workspace id" in {
+      val workspace = minimalTestData.workspace
+      val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())
+
+      val mockWorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
+      when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.workspaceIdAsUUID), any()))
+        .thenReturn(Future.successful(Option(workspace)))
+
+      val emptyPao = new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())
+
+      val policyService = mock[PolicyService]
+      when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(emptyPao)))
+      when(policyService.getOrCreateSnapshotPao(any(), any())).thenReturn(Future.successful(emptyPao))
+      when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
+
+      val dataRepo = defaultDataRepoDao()
+      snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
+
+      val snapshotService = SnapshotService.constructor(
+        mockWorkspaceRepository,
+        defaultMockSamDao(),
+        defaultMockWorkspaceManagerDao(),
+        "fake-terra-data-repo-dev",
+        dataRepo,
+        defaultWorkspaceServiceConstructor,
+        policyService
+      )(testContext)
+
+      Await.result(snapshotService.createSnapshotsByWorkspaceIdV3(workspace.workspaceIdAsUUID.toString, snapshotIds),
+                   Duration.Inf
+      )
+      snapshotIds.map(id =>
+        verify(policyService).linkSnapshotPaoToWorkspacePao(mockitoEq(id),
+                                                            mockitoEq(workspace.workspaceIdAsUUID),
+                                                            mockitoEq(false),
+                                                            any()
+        )
+      )
+    }
+
     "fail to create multiple snapshot references if the workspace does not have a PAO" in {
       val workspace = minimalTestData.workspace
       val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -12,8 +12,7 @@ import bio.terra.datarepo.model.{
 import bio.terra.policy.model.{TpsPaoGetResult, TpsPolicyInput, TpsPolicyInputs, TpsPolicyPair}
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model._
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
-import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
@@ -28,11 +27,11 @@ import org.broadinstitute.dsde.rawls.model.{
   SamResourceTypeName,
   SamResourceTypeNames,
   SamUserStatusResponse,
-  Workspace,
   WorkspaceType
 }
 import org.broadinstitute.dsde.rawls.policy.PolicyService
 import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceService}
+import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito._

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -27,6 +27,7 @@ import org.broadinstitute.dsde.rawls.model.{
   SamResourceTypeName,
   SamResourceTypeNames,
   SamUserStatusResponse,
+  Workspace,
   WorkspaceType
 }
 import org.broadinstitute.dsde.rawls.policy.PolicyService
@@ -125,10 +126,28 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
     mockDataRepoDAO
   }
 
-  private def defaultWorkspaceServiceConstructor(ctx: RawlsRequestContext = testContext) =
+  private def defaultMockWorkspaceRepository(workspace: Workspace): WorkspaceRepository = {
+    val mockWorkspaceRepository = mock[WorkspaceRepository]
+    when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.workspaceIdAsUUID), any()))
+      .thenReturn(Future.successful(Option(workspace)))
+    when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.toWorkspaceName), any()))
+      .thenReturn(Future.successful(Option(workspace)))
+    mockWorkspaceRepository
+  }
+
+  private def defaultWorkspaceServiceConstructor(ctx: RawlsRequestContext = testContext): WorkspaceService =
     mock[WorkspaceService](RETURNS_SMART_NULLS)
 
-  private def defaultPolicyService: PolicyService = mock[PolicyService](RETURNS_SMART_NULLS)
+  private def defaultPolicyService: PolicyService = {
+    val emptyPao =
+      new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs()).sourcesObjectIds(List[UUID]().asJava)
+
+    val policyService = mock[PolicyService]
+    when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(emptyPao)))
+    when(policyService.getOrCreateSnapshotPao(any(), any())).thenReturn(Future.successful(emptyPao))
+    when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
+    policyService
+  }
 
   "SnapshotService" should {
     "create a new snapshot reference to a TDR snapshot" in withMinimalTestDatabase { _ =>
@@ -1398,22 +1417,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
       val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())
 
-      val mockWorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
-      when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.toWorkspaceName), any()))
-        .thenReturn(Future.successful(Option(workspace)))
-
-      val emptyPao = new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())
-
-      val policyService = mock[PolicyService]
-      when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(emptyPao)))
-      when(policyService.getOrCreateSnapshotPao(any(), any())).thenReturn(Future.successful(emptyPao))
-      when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
+      val policyService = defaultPolicyService
 
       val dataRepo = defaultDataRepoDao()
       snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
 
       val snapshotService = SnapshotService.constructor(
-        mockWorkspaceRepository,
+        defaultMockWorkspaceRepository(workspace),
         defaultMockSamDao(),
         defaultMockWorkspaceManagerDao(),
         "fake-terra-data-repo-dev",
@@ -1438,22 +1448,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
       val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())
 
-      val mockWorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
-      when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.workspaceIdAsUUID), any()))
-        .thenReturn(Future.successful(Option(workspace)))
-
-      val emptyPao = new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())
-
-      val policyService = mock[PolicyService]
-      when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(emptyPao)))
-      when(policyService.getOrCreateSnapshotPao(any(), any())).thenReturn(Future.successful(emptyPao))
-      when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
+      val policyService = defaultPolicyService
 
       val dataRepo = defaultDataRepoDao()
       snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
 
       val snapshotService = SnapshotService.constructor(
-        mockWorkspaceRepository,
+        defaultMockWorkspaceRepository(workspace),
         defaultMockSamDao(),
         defaultMockWorkspaceManagerDao(),
         "fake-terra-data-repo-dev",
@@ -1478,22 +1479,14 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
       val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())
 
-      val mockWorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
-      when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.toWorkspaceName), any()))
-        .thenReturn(Future.successful(Option(workspace)))
-
-      val emptyPao = new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())
-
-      val policyService = mock[PolicyService]
-      when(policyService.getPao(any(), any())).thenReturn(Future.successful(None))
-      when(policyService.getOrCreateSnapshotPao(any(), any())).thenReturn(Future.successful(emptyPao))
-      when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
+      val policyService = defaultPolicyService
+      when(policyService.getPao(mockitoEq(workspace.workspaceIdAsUUID), any())).thenReturn(Future.successful(None))
 
       val dataRepo = defaultDataRepoDao()
       snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
 
       val snapshotService = SnapshotService.constructor(
-        mockWorkspaceRepository,
+        defaultMockWorkspaceRepository(workspace),
         defaultMockSamDao(),
         defaultMockWorkspaceManagerDao(),
         "fake-terra-data-repo-dev",
@@ -1521,16 +1514,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
       val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())
 
-      val mockWorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
-      when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.toWorkspaceName), any()))
-        .thenReturn(Future.successful(Option(workspace)))
-
-      val emptyPao = new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())
-
-      val policyService = mock[PolicyService]
-      when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(emptyPao)))
-      when(policyService.getOrCreateSnapshotPao(any(), any())).thenReturn(Future.successful(emptyPao))
-      when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
+      val policyService = defaultPolicyService
 
       val dataRepo = defaultDataRepoDao()
       snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
@@ -1538,7 +1522,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         throw new client.ApiException(StatusCodes.NotFound.intValue, "not found")
       )
       val snapshotService = SnapshotService.constructor(
-        mockWorkspaceRepository,
+        defaultMockWorkspaceRepository(workspace),
         defaultMockSamDao(),
         defaultMockWorkspaceManagerDao(),
         "fake-terra-data-repo-dev",
@@ -1566,26 +1550,19 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
       val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())
 
-      val mockWorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
-      when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.toWorkspaceName), any()))
-        .thenReturn(Future.successful(Option(workspace)))
-
-      val emptyPao = new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())
       val protectedDataPao = new TpsPaoGetResult().effectiveAttributes(
         new TpsPolicyInputs().inputs(
           List(new TpsPolicyInput().namespace(TERRA_POLICY_NAMESPACE).name(TpsPolicies.ProtectedData.name)).asJava
         )
       )
 
-      val policyService = mock[PolicyService]
-      when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(emptyPao)))
+      val policyService = defaultPolicyService
       when(policyService.getOrCreateSnapshotPao(any(), any())).thenReturn(Future.successful(protectedDataPao))
-      when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
 
       val dataRepo = defaultDataRepoDao()
       snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
       val snapshotService = SnapshotService.constructor(
-        mockWorkspaceRepository,
+        defaultMockWorkspaceRepository(workspace),
         defaultMockSamDao(),
         defaultMockWorkspaceManagerDao(),
         "fake-terra-data-repo-dev",
@@ -1612,11 +1589,6 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
       val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())
 
-      val mockWorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
-      when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.toWorkspaceName), any()))
-        .thenReturn(Future.successful(Option(workspace)))
-
-      val emptyPao = new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())
       val snapshotPao1 = new TpsPaoGetResult().effectiveAttributes(
         new TpsPolicyInputs().inputs(
           List(
@@ -1642,12 +1614,10 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         )
       )
 
-      val policyService = mock[PolicyService]
-      when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(emptyPao)))
+      val policyService = defaultPolicyService
       when(policyService.getOrCreateSnapshotPao(any(), any()))
         .thenReturn(Future.successful(snapshotPao1))
         .thenReturn(Future.successful(snapshotPao2))
-      when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
 
       val dataRepo = defaultDataRepoDao()
       snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
@@ -1661,7 +1631,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       ).thenReturn(Future.unit)
 
       val snapshotService = SnapshotService.constructor(
-        mockWorkspaceRepository,
+        defaultMockWorkspaceRepository(workspace),
         defaultMockSamDao(),
         defaultMockWorkspaceManagerDao(),
         "fake-terra-data-repo-dev",
@@ -1683,6 +1653,47 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
                                                             mockitoEq(false),
                                                             any()
         )
+      )
+    }
+
+    "not try to link snapshots that are already linked to the workspace" in {
+      val workspace = minimalTestData.workspace
+      val newSnapshotId = UUID.randomUUID
+      val existingSnapshotId = UUID.randomUUID
+      val snapshotIds = Set(newSnapshotId, existingSnapshotId)
+
+      val workspacePao = new TpsPaoGetResult()
+        .effectiveAttributes(new TpsPolicyInputs())
+        .sourcesObjectIds(List(existingSnapshotId).asJava)
+
+      val policyService = defaultPolicyService
+      when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(workspacePao)))
+
+      val dataRepo = defaultDataRepoDao()
+      snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
+
+      val snapshotService = SnapshotService.constructor(
+        defaultMockWorkspaceRepository(workspace),
+        defaultMockSamDao(),
+        defaultMockWorkspaceManagerDao(),
+        "fake-terra-data-repo-dev",
+        dataRepo,
+        defaultWorkspaceServiceConstructor,
+        policyService
+      )(testContext)
+
+      Await.result(snapshotService.createSnapshotsByWorkspaceIdV3(workspace.workspaceIdAsUUID.toString, snapshotIds),
+                   Duration.Inf
+      )
+      verify(policyService).linkSnapshotPaoToWorkspacePao(mockitoEq(newSnapshotId),
+                                                          mockitoEq(workspace.workspaceIdAsUUID),
+                                                          mockitoEq(false),
+                                                          any()
+      )
+      verify(policyService, never).linkSnapshotPaoToWorkspacePao(mockitoEq(existingSnapshotId),
+                                                                 mockitoEq(workspace.workspaceIdAsUUID),
+                                                                 mockitoEq(false),
+                                                                 any()
       )
     }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -9,10 +9,11 @@ import bio.terra.datarepo.model.{
   SnapshotModel,
   SnapshotSourceModel
 }
+import bio.terra.policy.model.{TpsPaoGetResult, TpsPolicyInput, TpsPolicyInputs, TpsPolicyPair}
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
-import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
+import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
@@ -27,10 +28,13 @@ import org.broadinstitute.dsde.rawls.model.{
   SamResourceTypeName,
   SamResourceTypeNames,
   SamUserStatusResponse,
+  Workspace,
   WorkspaceType
 }
+import org.broadinstitute.dsde.rawls.policy.PolicyService
+import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceService}
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -122,6 +126,11 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
     mockDataRepoDAO
   }
 
+  private def defaultWorkspaceServiceConstructor(ctx: RawlsRequestContext = testContext) =
+    mock[WorkspaceService](RETURNS_SMART_NULLS)
+
+  private def defaultPolicyService: PolicyService = mock[PolicyService](RETURNS_SMART_NULLS)
+
   "SnapshotService" should {
     "create a new snapshot reference to a TDR snapshot" in withMinimalTestDatabase { _ =>
       val mockSamDAO = defaultMockSamDao()
@@ -130,11 +139,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
 
       val snapshotService = SnapshotService.constructor(
-        slickDataSource,
+        new WorkspaceRepository(slickDataSource),
         mockSamDAO,
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
-        mockDataRepoDAO
+        mockDataRepoDAO,
+        defaultWorkspaceServiceConstructor,
+        defaultPolicyService
       )(testContext)
 
       val snapshotUuid = UUID.randomUUID()
@@ -176,11 +187,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
 
       val snapshotService = SnapshotService.constructor(
-        slickDataSource,
+        new WorkspaceRepository(slickDataSource),
         mockSamDAO,
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
-        mockDataRepoDAO
+        mockDataRepoDAO,
+        defaultWorkspaceServiceConstructor,
+        defaultPolicyService
       )(testContext)
 
       val snapshotUuid = UUID.randomUUID()
@@ -214,11 +227,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
 
       val snapshotService = SnapshotService.constructor(
-        slickDataSource,
+        new WorkspaceRepository(slickDataSource),
         mockSamDAO,
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
-        mockDataRepoDAO
+        mockDataRepoDAO,
+        defaultWorkspaceServiceConstructor,
+        defaultPolicyService
       )(testContext)
 
       val snapshotUuid = UUID.randomUUID()
@@ -254,11 +269,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
 
       val snapshotService = SnapshotService.constructor(
-        slickDataSource,
+        new WorkspaceRepository(slickDataSource),
         mockSamDAO,
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
-        mockDataRepoDAO
+        mockDataRepoDAO,
+        defaultWorkspaceServiceConstructor,
+        defaultPolicyService
       )(testContext)
 
       // call createSnapshot on the service
@@ -299,11 +316,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         val workspace = minimalTestData.workspace
 
         val snapshotService = SnapshotService.constructor(
-          slickDataSource,
+          new WorkspaceRepository(slickDataSource),
           mockSamDAO,
           mockWorkspaceManagerDAO,
           "fake-terra-data-repo-dev",
-          mockDataRepoDAO
+          mockDataRepoDAO,
+          defaultWorkspaceServiceConstructor,
+          defaultPolicyService
         )(testContext)
 
         // call createSnapshot on the service
@@ -363,11 +382,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         val workspace = minimalTestData.workspace
 
         val snapshotService = SnapshotService.constructor(
-          slickDataSource,
+          new WorkspaceRepository(slickDataSource),
           mockSamDAO,
           mockWorkspaceManagerDAO,
           "fake-terra-data-repo-dev",
-          mockDataRepoDAO
+          mockDataRepoDAO,
+          defaultWorkspaceServiceConstructor,
+          defaultPolicyService
         )(testContext)
 
         // call createSnapshot on the service
@@ -424,11 +445,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         val workspace = minimalTestData.workspace
 
         val snapshotService = SnapshotService.constructor(
-          slickDataSource,
+          new WorkspaceRepository(slickDataSource),
           mockSamDAO,
           mockWorkspaceManagerDAO,
           "fake-terra-data-repo-dev",
-          mockDataRepoDAO
+          mockDataRepoDAO,
+          defaultWorkspaceServiceConstructor,
+          defaultPolicyService
         )(testContext)
 
         // call createSnapshot on the service
@@ -499,11 +522,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         val workspace = minimalTestData.workspace
 
         val snapshotService = SnapshotService.constructor(
-          slickDataSource,
+          new WorkspaceRepository(slickDataSource),
           mockSamDAO,
           mockWorkspaceManagerDAO,
           "fake-terra-data-repo-dev",
-          mockDataRepoDAO
+          mockDataRepoDAO,
+          defaultWorkspaceServiceConstructor,
+          defaultPolicyService
         )(testContext)
 
         // call createSnapshot on the service
@@ -605,11 +630,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
 
       val snapshotService = SnapshotService.constructor(
-        slickDataSource,
+        new WorkspaceRepository(slickDataSource),
         mockSamDAO,
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
-        mockDataRepoDAO
+        mockDataRepoDAO,
+        defaultWorkspaceServiceConstructor,
+        defaultPolicyService
       )(testContext)
 
       intercept[RawlsException] {
@@ -707,11 +734,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = protectedWorkspaceTestData.protectedWorkspace
 
       val snapshotService = SnapshotService.constructor(
-        slickDataSource,
+        new WorkspaceRepository(slickDataSource),
         mockSamDAO,
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
-        mockDataRepoDAO
+        mockDataRepoDAO,
+        defaultWorkspaceServiceConstructor,
+        defaultPolicyService
       )(testContext)
 
       Await.result(
@@ -756,11 +785,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         .thenReturn(azureSnapshot)
 
       val snapshotService = SnapshotService.constructor(
-        slickDataSource,
+        new WorkspaceRepository(slickDataSource),
         defaultMockSamDao(),
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
-        mockDataRepoDAO
+        mockDataRepoDAO,
+        defaultWorkspaceServiceConstructor,
+        defaultPolicyService
       )(testContext)
 
       val thrown = intercept[RawlsException] {
@@ -815,12 +846,14 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         .thenReturn(azureWorkspaceDescription)
 
       val snapshotService = SnapshotService.constructor(
-        slickDataSource,
+        new WorkspaceRepository(slickDataSource),
         defaultMockSamDao(),
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
         // snapshots are assumed to be GCP unless they belong to a Dataset with the Azure cloudPlatform
-        new MockDataRepoDAO("mockDataRepo")
+        new MockDataRepoDAO("mockDataRepo"),
+        defaultWorkspaceServiceConstructor,
+        defaultPolicyService
       )(testContext)
 
       val snapshotUuid = UUID.randomUUID()
@@ -872,12 +905,14 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         .thenReturn(azureWorkspaceDescription)
 
       val snapshotService = SnapshotService.constructor(
-        slickDataSource,
+        new WorkspaceRepository(slickDataSource),
         defaultMockSamDao(),
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
         // snapshots are assumed to be GCP unless they belong to a Dataset with the Azure cloudPlatform
-        new MockDataRepoDAO("mockDataRepo")
+        new MockDataRepoDAO("mockDataRepo"),
+        defaultWorkspaceServiceConstructor,
+        defaultPolicyService
       )(testContext)
 
       val snapshotUuid = UUID.randomUUID()
@@ -949,11 +984,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         .thenReturn(azureSnapshot)
 
       val snapshotService = SnapshotService.constructor(
-        slickDataSource,
+        new WorkspaceRepository(slickDataSource),
         defaultMockSamDao(),
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
-        mockDataRepoDAO
+        mockDataRepoDAO,
+        defaultWorkspaceServiceConstructor,
+        defaultPolicyService
       )(testContext)
       val thrown = intercept[UnsupportedPlatformException] {
         Await.result(
@@ -1021,11 +1058,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
 
       val snapshotService = SnapshotService.constructor(
-        slickDataSource,
+        new WorkspaceRepository(slickDataSource),
         mockSamDAO,
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
-        mockDataRepoDAO
+        mockDataRepoDAO,
+        defaultWorkspaceServiceConstructor,
+        defaultPolicyService
       )(testContext)
 
       val snapshotUUID = UUID.randomUUID()
@@ -1320,11 +1359,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val workspace = minimalTestData.workspace
 
       val snapshotService = SnapshotService.constructor(
-        slickDataSource,
+        new WorkspaceRepository(slickDataSource),
         mockSamDAO,
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
-        mockDataRepoDAO
+        mockDataRepoDAO,
+        defaultWorkspaceServiceConstructor,
+        defaultPolicyService
       )(testContext)
 
       val snapshotUuid = UUID.randomUUID()
@@ -1352,6 +1393,259 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       )
     }
 
+    def emptySnapshot(id: UUID) = new SnapshotModel().id(id)
+
+    "create multiple snapshot references" in {
+      val workspace = minimalTestData.workspace
+      val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())
+
+      val mockWorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
+      when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.toWorkspaceName), any()))
+        .thenReturn(Future.successful(Option(workspace)))
+
+      val emptyPao = new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())
+
+      val policyService = mock[PolicyService]
+      when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(emptyPao)))
+      when(policyService.getOrCreateSnapshotPao(any(), any())).thenReturn(Future.successful(emptyPao))
+      when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
+
+      val dataRepo = defaultDataRepoDao()
+      snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
+
+      val snapshotService = SnapshotService.constructor(
+        mockWorkspaceRepository,
+        defaultMockSamDao(),
+        defaultMockWorkspaceManagerDao(),
+        "fake-terra-data-repo-dev",
+        dataRepo,
+        defaultWorkspaceServiceConstructor,
+        policyService
+      )(testContext)
+
+      Await.result(snapshotService.createSnapshotsByWorkspaceNameV3(workspace.toWorkspaceName, snapshotIds),
+                   Duration.Inf
+      )
+      snapshotIds.map(id =>
+        verify(policyService).linkSnapshotPaoToWorkspacePao(mockitoEq(id),
+                                                            mockitoEq(workspace.workspaceIdAsUUID),
+                                                            mockitoEq(false),
+                                                            any()
+        )
+      )
+    }
+
+    "fail to create multiple snapshot references if the workspace does not have a PAO" in {
+      val workspace = minimalTestData.workspace
+      val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())
+
+      val mockWorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
+      when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.toWorkspaceName), any()))
+        .thenReturn(Future.successful(Option(workspace)))
+
+      val emptyPao = new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())
+
+      val policyService = mock[PolicyService]
+      when(policyService.getPao(any(), any())).thenReturn(Future.successful(None))
+      when(policyService.getOrCreateSnapshotPao(any(), any())).thenReturn(Future.successful(emptyPao))
+      when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
+
+      val dataRepo = defaultDataRepoDao()
+      snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
+
+      val snapshotService = SnapshotService.constructor(
+        mockWorkspaceRepository,
+        defaultMockSamDao(),
+        defaultMockWorkspaceManagerDao(),
+        "fake-terra-data-repo-dev",
+        dataRepo,
+        defaultWorkspaceServiceConstructor,
+        policyService
+      )(testContext)
+
+      val exception = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(snapshotService.createSnapshotsByWorkspaceNameV3(workspace.toWorkspaceName, snapshotIds),
+                     Duration.Inf
+        )
+      }
+      exception.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
+      snapshotIds.map(id =>
+        verify(policyService, never).linkSnapshotPaoToWorkspacePao(mockitoEq(id),
+                                                                   mockitoEq(workspace.workspaceIdAsUUID),
+                                                                   mockitoEq(false),
+                                                                   any()
+        )
+      )
+    }
+
+    "fail to create multiple snapshot references if the user does not have access to one of the snapshots" in {
+      val workspace = minimalTestData.workspace
+      val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())
+
+      val mockWorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
+      when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.toWorkspaceName), any()))
+        .thenReturn(Future.successful(Option(workspace)))
+
+      val emptyPao = new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())
+
+      val policyService = mock[PolicyService]
+      when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(emptyPao)))
+      when(policyService.getOrCreateSnapshotPao(any(), any())).thenReturn(Future.successful(emptyPao))
+      when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
+
+      val dataRepo = defaultDataRepoDao()
+      snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
+      when(dataRepo.getSnapshot(mockitoEq(snapshotIds.last), any())).thenAnswer(_ =>
+        throw new client.ApiException(StatusCodes.NotFound.intValue, "not found")
+      )
+      val snapshotService = SnapshotService.constructor(
+        mockWorkspaceRepository,
+        defaultMockSamDao(),
+        defaultMockWorkspaceManagerDao(),
+        "fake-terra-data-repo-dev",
+        dataRepo,
+        defaultWorkspaceServiceConstructor,
+        policyService
+      )(testContext)
+
+      val exception = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(snapshotService.createSnapshotsByWorkspaceNameV3(workspace.toWorkspaceName, snapshotIds),
+                     Duration.Inf
+        )
+      }
+      exception.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
+      snapshotIds.map(id =>
+        verify(policyService, never).linkSnapshotPaoToWorkspacePao(mockitoEq(id),
+                                                                   mockitoEq(workspace.workspaceIdAsUUID),
+                                                                   mockitoEq(false),
+                                                                   any()
+        )
+      )
+    }
+
+    "fail to create a reference if any snapshots have protected data policies and the workspace doesn't" in {
+      val workspace = minimalTestData.workspace
+      val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())
+
+      val mockWorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
+      when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.toWorkspaceName), any()))
+        .thenReturn(Future.successful(Option(workspace)))
+
+      val emptyPao = new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())
+      val protectedDataPao = new TpsPaoGetResult().effectiveAttributes(
+        new TpsPolicyInputs().inputs(
+          List(new TpsPolicyInput().namespace(TERRA_POLICY_NAMESPACE).name(TpsPolicies.ProtectedData.name)).asJava
+        )
+      )
+
+      val policyService = mock[PolicyService]
+      when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(emptyPao)))
+      when(policyService.getOrCreateSnapshotPao(any(), any())).thenReturn(Future.successful(protectedDataPao))
+      when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
+
+      val dataRepo = defaultDataRepoDao()
+      snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
+      val snapshotService = SnapshotService.constructor(
+        mockWorkspaceRepository,
+        defaultMockSamDao(),
+        defaultMockWorkspaceManagerDao(),
+        "fake-terra-data-repo-dev",
+        dataRepo,
+        defaultWorkspaceServiceConstructor,
+        policyService
+      )(testContext)
+
+      intercept[ProtectedDataException] {
+        Await.result(snapshotService.createSnapshotsByWorkspaceNameV3(workspace.toWorkspaceName, snapshotIds),
+                     Duration.Inf
+        )
+      }
+      snapshotIds.map(id =>
+        verify(policyService, never).linkSnapshotPaoToWorkspacePao(mockitoEq(id),
+                                                                   mockitoEq(workspace.workspaceIdAsUUID),
+                                                                   mockitoEq(false),
+                                                                   any()
+        )
+      )
+    }
+
+    "add new groups to the workspace's auth domain if any snapshots have an auth domain" in {
+      val workspace = minimalTestData.workspace
+      val snapshotIds = Set(UUID.randomUUID(), UUID.randomUUID())
+
+      val mockWorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
+      when(mockWorkspaceRepository.getWorkspace(mockitoEq(workspace.toWorkspaceName), any()))
+        .thenReturn(Future.successful(Option(workspace)))
+
+      val emptyPao = new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())
+      val snapshotPao1 = new TpsPaoGetResult().effectiveAttributes(
+        new TpsPolicyInputs().inputs(
+          List(
+            new TpsPolicyInput()
+              .namespace(TERRA_POLICY_NAMESPACE)
+              .name(TpsPolicies.GroupConstraint.name)
+              .additionalData(
+                List(new TpsPolicyPair().key(TpsPolicies.GroupConstraint.additionalDataKey).value("group1")).asJava
+              )
+          ).asJava
+        )
+      )
+      val snapshotPao2 = new TpsPaoGetResult().effectiveAttributes(
+        new TpsPolicyInputs().inputs(
+          List(
+            new TpsPolicyInput()
+              .namespace(TERRA_POLICY_NAMESPACE)
+              .name(TpsPolicies.GroupConstraint.name)
+              .additionalData(
+                List(new TpsPolicyPair().key(TpsPolicies.GroupConstraint.additionalDataKey).value("group2")).asJava
+              )
+          ).asJava
+        )
+      )
+
+      val policyService = mock[PolicyService]
+      when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(emptyPao)))
+      when(policyService.getOrCreateSnapshotPao(any(), any()))
+        .thenReturn(Future.successful(snapshotPao1))
+        .thenReturn(Future.successful(snapshotPao2))
+      when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
+
+      val dataRepo = defaultDataRepoDao()
+      snapshotIds.map(id => when(dataRepo.getSnapshot(mockitoEq(id), any())).thenReturn(emptySnapshot(id)))
+
+      val workspaceService = mock[WorkspaceService]
+      when(
+        workspaceService.addAuthDomainGroups(mockitoEq(workspace.toWorkspaceName),
+                                             mockitoEq(Set("group1", "group2")),
+                                             any()
+        )
+      ).thenReturn(Future.unit)
+
+      val snapshotService = SnapshotService.constructor(
+        mockWorkspaceRepository,
+        defaultMockSamDao(),
+        defaultMockWorkspaceManagerDao(),
+        "fake-terra-data-repo-dev",
+        dataRepo,
+        _ => workspaceService,
+        policyService
+      )(testContext)
+
+      Await.result(snapshotService.createSnapshotsByWorkspaceNameV3(workspace.toWorkspaceName, snapshotIds),
+                   Duration.Inf
+      )
+      verify(workspaceService).addAuthDomainGroups(mockitoEq(workspace.toWorkspaceName),
+                                                   mockitoEq(Set("group1", "group2")),
+                                                   any()
+      )
+      snapshotIds.map(id =>
+        verify(policyService).linkSnapshotPaoToWorkspacePao(mockitoEq(id),
+                                                            mockitoEq(workspace.workspaceIdAsUUID),
+                                                            mockitoEq(false),
+                                                            any()
+        )
+      )
+    }
   }
 
   def generateTestReferences(numReferences: Int): List[ResourceDescription] =
@@ -1417,11 +1711,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
     val mockDataRepoDAO = defaultDataRepoDao()
 
     SnapshotService.constructor(
-      slickDataSource,
+      new WorkspaceRepository(slickDataSource),
       mockSamDAO,
       mockWorkspaceManagerDAO,
       "fake-terra-data-repo-dev",
-      mockDataRepoDAO
+      mockDataRepoDAO,
+      defaultWorkspaceServiceConstructor,
+      defaultPolicyService
     )(testContext)
 
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.stream.ActorMaterializer
 import akka.testkit.{TestActors, TestKitBase}
-import bio.terra.policy.model.TpsPaoGetResult
+import bio.terra.policy.model.{TpsPaoGetResult, TpsPolicyInputs}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.typesafe.config.ConfigFactory
@@ -180,7 +180,11 @@ trait ApiServiceSpec
     val policyService = mock[PolicyService](RETURNS_SMART_NULLS)
     when(policyService.createWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
     when(policyService.mergeWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
-    when(policyService.getPao(any(), any())).thenReturn(Future.successful(Option(new TpsPaoGetResult())))
+    when(policyService.getPao(any(), any()))
+      .thenReturn(Future.successful(Option(new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs()))))
+    when(policyService.getOrCreateSnapshotPao(any(), any()))
+      .thenReturn(Future.successful(new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())))
+    when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
     when(policyService.deleteWorkspacePao(any(), any())).thenReturn(Future.unit)
 
     override val executionServiceCluster = MockShardedExecutionServiceCluster.fromDAO(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -253,11 +253,13 @@ trait ApiServiceSpec
     ) _
 
     override val snapshotServiceConstructor = SnapshotService.constructor(
-      slickDataSource,
+      new WorkspaceRepository(slickDataSource),
       samDAO,
       workspaceManagerDAO,
       mockServer.mockServerBaseUrl,
-      dataRepoDAO
+      dataRepoDAO,
+      _ => mock[WorkspaceService](RETURNS_SMART_NULLS),
+      policyService
     )
 
     override val genomicsServiceConstructor = GenomicsServiceImpl.constructor(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -83,6 +83,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.DurationConverters.JavaDurationOps
+import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 
 //noinspection TypeAnnotation
@@ -181,7 +182,11 @@ trait ApiServiceSpec
     when(policyService.createWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
     when(policyService.mergeWorkspacePao(any(), any(), any())).thenReturn(Future.unit)
     when(policyService.getPao(any(), any()))
-      .thenReturn(Future.successful(Option(new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs()))))
+      .thenReturn(
+        Future.successful(
+          Option(new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs()).sourcesObjectIds(List[UUID]().asJava))
+        )
+      )
     when(policyService.getOrCreateSnapshotPao(any(), any()))
       .thenReturn(Future.successful(new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())))
     when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.rawls.mock.{MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
+import spray.json.DefaultJsonProtocol.listFormat
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
@@ -19,6 +20,8 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
 
   val v2BaseSnapshotsPath = s"${testData.wsName.path}/snapshots/v2"
   val v2WorkspaceIdBaseSnapshotsPath = s"/workspaces/${testData.workspace.workspaceIdAsUUID}/snapshots/v2"
+  val v3BaseSnapshotsPath = s"${testData.wsName.path}/snapshots/v3"
+  val v3WorkspaceIdBaseSnapshotsPath = s"/workspaces/${testData.workspace.workspaceIdAsUUID}/snapshots/v3"
 
   val defaultNamedSnapshotJson = httpJson(
     NamedDataRepoSnapshot(
@@ -580,4 +583,23 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
         }
     }
 
+  it should "return 204 when creating multiple snapshots using workspaceName" in withTestDataApiServices { services =>
+    Post(v3BaseSnapshotsPath, List(UUID.randomUUID, UUID.randomUUID)) ~>
+      sealRoute(services.snapshotRoutes()) ~>
+      check {
+        assertResult(StatusCodes.NoContent) {
+          status
+        }
+      }
+  }
+
+  it should "return 204 when creating multiple snapshots using workspaceId" in withTestDataApiServices { services =>
+    Post(v3WorkspaceIdBaseSnapshotsPath, List(UUID.randomUUID, UUID.randomUUID)) ~>
+      sealRoute(services.snapshotRoutes()) ~>
+      check {
+        assertResult(StatusCodes.NoContent) {
+          status
+        }
+      }
+  }
 }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
@@ -246,5 +246,7 @@ object DataReferenceModelJsonSupport extends JsonSupport {
     ValueObjectFormat(DataReferenceDescriptionField)
   implicit val NamedDataRepoSnapshotFormat: RootJsonFormat[NamedDataRepoSnapshot] = jsonFormat5(NamedDataRepoSnapshot)
   implicit val SnapshotListResponseFormat: RootJsonFormat[SnapshotListResponse] = jsonFormat1(SnapshotListResponse)
-  implicit val SnapshotListResponseV3Format: RootJsonFormat[SnapshotListResponseV3] = jsonFormat1(SnapshotListResponseV3)
+  implicit val SnapshotListResponseV3Format: RootJsonFormat[SnapshotListResponseV3] = jsonFormat1(
+    SnapshotListResponseV3
+  )
 }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
@@ -17,6 +17,7 @@ case class NamedDataRepoSnapshot(name: DataReferenceName,
                                  properties: Option[Map[String, String]] = None
 )
 case class SnapshotListResponse(gcpDataRepoSnapshots: Seq[DataRepoSnapshotResource])
+case class SnapshotListResponseV3(snapshotIds: List[UUID])
 
 object DataReferenceModelJsonSupport extends JsonSupport {
   def stringOrNull(in: Any): JsValue = Option(in) match {
@@ -245,4 +246,5 @@ object DataReferenceModelJsonSupport extends JsonSupport {
     ValueObjectFormat(DataReferenceDescriptionField)
   implicit val NamedDataRepoSnapshotFormat: RootJsonFormat[NamedDataRepoSnapshot] = jsonFormat5(NamedDataRepoSnapshot)
   implicit val SnapshotListResponseFormat: RootJsonFormat[SnapshotListResponse] = jsonFormat1(SnapshotListResponse)
+  implicit val SnapshotListResponseV3Format: RootJsonFormat[SnapshotListResponseV3] = jsonFormat1(SnapshotListResponseV3)
 }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
@@ -17,7 +17,6 @@ case class NamedDataRepoSnapshot(name: DataReferenceName,
                                  properties: Option[Map[String, String]] = None
 )
 case class SnapshotListResponse(gcpDataRepoSnapshots: Seq[DataRepoSnapshotResource])
-case class SnapshotListResponseV3(snapshotIds: List[UUID])
 
 object DataReferenceModelJsonSupport extends JsonSupport {
   def stringOrNull(in: Any): JsValue = Option(in) match {
@@ -246,7 +245,4 @@ object DataReferenceModelJsonSupport extends JsonSupport {
     ValueObjectFormat(DataReferenceDescriptionField)
   implicit val NamedDataRepoSnapshotFormat: RootJsonFormat[NamedDataRepoSnapshot] = jsonFormat5(NamedDataRepoSnapshot)
   implicit val SnapshotListResponseFormat: RootJsonFormat[SnapshotListResponse] = jsonFormat1(SnapshotListResponse)
-  implicit val SnapshotListResponseV3Format: RootJsonFormat[SnapshotListResponseV3] = jsonFormat1(
-    SnapshotListResponseV3
-  )
 }


### PR DESCRIPTION
Ticket: [CORE-440](https://broadworkbench.atlassian.net/browse/CORE-440)
* Remove WSM involvement in snapshot import
* Deprecate v2 snapshot API
* Add v3 snapshot API with new createSnapshots API which links provided snapshot PAOs to workspace PAO

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[CORE-440]: https://broadworkbench.atlassian.net/browse/CORE-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ