### PR TITLE
CORE-427: batchUpsert/batchUpdate stream their inputs

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
@@ -16,8 +16,7 @@ import java.time.temporal.ChronoUnit
 import java.util.UUID
 import scala.concurrent.{blocking, ExecutionContext, Future}
 
-class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec: ExecutionContext)
-    extends TpsDAO {
+class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec: ExecutionContext) extends TpsDAO {
   protected def getApiClient(ctx: RawlsRequestContext): ApiClient = {
     val client: ApiClient = new ApiClient()
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.workspace.model.CloudPlatform
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
@@ -111,12 +112,16 @@ object EntityManager {
                            cacheEnabled: Boolean,
                            queryTimeout: Duration,
                            metricsPrefix: String
-  )(implicit ec: ExecutionContext): EntityManager = {
+  )(implicit ec: ExecutionContext, system: ActorSystem): EntityManager = {
     // create the EntityManager along with its associated provider-builders. Since entities are only accessed
     // in the context of a workspace, this is safe/correct to do here. We also want to use the same dataSource
     // and execution context for the rawls entity provider that the entity service uses.
     val defaultEntityProviderBuilder =
-      new LocalEntityProviderBuilder(dataSource, cacheEnabled, queryTimeout, metricsPrefix) // implicit executionContext
+      new LocalEntityProviderBuilder(dataSource,
+                                     cacheEnabled,
+                                     queryTimeout,
+                                     metricsPrefix
+      ) // implicit executionContext, system
     val dataRepoEntityProviderBuilder = new DataRepoEntityProviderBuilder(workspaceManagerDAO,
                                                                           dataRepoDAO,
                                                                           samDAO,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -444,7 +444,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
     }
 
   def batchUpdateEntitiesInternal(workspaceName: WorkspaceName,
-                                  inputStream: Source[ByteString, _],
+                                  entityUpdateStream: Source[EntityUpdateDefinition, _],
                                   upsert: Boolean,
                                   dataReference: Option[DataReferenceName],
                                   billingProject: Option[GoogleProjectId],
@@ -462,16 +462,6 @@ class EntityService(protected val ctx: RawlsRequestContext,
             EntityRequestArguments(workspaceContext, s, dataReference, billingProject)
           )
         }
-        // parse the input Source[ByteString ...] into Source[EntityUpdateDefinition ...]
-        entityUpdateStream = inputStream.map(_.utf8String).map { jsonStr =>
-          Try(jsonStr.parseJson.convertTo[EntityUpdateDefinition]) match {
-            case Success(obj) => obj
-            case Failure(ex) =>
-              throw new RawlsExceptionWithErrorReport(
-                ErrorReport(s"Invalid JSON in entity update definitions: ${ex.getMessage}")
-              )
-          }
-        }
 
         entities <-
           if (upsert) {
@@ -487,24 +477,24 @@ class EntityService(protected val ctx: RawlsRequestContext,
     }
 
   def batchUpdateEntities(workspaceName: WorkspaceName,
-                          inputStream: Source[ByteString, _],
+                          entityUpdateStream: Source[EntityUpdateDefinition, _],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
     traceFutureWithParent("EntityService.batchUpdateEntities", ctx) { s =>
-      batchUpdateEntitiesInternal(workspaceName, inputStream, upsert = false, dataReference, billingProject, s)
+      batchUpdateEntitiesInternal(workspaceName, entityUpdateStream, upsert = false, dataReference, billingProject, s)
         .recover(
           sqlLoggingRecover(s"batchUpdateEntities: $workspaceName")
         )
     }
 
   def batchUpsertEntities(workspaceName: WorkspaceName,
-                          inputStream: Source[ByteString, _],
+                          entityUpdateStream: Source[EntityUpdateDefinition, _],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
     traceFutureWithParent("EntityService.batchUpsertEntities", ctx) { s =>
-      batchUpdateEntitiesInternal(workspaceName, inputStream, upsert = true, dataReference, billingProject, s)
+      batchUpdateEntitiesInternal(workspaceName, entityUpdateStream, upsert = true, dataReference, billingProject, s)
         .recover(
           sqlLoggingRecover(s"batchUpsertEntities: $workspaceName")
         )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -459,7 +459,6 @@ class EntityService(protected val ctx: RawlsRequestContext,
             EntityRequestArguments(workspaceContext, s, dataReference, billingProject)
           )
         }
-
         entities <-
           if (upsert) {
             traceFutureWithParent("EntityProvider.batchUpsertEntities", parentContext) { s =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -4,7 +4,6 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.stream.scaladsl.{Sink, Source}
-import akka.util.ByteString
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.cloud.bigquery.BigQueryException
 import com.typesafe.scalalogging.LazyLogging
@@ -25,11 +24,9 @@ import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, Json
 import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceSettingService}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValidationUtils}
 import slick.dbio.DBIO
-import spray.json._
 
 import java.sql.SQLException
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
 
 object EntityService {
   def constructor(dataSource: SlickDataSource,
@@ -444,7 +441,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
     }
 
   def batchUpdateEntitiesInternal(workspaceName: WorkspaceName,
-                                  entityUpdateStream: Source[EntityUpdateDefinition, _],
+                                  entityUpdates: Source[EntityUpdateDefinition, _],
                                   upsert: Boolean,
                                   dataReference: Option[DataReferenceName],
                                   billingProject: Option[GoogleProjectId],
@@ -466,35 +463,35 @@ class EntityService(protected val ctx: RawlsRequestContext,
         entities <-
           if (upsert) {
             traceFutureWithParent("EntityProvider.batchUpsertEntities", parentContext) { s =>
-              entityProvider.batchUpsertEntities(entityUpdateStream, s)
+              entityProvider.batchUpsertEntities(entityUpdates, s)
             }
           } else {
             traceFutureWithParent("EntityProvider.batchUpdateEntities", parentContext) { s =>
-              entityProvider.batchUpdateEntities(entityUpdateStream, s)
+              entityProvider.batchUpdateEntities(entityUpdates, s)
             }
           }
       } yield entities
     }
 
   def batchUpdateEntities(workspaceName: WorkspaceName,
-                          entityUpdateStream: Source[EntityUpdateDefinition, _],
+                          entityUpdates: Source[EntityUpdateDefinition, _],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
     traceFutureWithParent("EntityService.batchUpdateEntities", ctx) { s =>
-      batchUpdateEntitiesInternal(workspaceName, entityUpdateStream, upsert = false, dataReference, billingProject, s)
+      batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = false, dataReference, billingProject, s)
         .recover(
           sqlLoggingRecover(s"batchUpdateEntities: $workspaceName")
         )
     }
 
   def batchUpsertEntities(workspaceName: WorkspaceName,
-                          entityUpdateStream: Source[EntityUpdateDefinition, _],
+                          entityUpdates: Source[EntityUpdateDefinition, _],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
     traceFutureWithParent("EntityService.batchUpsertEntities", ctx) { s =>
-      batchUpdateEntitiesInternal(workspaceName, entityUpdateStream, upsert = true, dataReference, billingProject, s)
+      batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject, s)
         .recover(
           sqlLoggingRecover(s"batchUpsertEntities: $workspaceName")
         )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.entities
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.cloud.bigquery.BigQueryException
@@ -24,10 +24,10 @@ import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceSettingService}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValidationUtils}
+import slick.dbio.DBIO
 import spray.json._
 
 import java.sql.SQLException
-import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -1,8 +1,10 @@
 package org.broadinstitute.dsde.rawls.entities
 
 import akka.NotUsed
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.stream.scaladsl.Source
+import akka.util.ByteString
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.cloud.bigquery.BigQueryException
 import com.typesafe.scalalogging.LazyLogging
@@ -20,9 +22,11 @@ import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValidationUtils}
+import spray.json._
 
 import java.sql.SQLException
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
 object EntityService {
   def constructor(dataSource: SlickDataSource,
@@ -30,7 +34,7 @@ object EntityService {
                   workbenchMetricBaseName: String,
                   entityManager: EntityManager,
                   pageSizeLimit: Int
-  )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): EntityService =
+  )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext, system: ActorSystem): EntityService =
     new EntityService(ctx, dataSource, samDAO, entityManager, workbenchMetricBaseName, pageSizeLimit)
 }
 
@@ -40,7 +44,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                     entityManager: EntityManager,
                     override val workbenchMetricBaseName: String,
                     pageSizeLimit: Int
-)(implicit protected val executionContext: ExecutionContext)
+)(implicit protected val executionContext: ExecutionContext, system: ActorSystem)
     extends WorkspaceSupport
     with EntitySupport
     with AttributeSupport
@@ -426,7 +430,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
     }
 
   def batchUpdateEntitiesInternal(workspaceName: WorkspaceName,
-                                  entityUpdates: Seq[EntityUpdateDefinition],
+                                  inputStream: Source[ByteString, _],
                                   upsert: Boolean,
                                   dataReference: Option[DataReferenceName],
                                   billingProject: Option[GoogleProjectId],
@@ -444,40 +448,51 @@ class EntityService(protected val ctx: RawlsRequestContext,
             EntityRequestArguments(workspaceContext, s, dataReference, billingProject)
           )
         }
+        // parse the input Source[ByteString ...] into Source[EntityUpdateDefinition ...]
+        entityUpdateStream = inputStream.map(_.utf8String).map { jsonStr =>
+          Try(jsonStr.parseJson.convertTo[EntityUpdateDefinition]) match {
+            case Success(obj) => obj
+            case Failure(ex) =>
+              throw new RawlsExceptionWithErrorReport(
+                ErrorReport(s"Invalid JSON in entity update definitions: ${ex.getMessage}")
+              )
+          }
+        }
+
         entities <-
           if (upsert) {
             traceFutureWithParent("EntityProvider.batchUpsertEntities", parentContext) { s =>
-              entityProvider.batchUpsertEntities(entityUpdates, s)
+              entityProvider.batchUpsertEntities(entityUpdateStream, s)
             }
           } else {
             traceFutureWithParent("EntityProvider.batchUpdateEntities", parentContext) { s =>
-              entityProvider.batchUpdateEntities(entityUpdates, s)
+              entityProvider.batchUpdateEntities(entityUpdateStream, s)
             }
           }
       } yield entities
     }
 
   def batchUpdateEntities(workspaceName: WorkspaceName,
-                          entityUpdates: Seq[EntityUpdateDefinition],
+                          inputStream: Source[ByteString, _],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
     traceFutureWithParent("EntityService.batchUpdateEntities", ctx) { s =>
-      batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = false, dataReference, billingProject, s)
+      batchUpdateEntitiesInternal(workspaceName, inputStream, upsert = false, dataReference, billingProject, s)
         .recover(
-          sqlLoggingRecover(s"batchUpdateEntities: $workspaceName ${entityUpdates.size} updates")
+          sqlLoggingRecover(s"batchUpdateEntities: $workspaceName")
         )
     }
 
   def batchUpsertEntities(workspaceName: WorkspaceName,
-                          entityUpdates: Seq[EntityUpdateDefinition],
+                          inputStream: Source[ByteString, _],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
     traceFutureWithParent("EntityService.batchUpsertEntities", ctx) { s =>
-      batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject, s)
+      batchUpdateEntitiesInternal(workspaceName, inputStream, upsert = true, dataReference, billingProject, s)
         .recover(
-          sqlLoggingRecover(s"batchUpsertEntities: $workspaceName ${entityUpdates.size} upserts")
+          sqlLoggingRecover(s"batchUpsertEntities: $workspaceName")
         )
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -446,7 +446,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                   dataReference: Option[DataReferenceName],
                                   billingProject: Option[GoogleProjectId],
                                   parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     traceFutureWithParent("getV2WorkspaceContextAndPermissions", parentContext) { _ =>
       getV2WorkspaceContextAndPermissions(workspaceName,
                                           SamWorkspaceActions.write,
@@ -476,7 +476,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           entityUpdates: Source[EntityUpdateDefinition, _],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     traceFutureWithParent("EntityService.batchUpdateEntities", ctx) { s =>
       batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = false, dataReference, billingProject, s)
         .recover(
@@ -488,7 +488,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           entityUpdates: Source[EntityUpdateDefinition, _],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     traceFutureWithParent("EntityService.batchUpsertEntities", ctx) { s =>
       batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject, s)
         .recover(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -34,11 +34,11 @@ trait EntityProvider {
 
   // ----- implementation methods follow:
 
-  def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition],
+  def batchUpdateEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                           parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]]
 
-  def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition],
+  def batchUpsertEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                           parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]]
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -36,11 +36,11 @@ trait EntityProvider {
 
   def batchUpdateEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                           parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]]
+  ): Future[Source[Entity, _]]
 
   def batchUpsertEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                           parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]]
+  ): Future[Source[Entity, _]]
 
   def copyEntities(sourceWorkspaceContext: Workspace,
                    destWorkspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -61,12 +61,12 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments, repository
   override def batchUpdateEntities(
     entityUpdates: Source[EntityUpdateDefinition, _],
     parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] = ???
+  ): Future[Source[Entity, _]] = ???
 
   override def batchUpsertEntities(
     entityUpdates: Source[EntityUpdateDefinition, _],
     parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] = ???
+  ): Future[Source[Entity, _]] = ???
 
   override def copyEntities(sourceWorkspaceContext: Workspace,
                             destWorkspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dsde.rawls.entities.exceptions.{
 }
 import org.broadinstitute.dsde.rawls.entities.{EntityRequestArguments, EntityUtils}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
 import org.broadinstitute.dsde.rawls.model.{
   Attributable,
   AttributeEntityReference,
@@ -58,12 +59,12 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments, repository
   val workspaceId: UUID = requestArguments.workspace.workspaceIdAsUUID // shorthand for methods below
 
   override def batchUpdateEntities(
-    entityUpdates: Seq[AttributeUpdateOperations.EntityUpdateDefinition],
+    entityUpdates: Source[EntityUpdateDefinition, _],
     parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] = ???
 
   override def batchUpsertEntities(
-    entityUpdates: Seq[AttributeUpdateOperations.EntityUpdateDefinition],
+    entityUpdates: Source[EntityUpdateDefinition, _],
     parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] = ???
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -558,12 +558,12 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   override def expressionValidator: ExpressionValidator = new DataRepoEntityExpressionValidator(snapshotModel)
 
-  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition],
+  override def batchUpdateEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] =
     throw new UnsupportedEntityOperationException("batch-update entities not supported by this provider.")
 
-  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition],
+  override def batchUpsertEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] =
     throw new UnsupportedEntityOperationException("batch-upsert entities not supported by this provider.")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -560,12 +560,12 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   override def batchUpdateEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     throw new UnsupportedEntityOperationException("batch-update entities not supported by this provider.")
 
   override def batchUpsertEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     throw new UnsupportedEntityOperationException("batch-upsert entities not supported by this provider.")
 
   override def copyEntities(sourceWorkspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -90,6 +90,9 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
 
   final private val queryTimeoutSeconds: Int = queryTimeout.getSeconds.toInt
 
+  // TODO CORE-427: don't create a brand new ActorSystem; see if we can get the one from Boot.scala
+  implicit private val actorSystem: ActorSystem = ActorSystem("LocalEntityProvider")
+
   override def entityTypeMetadata(useCache: Boolean,
                                   parentContext: RawlsRequestContext
   ): Future[Map[String, EntityTypeMetadata]] =
@@ -523,102 +526,105 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
       }
     }
 
-  private def batchUpdateEntitiesImpl(entityUpdates: Seq[EntityUpdateDefinition],
-                                      upsert: Boolean,
-                                      parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] = {
-    val namesToCheck = for {
-      update <- entityUpdates
-      operation <- update.operations
-    } yield operation.name
+  private def batchUpdateEntitiesImpl(
+    updateStream: Source[EntityUpdateDefinition, _],
+    upsert: Boolean,
+    parentContext: RawlsRequestContext
+  ): Future[Traversable[Entity]] =
+    // immediately materialize the updateStream for backwards compatibility
+    updateStream.runWith(Sink.seq).flatMap { entityUpdates =>
+      val namesToCheck = for {
+        update <- entityUpdates
+        operation <- update.operations
+      } yield operation.name
 
-    traceFutureWithParent("LocalEntityProvider.batchUpdateEntitiesImpl", parentContext) { localContext =>
-      setTraceSpanAttribute(localContext, AttributeKey.stringKey("workspaceId"), workspaceContext.workspaceId)
-      setTraceSpanAttribute(localContext, AttributeKey.booleanKey("upsert"), java.lang.Boolean.valueOf(upsert))
-      setTraceSpanAttribute(localContext,
-                            AttributeKey.longKey("entityUpdatesCount"),
-                            java.lang.Long.valueOf(entityUpdates.length)
-      )
-      setTraceSpanAttribute(localContext,
-                            AttributeKey.longKey("entityOperationsCount"),
-                            java.lang.Long.valueOf(entityUpdates.map(_.operations.length).sum)
-      )
+      traceFutureWithParent("LocalEntityProvider.batchUpdateEntitiesImpl", parentContext) { localContext =>
+        setTraceSpanAttribute(localContext, AttributeKey.stringKey("workspaceId"), workspaceContext.workspaceId)
+        setTraceSpanAttribute(localContext, AttributeKey.booleanKey("upsert"), java.lang.Boolean.valueOf(upsert))
+        setTraceSpanAttribute(localContext,
+                              AttributeKey.longKey("entityUpdatesCount"),
+                              java.lang.Long.valueOf(entityUpdates.length)
+        )
+        setTraceSpanAttribute(localContext,
+                              AttributeKey.longKey("entityOperationsCount"),
+                              java.lang.Long.valueOf(entityUpdates.map(_.operations.length).sum)
+        )
 
-      withAttributeNamespaceCheck(namesToCheck) {
-        dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
-          val updateTrialsAction = traceDBIOWithParent("getActiveEntities", localContext)(_ =>
-            dataAccess.entityQuery.getActiveEntities(
-              workspaceContext,
-              entityUpdates.map(eu => AttributeEntityReference(eu.entityType, eu.name))
-            )
-          ) map { entities =>
-            val entitiesByName = entities.map(e => (e.entityType, e.name) -> e).toMap
-            entityUpdates.map { entityUpdate =>
-              entityUpdate -> (entitiesByName.get((entityUpdate.entityType, entityUpdate.name)) match {
-                case Some(e) =>
-                  Try(applyOperationsToEntity(e, entityUpdate.operations))
-                case None =>
-                  if (upsert) {
-                    Try(
-                      applyOperationsToEntity(Entity(entityUpdate.name, entityUpdate.entityType, Map.empty),
-                                              entityUpdate.operations
-                      )
-                    )
-                  } else {
-                    Failure(new RuntimeException("Entity does not exist"))
-                  }
-              })
-            }
-          }
-
-          val saveAction = updateTrialsAction flatMap { updateTrials =>
-            val errorReports = updateTrials.collect { case (entityUpdate, Failure(regrets)) =>
-              ErrorReport(s"Could not update ${entityUpdate.entityType} ${entityUpdate.name}", ErrorReport(regrets))
-            }
-            if (errorReports.nonEmpty) {
-              DBIO.failed(
-                new RawlsExceptionWithErrorReport(
-                  ErrorReport(StatusCodes.BadRequest, "Some entities could not be updated.", errorReports)
-                )
+        withAttributeNamespaceCheck(namesToCheck) {
+          dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
+            val updateTrialsAction = traceDBIOWithParent("getActiveEntities", localContext)(_ =>
+              dataAccess.entityQuery.getActiveEntities(
+                workspaceContext,
+                entityUpdates.map(eu => AttributeEntityReference(eu.entityType, eu.name))
               )
-            } else {
-              val t = updateTrials.collect { case (entityUpdate, Success(entity)) => entity }
-
-              traceDBIOWithParent("saveAction", localContext) { subContext =>
-                dataAccess.entityQuery
-                  .save(workspaceContext, t, subContext.toTracingContext)
-                  .withStatementParameters(statementInit = _.setQueryTimeout(queryTimeoutSeconds))
+            ) map { entities =>
+              val entitiesByName = entities.map(e => (e.entityType, e.name) -> e).toMap
+              entityUpdates.map { entityUpdate =>
+                entityUpdate -> (entitiesByName.get((entityUpdate.entityType, entityUpdate.name)) match {
+                  case Some(e) =>
+                    Try(applyOperationsToEntity(e, entityUpdate.operations))
+                  case None =>
+                    if (upsert) {
+                      Try(
+                        applyOperationsToEntity(Entity(entityUpdate.name, entityUpdate.entityType, Map.empty),
+                                                entityUpdate.operations
+                        )
+                      )
+                    } else {
+                      Failure(new RuntimeException("Entity does not exist"))
+                    }
+                })
               }
             }
-          }
 
-          saveAction
-        } recover {
-          case icve: java.sql.SQLIntegrityConstraintViolationException =>
-            val userMessage =
-              s"Database error occurred. Check if you are uploading entity names that differ only in case " +
-                s"from pre-existing entities."
-            throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, icve))
-          case bue: java.sql.BatchUpdateException =>
-            val maybeCaseIssue = bue.getMessage.startsWith("Duplicate entry")
-            val userMessage = if (maybeCaseIssue) {
-              s"Database error occurred. Check if you are uploading entity names that differ only in case " +
-                s"from pre-existing entities."
-            } else {
-              s"Database error occurred. Underlying error message: ${bue.getMessage}"
+            val saveAction = updateTrialsAction flatMap { updateTrials =>
+              val errorReports = updateTrials.collect { case (entityUpdate, Failure(regrets)) =>
+                ErrorReport(s"Could not update ${entityUpdate.entityType} ${entityUpdate.name}", ErrorReport(regrets))
+              }
+              if (errorReports.nonEmpty) {
+                DBIO.failed(
+                  new RawlsExceptionWithErrorReport(
+                    ErrorReport(StatusCodes.BadRequest, "Some entities could not be updated.", errorReports)
+                  )
+                )
+              } else {
+                val t = updateTrials.collect { case (entityUpdate, Success(entity)) => entity }
+
+                traceDBIOWithParent("saveAction", localContext) { subContext =>
+                  dataAccess.entityQuery
+                    .save(workspaceContext, t, subContext.toTracingContext)
+                    .withStatementParameters(statementInit = _.setQueryTimeout(queryTimeoutSeconds))
+                }
+              }
             }
-            throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, bue))
+
+            saveAction
+          } recover {
+            case icve: java.sql.SQLIntegrityConstraintViolationException =>
+              val userMessage =
+                s"Database error occurred. Check if you are uploading entity names that differ only in case " +
+                  s"from pre-existing entities."
+              throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, icve))
+            case bue: java.sql.BatchUpdateException =>
+              val maybeCaseIssue = bue.getMessage.startsWith("Duplicate entry")
+              val userMessage = if (maybeCaseIssue) {
+                s"Database error occurred. Check if you are uploading entity names that differ only in case " +
+                  s"from pre-existing entities."
+              } else {
+                s"Database error occurred. Underlying error message: ${bue.getMessage}"
+              }
+              throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, bue))
+          }
         }
       }
     }
-  }
 
-  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition],
+  override def batchUpdateEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] =
     batchUpdateEntitiesImpl(entityUpdates, upsert = false, parentContext)
 
-  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition],
+  override def batchUpsertEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] =
     batchUpdateEntitiesImpl(entityUpdates, upsert = true, parentContext)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -528,7 +528,7 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     upsert: Boolean,
     parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] =
-    // immediately materialize the updateStream for backwards compatibility
+    // immediately materialize the updateStream so existing code can work with a Seq
     updateStream.runWith(Sink.seq).flatMap { entityUpdates =>
       val namesToCheck = for {
         update <- entityUpdates

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -74,7 +74,7 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
                           cacheEnabled: Boolean,
                           queryTimeout: Duration,
                           override val workbenchMetricBaseName: String
-)(implicit protected val executionContext: ExecutionContext)
+)(implicit protected val executionContext: ExecutionContext, actorSystem: ActorSystem)
     extends EntityProvider
     with LazyLogging
     with EntitySupport
@@ -89,9 +89,6 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
   override val workspaceContext = requestArguments.workspace
 
   final private val queryTimeoutSeconds: Int = queryTimeout.getSeconds.toInt
-
-  // TODO CORE-427: don't create a brand new ActorSystem; see if we can get the one from Boot.scala
-  implicit private val actorSystem: ActorSystem = ActorSystem("LocalEntityProvider")
 
   override def entityTypeMetadata(useCache: Boolean,
                                   parentContext: RawlsRequestContext

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -527,103 +527,106 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     updateStream: Source[EntityUpdateDefinition, _],
     upsert: Boolean,
     parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     // immediately materialize the updateStream so existing code can work with a Seq
-    updateStream.runWith(Sink.seq).flatMap { entityUpdates =>
-      val namesToCheck = for {
-        update <- entityUpdates
-        operation <- update.operations
-      } yield operation.name
+    updateStream
+      .runWith(Sink.seq)
+      .flatMap { entityUpdates =>
+        val namesToCheck = for {
+          update <- entityUpdates
+          operation <- update.operations
+        } yield operation.name
 
-      traceFutureWithParent("LocalEntityProvider.batchUpdateEntitiesImpl", parentContext) { localContext =>
-        setTraceSpanAttribute(localContext, AttributeKey.stringKey("workspaceId"), workspaceContext.workspaceId)
-        setTraceSpanAttribute(localContext, AttributeKey.booleanKey("upsert"), java.lang.Boolean.valueOf(upsert))
-        setTraceSpanAttribute(localContext,
-                              AttributeKey.longKey("entityUpdatesCount"),
-                              java.lang.Long.valueOf(entityUpdates.length)
-        )
-        setTraceSpanAttribute(localContext,
-                              AttributeKey.longKey("entityOperationsCount"),
-                              java.lang.Long.valueOf(entityUpdates.map(_.operations.length).sum)
-        )
+        traceFutureWithParent("LocalEntityProvider.batchUpdateEntitiesImpl", parentContext) { localContext =>
+          setTraceSpanAttribute(localContext, AttributeKey.stringKey("workspaceId"), workspaceContext.workspaceId)
+          setTraceSpanAttribute(localContext, AttributeKey.booleanKey("upsert"), java.lang.Boolean.valueOf(upsert))
+          setTraceSpanAttribute(localContext,
+                                AttributeKey.longKey("entityUpdatesCount"),
+                                java.lang.Long.valueOf(entityUpdates.length)
+          )
+          setTraceSpanAttribute(localContext,
+                                AttributeKey.longKey("entityOperationsCount"),
+                                java.lang.Long.valueOf(entityUpdates.map(_.operations.length).sum)
+          )
 
-        withAttributeNamespaceCheck(namesToCheck) {
-          dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
-            val updateTrialsAction = traceDBIOWithParent("getActiveEntities", localContext)(_ =>
-              dataAccess.entityQuery.getActiveEntities(
-                workspaceContext,
-                entityUpdates.map(eu => AttributeEntityReference(eu.entityType, eu.name))
-              )
-            ) map { entities =>
-              val entitiesByName = entities.map(e => (e.entityType, e.name) -> e).toMap
-              entityUpdates.map { entityUpdate =>
-                entityUpdate -> (entitiesByName.get((entityUpdate.entityType, entityUpdate.name)) match {
-                  case Some(e) =>
-                    Try(applyOperationsToEntity(e, entityUpdate.operations))
-                  case None =>
-                    if (upsert) {
-                      Try(
-                        applyOperationsToEntity(Entity(entityUpdate.name, entityUpdate.entityType, Map.empty),
-                                                entityUpdate.operations
-                        )
-                      )
-                    } else {
-                      Failure(new RuntimeException("Entity does not exist"))
-                    }
-                })
-              }
-            }
-
-            val saveAction = updateTrialsAction flatMap { updateTrials =>
-              val errorReports = updateTrials.collect { case (entityUpdate, Failure(regrets)) =>
-                ErrorReport(s"Could not update ${entityUpdate.entityType} ${entityUpdate.name}", ErrorReport(regrets))
-              }
-              if (errorReports.nonEmpty) {
-                DBIO.failed(
-                  new RawlsExceptionWithErrorReport(
-                    ErrorReport(StatusCodes.BadRequest, "Some entities could not be updated.", errorReports)
-                  )
+          withAttributeNamespaceCheck(namesToCheck) {
+            dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
+              val updateTrialsAction = traceDBIOWithParent("getActiveEntities", localContext)(_ =>
+                dataAccess.entityQuery.getActiveEntities(
+                  workspaceContext,
+                  entityUpdates.map(eu => AttributeEntityReference(eu.entityType, eu.name))
                 )
-              } else {
-                val t = updateTrials.collect { case (entityUpdate, Success(entity)) => entity }
-
-                traceDBIOWithParent("saveAction", localContext) { subContext =>
-                  dataAccess.entityQuery
-                    .save(workspaceContext, t, subContext.toTracingContext)
-                    .withStatementParameters(statementInit = _.setQueryTimeout(queryTimeoutSeconds))
+              ) map { entities =>
+                val entitiesByName = entities.map(e => (e.entityType, e.name) -> e).toMap
+                entityUpdates.map { entityUpdate =>
+                  entityUpdate -> (entitiesByName.get((entityUpdate.entityType, entityUpdate.name)) match {
+                    case Some(e) =>
+                      Try(applyOperationsToEntity(e, entityUpdate.operations))
+                    case None =>
+                      if (upsert) {
+                        Try(
+                          applyOperationsToEntity(Entity(entityUpdate.name, entityUpdate.entityType, Map.empty),
+                                                  entityUpdate.operations
+                          )
+                        )
+                      } else {
+                        Failure(new RuntimeException("Entity does not exist"))
+                      }
+                  })
                 }
               }
-            }
 
-            saveAction
-          } recover {
-            case icve: java.sql.SQLIntegrityConstraintViolationException =>
-              val userMessage =
-                s"Database error occurred. Check if you are uploading entity names that differ only in case " +
-                  s"from pre-existing entities."
-              throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, icve))
-            case bue: java.sql.BatchUpdateException =>
-              val maybeCaseIssue = bue.getMessage.startsWith("Duplicate entry")
-              val userMessage = if (maybeCaseIssue) {
-                s"Database error occurred. Check if you are uploading entity names that differ only in case " +
-                  s"from pre-existing entities."
-              } else {
-                s"Database error occurred. Underlying error message: ${bue.getMessage}"
+              val saveAction = updateTrialsAction flatMap { updateTrials =>
+                val errorReports = updateTrials.collect { case (entityUpdate, Failure(regrets)) =>
+                  ErrorReport(s"Could not update ${entityUpdate.entityType} ${entityUpdate.name}", ErrorReport(regrets))
+                }
+                if (errorReports.nonEmpty) {
+                  DBIO.failed(
+                    new RawlsExceptionWithErrorReport(
+                      ErrorReport(StatusCodes.BadRequest, "Some entities could not be updated.", errorReports)
+                    )
+                  )
+                } else {
+                  val t = updateTrials.collect { case (entityUpdate, Success(entity)) => entity }
+
+                  traceDBIOWithParent("saveAction", localContext) { subContext =>
+                    dataAccess.entityQuery
+                      .save(workspaceContext, t, subContext.toTracingContext)
+                      .withStatementParameters(statementInit = _.setQueryTimeout(queryTimeoutSeconds))
+                  }
+                }
               }
-              throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, bue))
+
+              saveAction
+            } recover {
+              case icve: java.sql.SQLIntegrityConstraintViolationException =>
+                val userMessage =
+                  s"Database error occurred. Check if you are uploading entity names that differ only in case " +
+                    s"from pre-existing entities."
+                throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, icve))
+              case bue: java.sql.BatchUpdateException =>
+                val maybeCaseIssue = bue.getMessage.startsWith("Duplicate entry")
+                val userMessage = if (maybeCaseIssue) {
+                  s"Database error occurred. Check if you are uploading entity names that differ only in case " +
+                    s"from pre-existing entities."
+                } else {
+                  s"Database error occurred. Underlying error message: ${bue.getMessage}"
+                }
+                throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, bue))
+            }
           }
         }
       }
-    }
+      .map(writeResults => Source(writeResults.toSeq))
 
   override def batchUpdateEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     batchUpdateEntitiesImpl(entityUpdates, upsert = false, parentContext)
 
   override def batchUpsertEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     batchUpdateEntitiesImpl(entityUpdates, upsert = true, parentContext)
 
   override def copyEntities(sourceWorkspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderBuilder.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.local
 
+import akka.actor.ActorSystem
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.base.EntityProviderBuilder
@@ -17,7 +18,8 @@ class LocalEntityProviderBuilder(dataSource: SlickDataSource,
                                  queryTimeout: Duration,
                                  metricsPrefix: String
 )(implicit
-  protected val executionContext: ExecutionContext
+  protected val executionContext: ExecutionContext,
+  system: ActorSystem
 ) extends EntityProviderBuilder[LocalEntityProvider] {
 
   override def builds: TypeTag[LocalEntityProvider] = typeTag[LocalEntityProvider]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -4,6 +4,8 @@ import akka.actor.SupervisorStrategy.{Escalate, Stop}
 import akka.actor._
 import akka.http.scaladsl.model.StatusCodes
 import akka.pattern._
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.typesafe.scalalogging.LazyLogging
@@ -410,7 +412,7 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
 
       // Start reading the file. This returns a stream
       logger.info(s"checking access to $upsertFile for jobId ${jobId.toString} ...")
-      val upsertStream = getUpsertStream(upsertFile)
+      val upsertStream: fs2.Stream[IO, Byte] = getUpsertStream(upsertFile)
 
       // Ensure that the file has some contents. Our implementation of GoogleStorageInterpreter will return an empty
       // stream instead of an error in cases where it could not read the file. We check to see if there is at least
@@ -446,12 +448,17 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
       // convenience method to encapsulate the call to EntityService's batchUpdateEntitiesInternal
       def performUpsertBatch(idx: Long, upsertBatch: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] = {
         logger.info(s"upserting batch #$idx of ${upsertBatch.size} entities for jobId ${jobId.toString} ...")
+
+        // translate the upsertBatch back into a stream of json.
+        // TODO CORE-427: rewrite this monitor to fully stream, instead of stream->materialize->stream
+        val inputStream: Source[ByteString, _] = Source.single(ByteString(upsertBatch.toJson.prettyPrint))
+
         for {
           petUserInfo <- getPetServiceAccountUserInfo(workspace.googleProjectId, userEmail)
           requestContext = RawlsRequestContext(petUserInfo)
           upsertResults <- entityService(requestContext).batchUpdateEntitiesInternal(
             workspace.toWorkspaceName,
-            upsertBatch,
+            inputStream,
             upsert = isUpsert,
             None,
             None,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -451,14 +451,14 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
 
         // translate the upsertBatch back into a stream of json.
         // TODO CORE-427: rewrite this monitor to fully stream, instead of stream->materialize->stream
-        val inputStream: Source[ByteString, _] = Source.single(ByteString(upsertBatch.toJson.prettyPrint))
+        val entityUpdateStream: Source[EntityUpdateDefinition, _] = Source(upsertBatch)
 
         for {
           petUserInfo <- getPetServiceAccountUserInfo(workspace.googleProjectId, userEmail)
           requestContext = RawlsRequestContext(petUserInfo)
           upsertResults <- entityService(requestContext).batchUpdateEntitiesInternal(
             workspace.toWorkspaceName,
-            inputStream,
+            entityUpdateStream,
             upsert = isUpsert,
             None,
             None,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -4,7 +4,7 @@ import akka.actor.SupervisorStrategy.{Escalate, Stop}
 import akka.actor._
 import akka.http.scaladsl.model.StatusCodes
 import akka.pattern._
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -456,7 +456,7 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
         for {
           petUserInfo <- getPetServiceAccountUserInfo(workspace.googleProjectId, userEmail)
           requestContext = RawlsRequestContext(petUserInfo)
-          upsertResults <- entityService(requestContext).batchUpdateEntitiesInternal(
+          upsertResultsSource <- entityService(requestContext).batchUpdateEntitiesInternal(
             workspace.toWorkspaceName,
             entityUpdateStream,
             upsert = isUpsert,
@@ -464,7 +464,8 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
             None,
             requestContext
           )
-        } yield upsertResults
+          upsertResults <- upsertResultsSource.runWith(Sink.seq)
+        } yield upsertResults.toTraversable
       }
 
       // create our pause signal. We use this to control when the stream should pause and resume.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -38,7 +38,7 @@ trait EntityApiService extends UserInfoDirectives {
   val entityServiceConstructor: RawlsRequestContext => EntityService
   val batchUpsertMaxBytes: Long
 
-  implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json()
+  implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json(batchUpsertMaxBytes.toInt)
 
   def entityRoutes(otelContext: Context = Context.root()): server.Route = {
     requireUserInfo(Option(otelContext)) { userInfo =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.webservice
 
 import akka.http.scaladsl.common.{EntityStreamingSupport, JsonEntityStreamingSupport}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
+import akka.http.scaladsl.model.{ContentTypes, EntityStreamSizeException, HttpEntity, StatusCodes}
 import akka.http.scaladsl.model.StatusCodes.BadRequest
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
@@ -205,6 +205,9 @@ trait EntityApiService extends UserInfoDirectives {
                                            billingProject
                       )
                       .map(_ => StatusCodes.NoContent)
+                      .recover { case _: EntityStreamSizeException =>
+                        StatusCodes.PayloadTooLarge
+                      }
                   }
                 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.model.StatusCodes.BadRequest
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
+import akka.stream.alpakka.json.scaladsl.JsonReader
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import io.opentelemetry.context.Context
@@ -193,27 +194,35 @@ trait EntityApiService extends UserInfoDirectives {
           path("workspaces" / Segment / Segment / "entities" / "batchUpsert") { (workspaceNamespace, workspaceName) =>
             post {
               withSizeLimit(batchUpsertMaxBytes) {
-                entity(as[Array[EntityUpdateDefinition]]) { operations =>
+                //
+                extractRequestEntity { requestEntity =>
+                  val inputStream: Source[ByteString, _] =
+                    requestEntity.dataBytes.via(JsonReader.select("$.[]")) // entity updates are in a top-level array
+
                   complete {
                     entityServiceConstructor(ctx)
                       .batchUpsertEntities(WorkspaceName(workspaceNamespace, workspaceName),
-                                           operations,
+                                           inputStream,
                                            dataReference,
                                            billingProject
                       )
                       .map(_ => StatusCodes.NoContent)
                   }
                 }
+
               }
             }
           } ~
           path("workspaces" / Segment / Segment / "entities" / "batchUpdate") { (workspaceNamespace, workspaceName) =>
             post {
-              entity(as[Array[EntityUpdateDefinition]]) { operations =>
+              extractRequestEntity { requestEntity =>
+                val inputStream: Source[ByteString, _] =
+                  requestEntity.dataBytes.via(JsonReader.select("$.[]")) // entity updates are in a top-level array
+
                 complete {
                   entityServiceConstructor(ctx)
                     .batchUpdateEntities(WorkspaceName(workspaceNamespace, workspaceName),
-                                         operations,
+                                         inputStream,
                                          dataReference,
                                          billingProject
                     )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -38,6 +38,8 @@ trait EntityApiService extends UserInfoDirectives {
   val entityServiceConstructor: RawlsRequestContext => EntityService
   val batchUpsertMaxBytes: Long
 
+  // the Int.MaxValue defines the size allowed by JsonEntityStreamingSupport. We set this to the max allowable,
+  // then have more fine-grained size validation using withSizeLimit specifically for the batchUpsert API
   implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json(Int.MaxValue)
 
   def entityRoutes(otelContext: Context = Context.root()): server.Route = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -38,7 +38,7 @@ trait EntityApiService extends UserInfoDirectives {
   val entityServiceConstructor: RawlsRequestContext => EntityService
   val batchUpsertMaxBytes: Long
 
-  implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json(batchUpsertMaxBytes.toInt)
+  implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json(Int.MaxValue)
 
   def entityRoutes(otelContext: Context = Context.root()): server.Route = {
     requireUserInfo(Option(otelContext)) { userInfo =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -196,12 +196,11 @@ trait EntityApiService extends UserInfoDirectives {
           path("workspaces" / Segment / Segment / "entities" / "batchUpsert") { (workspaceNamespace, workspaceName) =>
             post {
               withSizeLimit(batchUpsertMaxBytes) {
-                //
-                entity(asSourceOf[EntityUpdateDefinition]) { entityUpdateStream =>
+                entity(asSourceOf[EntityUpdateDefinition]) { operations =>
                   complete {
                     entityServiceConstructor(ctx)
                       .batchUpsertEntities(WorkspaceName(workspaceNamespace, workspaceName),
-                                           entityUpdateStream,
+                                           operations,
                                            dataReference,
                                            billingProject
                       )
@@ -214,11 +213,11 @@ trait EntityApiService extends UserInfoDirectives {
           } ~
           path("workspaces" / Segment / Segment / "entities" / "batchUpdate") { (workspaceNamespace, workspaceName) =>
             post {
-              entity(asSourceOf[EntityUpdateDefinition]) { entityUpdateStream =>
+              entity(asSourceOf[EntityUpdateDefinition]) { operations =>
                 complete {
                   entityServiceConstructor(ctx)
                     .batchUpdateEntities(WorkspaceName(workspaceNamespace, workspaceName),
-                                         entityUpdateStream,
+                                         operations,
                                          dataReference,
                                          billingProject
                     )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -6,7 +6,6 @@ import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.model.StatusCodes.BadRequest
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
-import akka.stream.alpakka.json.scaladsl.JsonReader
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import io.opentelemetry.context.Context
@@ -23,6 +22,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model.{AttributeName, _}
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
 import org.broadinstitute.dsde.rawls.webservice.CustomDirectives._
+import spray.json._
 import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.ExecutionContext
@@ -37,6 +37,8 @@ trait EntityApiService extends UserInfoDirectives {
 
   val entityServiceConstructor: RawlsRequestContext => EntityService
   val batchUpsertMaxBytes: Long
+
+  implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json()
 
   def entityRoutes(otelContext: Context = Context.root()): server.Route = {
     requireUserInfo(Option(otelContext)) { userInfo =>
@@ -195,14 +197,11 @@ trait EntityApiService extends UserInfoDirectives {
             post {
               withSizeLimit(batchUpsertMaxBytes) {
                 //
-                extractRequestEntity { requestEntity =>
-                  val inputStream: Source[ByteString, _] =
-                    requestEntity.dataBytes.via(JsonReader.select("$.[]")) // entity updates are in a top-level array
-
+                entity(asSourceOf[EntityUpdateDefinition]) { entityUpdateStream =>
                   complete {
                     entityServiceConstructor(ctx)
                       .batchUpsertEntities(WorkspaceName(workspaceNamespace, workspaceName),
-                                           inputStream,
+                                           entityUpdateStream,
                                            dataReference,
                                            billingProject
                       )
@@ -215,14 +214,11 @@ trait EntityApiService extends UserInfoDirectives {
           } ~
           path("workspaces" / Segment / Segment / "entities" / "batchUpdate") { (workspaceNamespace, workspaceName) =>
             post {
-              extractRequestEntity { requestEntity =>
-                val inputStream: Source[ByteString, _] =
-                  requestEntity.dataBytes.via(JsonReader.select("$.[]")) // entity updates are in a top-level array
-
+              entity(asSourceOf[EntityUpdateDefinition]) { entityUpdateStream =>
                 complete {
                   entityServiceConstructor(ctx)
                     .batchUpdateEntities(WorkspaceName(workspaceNamespace, workspaceName),
-                                         inputStream,
+                                         entityUpdateStream,
                                          dataReference,
                                          billingProject
                     )
@@ -283,10 +279,6 @@ trait EntityApiService extends UserInfoDirectives {
           path("workspaces" / Segment / Segment / "entities" / Segment) {
             (workspaceNamespace, workspaceName, entityType) =>
               get {
-                // if any other APIs adopt streaming, move this implicit val higher up in the EntityApiService trait
-                implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json()
-                import spray.json._
-
                 // listEntities returns a source of Entity. We will stream-output each successful entity to the user,
                 // and if an exception occurs midstream we want to output the exception (wrapped in an ErrorReport)
                 // as the final element. Akka and Spray have a hard time with the mixed element types in the stream,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityManagerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityManagerSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
@@ -31,6 +32,7 @@ import scala.concurrent.{Await, Future}
 class EntityManagerSpec extends AnyFlatSpec with MockitoTestUtils with Matchers {
 
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+  implicit private val system: ActorSystem = ActorSystem("EntityManagerSpec")
 
   val defaultRequestContext: RawlsRequestContext =
     RawlsRequestContext(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityShardingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityShardingSpec.scala
@@ -66,6 +66,8 @@ class EntityShardingSpec
 
     override val batchUpsertMaxBytes = testConf.getLong("entityUpsert.maxContentSizeBytes")
 
+    implicit private val system: ActorSystem = ActorSystem("EntityShardingSpec")
+
     val entityServiceConstructor = EntityService.constructor(
       slickDataSource,
       samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.rawls.entities.local
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.util.ByteString
 import breeze.linalg._
 import breeze.stats._
 import com.typesafe.config.ConfigFactory

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.entities.local
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.util.ByteString
 import breeze.linalg._
 import breeze.stats._
 import com.typesafe.config.ConfigFactory
@@ -148,6 +149,7 @@ class BatchUpsertScalingSpec
 
       // parse into EntityUpdateDefinition. This is our initial load file, as if the user had an empty workspace
       // and uploaded a TSV to create a new data table.
+      val initialUpsertByteSource = akka.stream.scaladsl.Source.single(ByteString(batchUpsertFile))
       val initialUpsert: Seq[EntityUpdateDefinition] = batchUpsertFile.parseJson.convertTo[Seq[EntityUpdateDefinition]]
 
       // copy the initial upsert, but change one value. This is as if the user downloaded a data table to TSV,
@@ -196,13 +198,21 @@ class BatchUpsertScalingSpec
         } else {
           val (loadDuration, _) = profile {
             Await.result(
-              testApiService.entityService.batchUpsertEntities(minimalTestData.wsName, initialUpsert, None, None),
+              testApiService.entityService.batchUpsertEntities(minimalTestData.wsName,
+                                                               initialUpsertByteSource,
+                                                               None,
+                                                               None
+              ),
               waitDuration
             )
           }
           val (changeDuration, _) = profile {
             Await.result(
-              testApiService.entityService.batchUpsertEntities(minimalTestData.wsName, modifiedUpsert, None, None),
+              testApiService.entityService.batchUpsertEntities(minimalTestData.wsName,
+                                                               initialUpsertByteSource,
+                                                               None,
+                                                               None
+              ),
               waitDuration
             )
           }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
@@ -149,8 +149,8 @@ class BatchUpsertScalingSpec
 
       // parse into EntityUpdateDefinition. This is our initial load file, as if the user had an empty workspace
       // and uploaded a TSV to create a new data table.
-      val initialUpsertByteSource = akka.stream.scaladsl.Source.single(ByteString(batchUpsertFile))
       val initialUpsert: Seq[EntityUpdateDefinition] = batchUpsertFile.parseJson.convertTo[Seq[EntityUpdateDefinition]]
+      val initialUpsertSource = akka.stream.scaladsl.Source(initialUpsert)
 
       // copy the initial upsert, but change one value. This is as if the user downloaded a data table to TSV,
       // modified one cell, and re-uploaded the entire TSV.
@@ -198,21 +198,13 @@ class BatchUpsertScalingSpec
         } else {
           val (loadDuration, _) = profile {
             Await.result(
-              testApiService.entityService.batchUpsertEntities(minimalTestData.wsName,
-                                                               initialUpsertByteSource,
-                                                               None,
-                                                               None
-              ),
+              testApiService.entityService.batchUpsertEntities(minimalTestData.wsName, initialUpsertSource, None, None),
               waitDuration
             )
           }
           val (changeDuration, _) = profile {
             Await.result(
-              testApiService.entityService.batchUpsertEntities(minimalTestData.wsName,
-                                                               initialUpsertByteSource,
-                                                               None,
-                                                               None
-              ),
+              testApiService.entityService.batchUpsertEntities(minimalTestData.wsName, initialUpsertSource, None, None),
               waitDuration
             )
           }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.entities.local
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.config.ConfigFactory
 import cromwell.client.model.{ToolInputParameter, ValueType}
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.{
 }
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationContext
-import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityRequestArguments, EntityService}
+import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityRequestArguments, EntityService, EntityUtils}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, EntityUpdateDefinition}
@@ -485,7 +485,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             )
             val upsert = EntityUpdateDefinition("001", typeUnderTest, Seq(op))
             // perform upsert
-            provider.batchUpsertEntities(Seq(upsert), testContext).futureValue
+            provider.batchUpsertEntities(Source.single(upsert), testContext).futureValue
 
             // get database-level entity record for the entity containing the reference
             val entityRecordContainingReference = runAndWait(
@@ -534,7 +534,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val op = AddUpdateAttribute(fooAttribute, AttributeString("updated"))
             val upsert = EntityUpdateDefinition("001", typeUnderTest, Seq(op))
             // perform upsert
-            provider.batchUpsertEntities(Seq(upsert), testContext).futureValue
+            provider.batchUpsertEntities(Source.single(upsert), testContext).futureValue
 
             // get actual entities, after upsert
             val entitiesAfterUpsert = getAllEntities(testWorkspace.workspace)
@@ -578,7 +578,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val op = AddUpdateAttribute(fooAttribute, AttributeString("updated"))
             val upsert = EntityUpdateDefinition("001", typeUnderTest, Seq(op))
             // perform upsert
-            provider.batchUpdateEntities(Seq(upsert), testContext).futureValue
+            provider.batchUpdateEntities(Source.single(upsert), testContext).futureValue
 
             // get actual entities, after upsert
             val entitiesAfterUpdate = getAllEntities(testWorkspace.workspace)
@@ -824,7 +824,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           }.toSeq
           EntityUpdateDefinition(entity.name, entity.entityType, attributeUpdates)
         }
-        provider.batchUpsertEntities(updateDefinition, testContext).futureValue
+        provider.batchUpsertEntities(Source(updateDefinition), testContext).futureValue
 
         // get our entity
         val entity = provider.getEntity("cat", "005", testContext).futureValue
@@ -853,7 +853,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           }.toSeq
           EntityUpdateDefinition(entity.name, entity.entityType, attributeUpdates)
         }
-        provider.batchUpdateEntities(updateDefinition, testContext).futureValue
+        provider.batchUpdateEntities(Source(updateDefinition), testContext).futureValue
 
         // get our entity
         val entity = provider.getEntity("cat", "005", testContext).futureValue

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.rawls.entities.local
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.config.ConfigFactory
 import cromwell.client.model.{ToolInputParameter, ValueType}
@@ -14,7 +13,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.{
 }
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationContext
-import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityRequestArguments, EntityService, EntityUtils}
+import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityRequestArguments, EntityService}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, EntityUpdateDefinition}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.local
 
+import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction, TestDriverComponent}
@@ -51,6 +52,8 @@ class LocalEntityProviderSpec
   import driver.api._
 
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(3000, Millis)))
+
+  implicit private val system: ActorSystem = ActorSystem("LocalEntityProviderSpec")
 
   val testConf = ConfigFactory.load()
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.entities.local
 
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction, TestDriverComponent}
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
@@ -353,7 +353,7 @@ class LocalEntityProviderSpec
         )
         val writes = localEntityProvider.batchUpsertEntities(Source(multiUpsert), testContext).futureValue
 
-        writes.size shouldBe 2
+        writes.runWith(Sink.seq).futureValue.size shouldBe 2
 
         val entityQuery = EntityQuery(1, 100, "name", SortDirections.Ascending, None)
         val parentContext = RawlsRequestContext(userInfo)
@@ -1050,7 +1050,7 @@ class LocalEntityProviderSpec
         // create the first entity with name "myname"
         val upsert1 = Seq(EntityUpdateDefinition("myname", "casetest", Seq()))
         val created1 = localEntityProvider.batchUpsertEntities(Source(upsert1), testContext).futureValue
-        created1.size shouldBe 1
+        created1.runWith(Sink.seq).futureValue.size shouldBe 1
 
         // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
         val upsert2 = Seq(EntityUpdateDefinition("MyName", "casetest", Seq()))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.local
 
+import akka.stream.scaladsl.Source
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction, TestDriverComponent}
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
@@ -347,7 +348,7 @@ class LocalEntityProviderSpec
                                  Seq(AddUpdateAttribute(AttributeName.withDefaultNS("two"), AttributeString("222")))
           )
         )
-        val writes = localEntityProvider.batchUpsertEntities(multiUpsert, testContext).futureValue
+        val writes = localEntityProvider.batchUpsertEntities(Source(multiUpsert), testContext).futureValue
 
         writes.size shouldBe 2
 
@@ -1045,13 +1046,13 @@ class LocalEntityProviderSpec
 
         // create the first entity with name "myname"
         val upsert1 = Seq(EntityUpdateDefinition("myname", "casetest", Seq()))
-        val created1 = localEntityProvider.batchUpsertEntities(upsert1, testContext).futureValue
+        val created1 = localEntityProvider.batchUpsertEntities(Source(upsert1), testContext).futureValue
         created1.size shouldBe 1
 
         // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
         val upsert2 = Seq(EntityUpdateDefinition("MyName", "casetest", Seq()))
         val ex = recoverToExceptionIf[Exception] {
-          localEntityProvider.batchUpsertEntities(upsert2, testContext)
+          localEntityProvider.batchUpsertEntities(Source(upsert2), testContext)
         }.futureValue
 
         ex match {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderTimeoutSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderTimeoutSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.local
 
+import akka.stream.scaladsl.Source
 import com.mysql.cj.jdbc.exceptions.MySQLTimeoutException
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
@@ -92,7 +93,7 @@ class LocalEntityProviderTimeoutSpec extends AnyWordSpecLike with Matchers with 
         val attrUpdate = AddUpdateAttribute(AttributeName.withDefaultNS("newAttr"), AttributeString("whatever"))
         val entityUpdate =
           EntityUpdateDefinition(name = "deleteTimeoutTest", entityType = "unitTestType", Seq(attrUpdate))
-        localEntityProvider.batchUpsertEntities(Seq(entityUpdate), testContext)
+        localEntityProvider.batchUpsertEntities(Source.single(entityUpdate), testContext)
       }
     }
 
@@ -101,7 +102,7 @@ class LocalEntityProviderTimeoutSpec extends AnyWordSpecLike with Matchers with 
         val attrUpdate = AddUpdateAttribute(AttributeName.withDefaultNS("newAttr"), AttributeString("whatever"))
         val entityUpdate =
           EntityUpdateDefinition(name = "deleteTimeoutTest", entityType = "unitTestType", Seq(attrUpdate))
-        localEntityProvider.batchUpdateEntities(Seq(entityUpdate), testContext)
+        localEntityProvider.batchUpdateEntities(Source.single(entityUpdate), testContext)
       }
     }
 //    "enforce on batchUpdateEntitiesImpl" ignore fail()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderTimeoutSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderTimeoutSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.local
 
+import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
 import com.mysql.cj.jdbc.exceptions.MySQLTimeoutException
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
@@ -21,6 +22,8 @@ import scala.concurrent.Future
 class LocalEntityProviderTimeoutSpec extends AnyWordSpecLike with Matchers with ScalaFutures with TestDriverComponent {
 
   import driver.api._
+
+  implicit private val system: ActorSystem = ActorSystem("LocalEntityProviderTimeoutSpec")
 
   /** Locks all rows of the ENTITY table for ${lockSeconds} seconds. Use this to simulate database contention. */
   private def lockAllEntities(dataSource: SlickDataSource, lockSeconds: Int): Future[Unit] = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -202,7 +202,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
         any[Option[GoogleProjectId]],
         any[RawlsRequestContext]
       )
-    ).thenReturn(Future(Seq.empty[Entity]))
+    ).thenReturn(Future(Source.empty[Entity]))
 
     val mockEntityServiceConstructor: RawlsRequestContext => EntityService = _ => mockEntityService
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.rawls.monitor
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
 import akka.testkit.TestKit
-import akka.util.ByteString
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.dataaccess._

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -197,7 +197,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
     when(
       mockEntityService.batchUpdateEntitiesInternal(
         any[WorkspaceName],
-        any[Source[ByteString, _]],
+        any[Source[EntityUpdateDefinition, _]],
         any[Boolean],
         any[Option[DataReferenceName]],
         any[Option[GoogleProjectId]],
@@ -1096,7 +1096,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
       eventually[Unit](Timeout(timeout), Interval(interval)) {
         verify(mockEntityService, times(1)).batchUpdateEntitiesInternal(
           any[WorkspaceName],
-          any[Source[ByteString, _]],
+          any[Source[EntityUpdateDefinition, _]],
           ArgumentMatchers.eq(expectation.isUpsert),
           any[Option[DataReferenceName]],
           any[Option[GoogleProjectId]],

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -1,7 +1,9 @@
 package org.broadinstitute.dsde.rawls.monitor
 
 import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
 import akka.testkit.TestKit
+import akka.util.ByteString
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.dataaccess._
@@ -195,7 +197,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
     when(
       mockEntityService.batchUpdateEntitiesInternal(
         any[WorkspaceName],
-        any[Seq[EntityUpdateDefinition]],
+        any[Source[ByteString, _]],
         any[Boolean],
         any[Option[DataReferenceName]],
         any[Option[GoogleProjectId]],
@@ -1094,7 +1096,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
       eventually[Unit](Timeout(timeout), Interval(interval)) {
         verify(mockEntityService, times(1)).batchUpdateEntitiesInternal(
           any[WorkspaceName],
-          any[Seq[EntityUpdateDefinition]],
+          any[Source[ByteString, _]],
           ArgumentMatchers.eq(expectation.isUpsert),
           any[Option[DataReferenceName]],
           any[Option[GoogleProjectId]],

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,9 +30,6 @@ object Dependencies {
   val akkaTestKit: ModuleID =           "com.typesafe.akka" %% "akka-testkit"             % akkaV     % "test"
   val akkaHttpTestKit: ModuleID =       "com.typesafe.akka" %% "akka-http-testkit"        % akkaHttpV % "test"
 
-  // this is the alpakka version compatible with our current akkaV
-  val alpakkaJsonStream: ModuleID =     "com.lightbend.akka" %% "akka-stream-alpakka-json-streaming" % "4.0.0"
-
   // This version of `cromwell-client` was packaged by `sbt` running on Scala 2.12 but actually contains only Java
   // classes (generated from OpenAPI YAML) that were not compiled against any version of the Scala library.
   // `cromwell-client` is therefore referenced here as a Java artifact with "_2.12" incorporated into its name,
@@ -241,7 +238,6 @@ object Dependencies {
     slickHikariCP,
     akkaHttp,
     akkaStream,
-    alpakkaJsonStream,
     webjarsLocator,
     circeYAML,
     commonsJEXL,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,6 +30,9 @@ object Dependencies {
   val akkaTestKit: ModuleID =           "com.typesafe.akka" %% "akka-testkit"             % akkaV     % "test"
   val akkaHttpTestKit: ModuleID =       "com.typesafe.akka" %% "akka-http-testkit"        % akkaHttpV % "test"
 
+  // this is the alpakka version compatible with our current akkaV
+  val alpakkaJsonStream: ModuleID =     "com.lightbend.akka" %% "akka-stream-alpakka-json-streaming" % "4.0.0"
+
   // This version of `cromwell-client` was packaged by `sbt` running on Scala 2.12 but actually contains only Java
   // classes (generated from OpenAPI YAML) that were not compiled against any version of the Scala library.
   // `cromwell-client` is therefore referenced here as a Java artifact with "_2.12" incorporated into its name,
@@ -238,6 +241,7 @@ object Dependencies {
     slickHikariCP,
     akkaHttp,
     akkaStream,
+    alpakkaJsonStream,
     webjarsLocator,
     circeYAML,
     commonsJEXL,


### PR DESCRIPTION
Ticket: CORE-427

This is a prefactoring for CORE-427 in support of Quicksilver-based batchUpsert.

In this PR, I am changing the akka-http batchUpsert and batchUpdate route definitions to read a stream of updates from the caller instead of materializing their entire payload into a single `Array`/`Seq` and holding the entire payload in memory. Additionally, I am updating the batchUpdate/batchUpsert methods to return a stream of results instead of materializing their results into a Seq. This will allow Quicksilver-based data tables to fully stream their upserts/updates.

The two places that currently use batchUpsert/batchUpdate are the LocalEntityProvider (legacy data tables) and the AvroUpsertMonitor (imports via cWDS). I have NOT optimized those callers:
* LocalEntityProvider immediately materializes the stream, so it behaves just like before this PR - the only change is that the materialization happens in a different location
* AvroUpsertMonitor has very pretty minor syntax changes for compatibility. It is rife for optimization but I suggest we do that in a separate PR.

In summary:
* before this PR, we materialized the batchUpsert/batchUpdate request body in `EntityApiService`. After this PR, we materialize it in `LocalEntityProvider`.
* moving the materialization lower in the stack will allow `CompactEntityProvider` to work with streams.

I have tested in a BEE with both synchronous and async-via-cwds TSV uploads, which exercise batchupsert.


