### PR TITLE
CORE-427: change batch upsert/update response to a stream

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -446,7 +446,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                   dataReference: Option[DataReferenceName],
                                   billingProject: Option[GoogleProjectId],
                                   parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     traceFutureWithParent("getV2WorkspaceContextAndPermissions", parentContext) { _ =>
       getV2WorkspaceContextAndPermissions(workspaceName,
                                           SamWorkspaceActions.write,
@@ -476,7 +476,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           entityUpdates: Source[EntityUpdateDefinition, _],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     traceFutureWithParent("EntityService.batchUpdateEntities", ctx) { s =>
       batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = false, dataReference, billingProject, s)
         .recover(
@@ -488,7 +488,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           entityUpdates: Source[EntityUpdateDefinition, _],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     traceFutureWithParent("EntityService.batchUpsertEntities", ctx) { s =>
       batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject, s)
         .recover(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -36,11 +36,11 @@ trait EntityProvider {
 
   def batchUpdateEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                           parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]]
+  ): Future[Source[Entity, _]]
 
   def batchUpsertEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                           parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]]
+  ): Future[Source[Entity, _]]
 
   def copyEntities(sourceWorkspaceContext: Workspace,
                    destWorkspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -61,12 +61,12 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments, repository
   override def batchUpdateEntities(
     entityUpdates: Source[EntityUpdateDefinition, _],
     parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] = ???
+  ): Future[Source[Entity, _]] = ???
 
   override def batchUpsertEntities(
     entityUpdates: Source[EntityUpdateDefinition, _],
     parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] = ???
+  ): Future[Source[Entity, _]] = ???
 
   override def copyEntities(sourceWorkspaceContext: Workspace,
                             destWorkspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -560,12 +560,12 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   override def batchUpdateEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     throw new UnsupportedEntityOperationException("batch-update entities not supported by this provider.")
 
   override def batchUpsertEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     throw new UnsupportedEntityOperationException("batch-upsert entities not supported by this provider.")
 
   override def copyEntities(sourceWorkspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -527,103 +527,106 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     updateStream: Source[EntityUpdateDefinition, _],
     upsert: Boolean,
     parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     // immediately materialize the updateStream so existing code can work with a Seq
-    updateStream.runWith(Sink.seq).flatMap { entityUpdates =>
-      val namesToCheck = for {
-        update <- entityUpdates
-        operation <- update.operations
-      } yield operation.name
+    updateStream
+      .runWith(Sink.seq)
+      .flatMap { entityUpdates =>
+        val namesToCheck = for {
+          update <- entityUpdates
+          operation <- update.operations
+        } yield operation.name
 
-      traceFutureWithParent("LocalEntityProvider.batchUpdateEntitiesImpl", parentContext) { localContext =>
-        setTraceSpanAttribute(localContext, AttributeKey.stringKey("workspaceId"), workspaceContext.workspaceId)
-        setTraceSpanAttribute(localContext, AttributeKey.booleanKey("upsert"), java.lang.Boolean.valueOf(upsert))
-        setTraceSpanAttribute(localContext,
-                              AttributeKey.longKey("entityUpdatesCount"),
-                              java.lang.Long.valueOf(entityUpdates.length)
-        )
-        setTraceSpanAttribute(localContext,
-                              AttributeKey.longKey("entityOperationsCount"),
-                              java.lang.Long.valueOf(entityUpdates.map(_.operations.length).sum)
-        )
+        traceFutureWithParent("LocalEntityProvider.batchUpdateEntitiesImpl", parentContext) { localContext =>
+          setTraceSpanAttribute(localContext, AttributeKey.stringKey("workspaceId"), workspaceContext.workspaceId)
+          setTraceSpanAttribute(localContext, AttributeKey.booleanKey("upsert"), java.lang.Boolean.valueOf(upsert))
+          setTraceSpanAttribute(localContext,
+                                AttributeKey.longKey("entityUpdatesCount"),
+                                java.lang.Long.valueOf(entityUpdates.length)
+          )
+          setTraceSpanAttribute(localContext,
+                                AttributeKey.longKey("entityOperationsCount"),
+                                java.lang.Long.valueOf(entityUpdates.map(_.operations.length).sum)
+          )
 
-        withAttributeNamespaceCheck(namesToCheck) {
-          dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
-            val updateTrialsAction = traceDBIOWithParent("getActiveEntities", localContext)(_ =>
-              dataAccess.entityQuery.getActiveEntities(
-                workspaceContext,
-                entityUpdates.map(eu => AttributeEntityReference(eu.entityType, eu.name))
-              )
-            ) map { entities =>
-              val entitiesByName = entities.map(e => (e.entityType, e.name) -> e).toMap
-              entityUpdates.map { entityUpdate =>
-                entityUpdate -> (entitiesByName.get((entityUpdate.entityType, entityUpdate.name)) match {
-                  case Some(e) =>
-                    Try(applyOperationsToEntity(e, entityUpdate.operations))
-                  case None =>
-                    if (upsert) {
-                      Try(
-                        applyOperationsToEntity(Entity(entityUpdate.name, entityUpdate.entityType, Map.empty),
-                                                entityUpdate.operations
-                        )
-                      )
-                    } else {
-                      Failure(new RuntimeException("Entity does not exist"))
-                    }
-                })
-              }
-            }
-
-            val saveAction = updateTrialsAction flatMap { updateTrials =>
-              val errorReports = updateTrials.collect { case (entityUpdate, Failure(regrets)) =>
-                ErrorReport(s"Could not update ${entityUpdate.entityType} ${entityUpdate.name}", ErrorReport(regrets))
-              }
-              if (errorReports.nonEmpty) {
-                DBIO.failed(
-                  new RawlsExceptionWithErrorReport(
-                    ErrorReport(StatusCodes.BadRequest, "Some entities could not be updated.", errorReports)
-                  )
+          withAttributeNamespaceCheck(namesToCheck) {
+            dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
+              val updateTrialsAction = traceDBIOWithParent("getActiveEntities", localContext)(_ =>
+                dataAccess.entityQuery.getActiveEntities(
+                  workspaceContext,
+                  entityUpdates.map(eu => AttributeEntityReference(eu.entityType, eu.name))
                 )
-              } else {
-                val t = updateTrials.collect { case (entityUpdate, Success(entity)) => entity }
-
-                traceDBIOWithParent("saveAction", localContext) { subContext =>
-                  dataAccess.entityQuery
-                    .save(workspaceContext, t, subContext.toTracingContext)
-                    .withStatementParameters(statementInit = _.setQueryTimeout(queryTimeoutSeconds))
+              ) map { entities =>
+                val entitiesByName = entities.map(e => (e.entityType, e.name) -> e).toMap
+                entityUpdates.map { entityUpdate =>
+                  entityUpdate -> (entitiesByName.get((entityUpdate.entityType, entityUpdate.name)) match {
+                    case Some(e) =>
+                      Try(applyOperationsToEntity(e, entityUpdate.operations))
+                    case None =>
+                      if (upsert) {
+                        Try(
+                          applyOperationsToEntity(Entity(entityUpdate.name, entityUpdate.entityType, Map.empty),
+                                                  entityUpdate.operations
+                          )
+                        )
+                      } else {
+                        Failure(new RuntimeException("Entity does not exist"))
+                      }
+                  })
                 }
               }
-            }
 
-            saveAction
-          } recover {
-            case icve: java.sql.SQLIntegrityConstraintViolationException =>
-              val userMessage =
-                s"Database error occurred. Check if you are uploading entity names that differ only in case " +
-                  s"from pre-existing entities."
-              throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, icve))
-            case bue: java.sql.BatchUpdateException =>
-              val maybeCaseIssue = bue.getMessage.startsWith("Duplicate entry")
-              val userMessage = if (maybeCaseIssue) {
-                s"Database error occurred. Check if you are uploading entity names that differ only in case " +
-                  s"from pre-existing entities."
-              } else {
-                s"Database error occurred. Underlying error message: ${bue.getMessage}"
+              val saveAction = updateTrialsAction flatMap { updateTrials =>
+                val errorReports = updateTrials.collect { case (entityUpdate, Failure(regrets)) =>
+                  ErrorReport(s"Could not update ${entityUpdate.entityType} ${entityUpdate.name}", ErrorReport(regrets))
+                }
+                if (errorReports.nonEmpty) {
+                  DBIO.failed(
+                    new RawlsExceptionWithErrorReport(
+                      ErrorReport(StatusCodes.BadRequest, "Some entities could not be updated.", errorReports)
+                    )
+                  )
+                } else {
+                  val t = updateTrials.collect { case (entityUpdate, Success(entity)) => entity }
+
+                  traceDBIOWithParent("saveAction", localContext) { subContext =>
+                    dataAccess.entityQuery
+                      .save(workspaceContext, t, subContext.toTracingContext)
+                      .withStatementParameters(statementInit = _.setQueryTimeout(queryTimeoutSeconds))
+                  }
+                }
               }
-              throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, bue))
+
+              saveAction
+            } recover {
+              case icve: java.sql.SQLIntegrityConstraintViolationException =>
+                val userMessage =
+                  s"Database error occurred. Check if you are uploading entity names that differ only in case " +
+                    s"from pre-existing entities."
+                throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, icve))
+              case bue: java.sql.BatchUpdateException =>
+                val maybeCaseIssue = bue.getMessage.startsWith("Duplicate entry")
+                val userMessage = if (maybeCaseIssue) {
+                  s"Database error occurred. Check if you are uploading entity names that differ only in case " +
+                    s"from pre-existing entities."
+                } else {
+                  s"Database error occurred. Underlying error message: ${bue.getMessage}"
+                }
+                throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, bue))
+            }
           }
         }
       }
-    }
+      .map(writeResults => Source(writeResults.toSeq))
 
   override def batchUpdateEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     batchUpdateEntitiesImpl(entityUpdates, upsert = false, parentContext)
 
   override def batchUpsertEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
-  ): Future[Traversable[Entity]] =
+  ): Future[Source[Entity, _]] =
     batchUpdateEntitiesImpl(entityUpdates, upsert = true, parentContext)
 
   override def copyEntities(sourceWorkspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -4,7 +4,7 @@ import akka.actor.SupervisorStrategy.{Escalate, Stop}
 import akka.actor._
 import akka.http.scaladsl.model.StatusCodes
 import akka.pattern._
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -456,7 +456,7 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
         for {
           petUserInfo <- getPetServiceAccountUserInfo(workspace.googleProjectId, userEmail)
           requestContext = RawlsRequestContext(petUserInfo)
-          upsertResults <- entityService(requestContext).batchUpdateEntitiesInternal(
+          upsertResultsSource <- entityService(requestContext).batchUpdateEntitiesInternal(
             workspace.toWorkspaceName,
             entityUpdateStream,
             upsert = isUpsert,
@@ -464,7 +464,8 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
             None,
             requestContext
           )
-        } yield upsertResults
+          upsertResults <- upsertResultsSource.runWith(Sink.seq)
+        } yield upsertResults.toTraversable
       }
 
       // create our pause signal. We use this to control when the stream should pause and resume.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.entities.local
 
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction, TestDriverComponent}
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
@@ -353,7 +353,7 @@ class LocalEntityProviderSpec
         )
         val writes = localEntityProvider.batchUpsertEntities(Source(multiUpsert), testContext).futureValue
 
-        writes.size shouldBe 2
+        writes.runWith(Sink.seq).futureValue.size shouldBe 2
 
         val entityQuery = EntityQuery(1, 100, "name", SortDirections.Ascending, None)
         val parentContext = RawlsRequestContext(userInfo)
@@ -1050,7 +1050,7 @@ class LocalEntityProviderSpec
         // create the first entity with name "myname"
         val upsert1 = Seq(EntityUpdateDefinition("myname", "casetest", Seq()))
         val created1 = localEntityProvider.batchUpsertEntities(Source(upsert1), testContext).futureValue
-        created1.size shouldBe 1
+        created1.runWith(Sink.seq).futureValue.size shouldBe 1
 
         // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
         val upsert2 = Seq(EntityUpdateDefinition("MyName", "casetest", Seq()))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -202,7 +202,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
         any[Option[GoogleProjectId]],
         any[RawlsRequestContext]
       )
-    ).thenReturn(Future(Seq.empty[Entity]))
+    ).thenReturn(Future(Source.empty[Entity]))
 
     val mockEntityServiceConstructor: RawlsRequestContext => EntityService = _ => mockEntityService
 


### PR DESCRIPTION
Ticket: CORE-427

Follow-on to #3286. That other PR changes the batchupsert/update methods to accept a stream input; this PR changes those same methods to return a stream output.
