### PR TITLE
CORE-427: change batchUpsert/Update return value to Int

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -446,7 +446,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                   dataReference: Option[DataReferenceName],
                                   billingProject: Option[GoogleProjectId],
                                   parentContext: RawlsRequestContext
-  ): Future[Source[Entity, _]] =
+  ): Future[Int] =
     traceFutureWithParent("getV2WorkspaceContextAndPermissions", parentContext) { _ =>
       getV2WorkspaceContextAndPermissions(workspaceName,
                                           SamWorkspaceActions.write,
@@ -476,7 +476,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           entityUpdates: Source[EntityUpdateDefinition, _],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
-  ): Future[Source[Entity, _]] =
+  ): Future[Int] =
     traceFutureWithParent("EntityService.batchUpdateEntities", ctx) { s =>
       batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = false, dataReference, billingProject, s)
         .recover(
@@ -488,7 +488,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           entityUpdates: Source[EntityUpdateDefinition, _],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
-  ): Future[Source[Entity, _]] =
+  ): Future[Int] =
     traceFutureWithParent("EntityService.batchUpsertEntities", ctx) { s =>
       batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject, s)
         .recover(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -36,11 +36,11 @@ trait EntityProvider {
 
   def batchUpdateEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                           parentContext: RawlsRequestContext
-  ): Future[Source[Entity, _]]
+  ): Future[Int]
 
   def batchUpsertEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                           parentContext: RawlsRequestContext
-  ): Future[Source[Entity, _]]
+  ): Future[Int]
 
   def copyEntities(sourceWorkspaceContext: Workspace,
                    destWorkspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -61,12 +61,12 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments, repository
   override def batchUpdateEntities(
     entityUpdates: Source[EntityUpdateDefinition, _],
     parentContext: RawlsRequestContext
-  ): Future[Source[Entity, _]] = ???
+  ): Future[Int] = ???
 
   override def batchUpsertEntities(
     entityUpdates: Source[EntityUpdateDefinition, _],
     parentContext: RawlsRequestContext
-  ): Future[Source[Entity, _]] = ???
+  ): Future[Int] = ???
 
   override def copyEntities(sourceWorkspaceContext: Workspace,
                             destWorkspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -560,12 +560,12 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   override def batchUpdateEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
-  ): Future[Source[Entity, _]] =
+  ): Future[Int] =
     throw new UnsupportedEntityOperationException("batch-update entities not supported by this provider.")
 
   override def batchUpsertEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
-  ): Future[Source[Entity, _]] =
+  ): Future[Int] =
     throw new UnsupportedEntityOperationException("batch-upsert entities not supported by this provider.")
 
   override def copyEntities(sourceWorkspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -527,7 +527,7 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     updateStream: Source[EntityUpdateDefinition, _],
     upsert: Boolean,
     parentContext: RawlsRequestContext
-  ): Future[Source[Entity, _]] =
+  ): Future[Int] =
     // immediately materialize the updateStream so existing code can work with a Seq
     updateStream
       .runWith(Sink.seq)
@@ -617,16 +617,16 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
           }
         }
       }
-      .map(writeResults => Source(writeResults.toSeq))
+      .map(writeResults => writeResults.size)
 
   override def batchUpdateEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
-  ): Future[Source[Entity, _]] =
+  ): Future[Int] =
     batchUpdateEntitiesImpl(entityUpdates, upsert = false, parentContext)
 
   override def batchUpsertEntities(entityUpdates: Source[EntityUpdateDefinition, _],
                                    parentContext: RawlsRequestContext
-  ): Future[Source[Entity, _]] =
+  ): Future[Int] =
     batchUpdateEntitiesImpl(entityUpdates, upsert = true, parentContext)
 
   override def copyEntities(sourceWorkspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -446,7 +446,7 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
       val batchStream = entityUpdateDefinitionStream.chunkN(batchSize)
 
       // convenience method to encapsulate the call to EntityService's batchUpdateEntitiesInternal
-      def performUpsertBatch(idx: Long, upsertBatch: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] = {
+      def performUpsertBatch(idx: Long, upsertBatch: Seq[EntityUpdateDefinition]): Future[Int] = {
         logger.info(s"upserting batch #$idx of ${upsertBatch.size} entities for jobId ${jobId.toString} ...")
 
         // translate the upsertBatch back into a stream of json.
@@ -456,7 +456,7 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
         for {
           petUserInfo <- getPetServiceAccountUserInfo(workspace.googleProjectId, userEmail)
           requestContext = RawlsRequestContext(petUserInfo)
-          upsertResultsSource <- entityService(requestContext).batchUpdateEntitiesInternal(
+          upsertResults <- entityService(requestContext).batchUpdateEntitiesInternal(
             workspace.toWorkspaceName,
             entityUpdateStream,
             upsert = isUpsert,
@@ -464,8 +464,7 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
             None,
             requestContext
           )
-          upsertResults <- upsertResultsSource.runWith(Sink.seq)
-        } yield upsertResults.toTraversable
+        } yield upsertResults
       }
 
       // create our pause signal. We use this to control when the stream should pause and resume.
@@ -506,9 +505,7 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
       // finally, after all the stream setup, tell the stream to execute
       val upsertResults = upsertFuturesStream.compile.toList.unsafeRunSync()
 
-      val numSuccesses: Int = upsertResults.collect { case Success(entityList) =>
-        entityList.size
-      }.sum
+      val numSuccesses: Int = upsertResults.collect { case Success(writeSize) => writeSize }.sum
 
       // if the failure has underlying causes, use those; else use the parent failure.
       // unresolved entity references only have useful error messages in the underlying causes, not the parent failure

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -353,7 +353,7 @@ class LocalEntityProviderSpec
         )
         val writes = localEntityProvider.batchUpsertEntities(Source(multiUpsert), testContext).futureValue
 
-        writes.runWith(Sink.seq).futureValue.size shouldBe 2
+        writes shouldBe 2
 
         val entityQuery = EntityQuery(1, 100, "name", SortDirections.Ascending, None)
         val parentContext = RawlsRequestContext(userInfo)
@@ -1050,7 +1050,7 @@ class LocalEntityProviderSpec
         // create the first entity with name "myname"
         val upsert1 = Seq(EntityUpdateDefinition("myname", "casetest", Seq()))
         val created1 = localEntityProvider.batchUpsertEntities(Source(upsert1), testContext).futureValue
-        created1.runWith(Sink.seq).futureValue.size shouldBe 1
+        created1 shouldBe 1
 
         // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
         val upsert2 = Seq(EntityUpdateDefinition("MyName", "casetest", Seq()))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -202,7 +202,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
         any[Option[GoogleProjectId]],
         any[RawlsRequestContext]
       )
-    ).thenReturn(Future(Source.empty[Entity]))
+    ).thenReturn(Future(0))
 
     val mockEntityServiceConstructor: RawlsRequestContext => EntityService = _ => mockEntityService
 


### PR DESCRIPTION
Ticket: CORE-427

Following up on [this discussion](https://github.com/broadinstitute/rawls/pull/3292#discussion_r2073766478), this PR changes the return value for batchUpsert and batchUpdate to be the quantity of entities written, instead of the written entities themselves. This is a much simpler and smaller object to work with.
