### PR TITLE
[CORE-474] Added lock and unlock permissions checks for workspace lock and unlock

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SamModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SamModel.scala
@@ -76,6 +76,8 @@ object SamWorkspaceActions {
   val updateAuthDomain = SamResourceAction("update_auth_domain")
   val readSettings = SamResourceAction("read_settings")
   val writeSettings = SamResourceAction("write_settings")
+  val lock = SamResourceAction("lock")
+  val unlock = SamResourceAction("unlock")
 }
 
 object SamBillingProjectActions {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1167,12 +1167,12 @@ class WorkspaceService(
     }
 
   def lockWorkspace(workspaceName: WorkspaceName): Future[Boolean] = for {
-    workspace <- getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.own, ignoreLock = true)
+    workspace <- getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.lock, ignoreLock = true)
     locked <- workspaceRepository.lockWorkspace(workspace)
   } yield locked
 
   def unlockWorkspace(workspaceName: WorkspaceName): Future[Boolean] = for {
-    workspace <- getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.own, ignoreLock = true)
+    workspace <- getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.unlock, ignoreLock = true)
     unlocked <- workspaceRepository.unlockWorkspace(workspace)
   } yield unlocked
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -445,7 +445,12 @@ class WorkspaceServiceSpec
         SamWorkspacePolicyNames.owner,
         SamPolicy(
           Set(WorkbenchEmail(testData.userOwner.userEmail.value)),
-          Set(SamWorkspaceActions.own, SamWorkspaceActions.write, SamWorkspaceActions.read),
+          Set(SamWorkspaceActions.own,
+              SamWorkspaceActions.write,
+              SamWorkspaceActions.read,
+              SamWorkspaceActions.lock,
+              SamWorkspaceActions.unlock
+          ),
           Set(SamWorkspaceRoles.owner)
         ),
         testContext


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-474

This PR updates action checks for the workspace lock and unlock APIs by replacing `own` actions with the recently added `lock` and `unlock` actions in this PR https://github.com/broadinstitute/sam/pull/1680.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
