### PR TITLE
CORE-425 limit data returned by quicksilver entityQuery

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
+import org.broadinstitute.dsde.rawls.model.FilterOperators.FilterOperator
 import org.broadinstitute.dsde.rawls.model.{
   Attributable,
   AttributeEntityReference,
@@ -275,74 +276,72 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   }
 
   def countEntities(workspaceId: UUID, entityType: String): ReadWriteAction[Int] =
-    concatSqlActions(
-      sql"select count(*) ",
-      fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType)
-    ).as[Int].map(_.head)
+    countEntitiesWithFilter(workspaceId, entityType, sql"")
 
   def countEntitiesWithColumnFilter(workspaceId: UUID,
                                     entityType: String,
                                     columnFilter: EntityColumnFilter
-  ): ReadWriteAction[Int] =
-    concatSqlActions(
-      sql"select count(*) ",
-      fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
-      columnFilterCondition(columnFilter)
-    ).as[Int].map(_.head)
+  ): ReadWriteAction[Int] = countEntitiesWithFilter(workspaceId, entityType, columnFilterCondition(columnFilter))
 
   def countEntitiesWithFilterTerms(workspaceId: UUID,
                                    entityType: String,
-                                   entityQuery: EntityQuery
+                                   entityQuery: EntityQuery,
+                                   filterTerms: Seq[String]
   ): ReadWriteAction[Int] =
-    concatSqlActions(
-      sql"select count(*) ",
-      fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
-      filterTermsCondition(entityQuery)
-    ).as[Int].map(_.head)
+    countEntitiesWithFilter(workspaceId, entityType, filterTermsCondition(filterTerms, entityQuery.filterOperator))
 
   def queryEntitiesWithFilterTerms(workspaceId: UUID,
                                    entityType: String,
-                                   entityQuery: EntityQuery
+                                   entityQuery: EntityQuery,
+                                   filterTerms: Seq[String]
   ): SqlStreamingAction[Seq[Entity], Entity, Read] =
-    concatSqlActions(
-      selectEntityColumns,
-      filteredAttributesColumn(entityQuery),
-      fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
-      filterTermsCondition(entityQuery),
-      orderBy(entityQuery),
-      paginationClause(entityQuery)
-    ).as[Entity]
+    queryEntitiesWithFilter(workspaceId,
+                            entityType,
+                            entityQuery,
+                            filterTermsCondition(filterTerms, entityQuery.filterOperator)
+    )
 
   def queryEntitiesWithColumnFilter(workspaceId: UUID,
                                     entityType: String,
                                     entityQuery: EntityQuery,
                                     columnFilter: EntityColumnFilter
   ): SqlStreamingAction[Seq[Entity], Entity, Read] =
-    concatSqlActions(
-      selectEntityColumns,
-      filteredAttributesColumn(entityQuery),
-      fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
-      columnFilterCondition(columnFilter),
-      orderBy(entityQuery),
-      paginationClause(entityQuery)
-    ).as[Entity]
+    queryEntitiesWithFilter(workspaceId, entityType, entityQuery, columnFilterCondition(columnFilter))
 
   def queryEntitiesWithNoFilter(workspaceId: UUID,
                                 entityType: String,
                                 entityQuery: EntityQuery
   ): SqlStreamingAction[Seq[Entity], Entity, Read] =
-    concatSqlActions(
-      selectEntityColumns,
-      filteredAttributesColumn(entityQuery),
-      fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
-      orderBy(entityQuery),
-      paginationClause(entityQuery)
-    ).as[Entity]
+    queryEntitiesWithFilter(workspaceId, entityType, entityQuery, sql"")
 
   // ====================================================================================================
   //  entity query helpers
   //      methods in this section are used for building entity query functions
   // ====================================================================================================
+
+  private def countEntitiesWithFilter(workspaceId: UUID,
+                                      entityType: String,
+                                      filter: SQLActionBuilder
+  ): ReadWriteAction[Int] =
+    concatSqlActions(
+      sql"select count(*) ",
+      fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
+      filter
+    ).as[Int].map(_.head)
+
+  private def queryEntitiesWithFilter(workspaceId: UUID,
+                                      entityType: String,
+                                      entityQuery: EntityQuery,
+                                      filter: SQLActionBuilder
+  ): SqlStreamingAction[Seq[Entity], Entity, Read] =
+    concatSqlActions(
+      selectEntityColumns,
+      filteredAttributesColumn(entityQuery),
+      fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
+      filter,
+      orderBy(entityQuery),
+      paginationClause(entityQuery)
+    ).as[Entity]
 
   private val selectEntityColumns =
     sql"select name, entity_type, "
@@ -382,14 +381,14 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   private def fromActiveEntitiesOfTypeInWorkspace(workspaceId: UUID, entityType: String) =
     sql" from ENTITY e where e.workspace_id = $workspaceId and e.entity_type = $entityType and e.deleted = 0"
 
-  private def filterTermsCondition(entityQuery: EntityQuery) = {
+  private def filterTermsCondition(filterTerms: Seq[String], operator: FilterOperator) = {
     // note the lower casing for case insensitive search
-    val filterClauses = entityQuery.filterTermsList.map { filterTerm =>
+    val filterClauses = filterTerms.map { filterTerm =>
       sql"""JSON_SEARCH(lower(e.attributes -> '#${CompactEntitySerialization.slickAttrsPath}'), 'one', ${'%' + filterTerm.toLowerCase + '%'})"""
     }
     concatSqlActions(
       sql" and (",
-      reduceSqlActionsWithDelim(filterClauses, sql" #${FilterOperators.toSql(entityQuery.filterOperator)} "),
+      reduceSqlActionsWithDelim(filterClauses, sql" #${FilterOperators.toSql(operator)} "),
       sql")"
     )
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -63,6 +63,9 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   implicit val getEntityTypeAndCount: GetResult[EntityTypeAndCount] =
     GetResult(r => EntityTypeAndCount(r.<<, r.<<))
 
+  implicit val getEntity: GetResult[Entity] =
+    GetResult(r => Entity(r.<<, r.<<, fromSql(r.<<)))
+
   private val fromEntityWhereNotDeleted = "from ENTITY e where e.deleted = 0"
 
   /**
@@ -300,49 +303,49 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   def queryEntitiesWithFilterTerms(workspaceId: UUID,
                                    entityType: String,
                                    entityQuery: EntityQuery
-  ): SqlStreamingAction[Seq[CompactEntityRecord], CompactEntityRecord, Read] =
+  ): SqlStreamingAction[Seq[Entity], Entity, Read] =
     concatSqlActions(
-      selectCompactEntityColumns,
+      selectEntityColumns,
       filteredAttributesColumn(entityQuery),
       fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
       filterTermsCondition(entityQuery),
       orderBy(entityQuery),
       paginationClause(entityQuery)
-    ).as[CompactEntityRecord]
+    ).as[Entity]
 
   def queryEntitiesWithColumnFilter(workspaceId: UUID,
                                     entityType: String,
                                     entityQuery: EntityQuery,
                                     columnFilter: EntityColumnFilter
-  ): SqlStreamingAction[Seq[CompactEntityRecord], CompactEntityRecord, Read] =
+  ): SqlStreamingAction[Seq[Entity], Entity, Read] =
     concatSqlActions(
-      selectCompactEntityColumns,
+      selectEntityColumns,
       filteredAttributesColumn(entityQuery),
       fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
       columnFilterCondition(columnFilter),
       orderBy(entityQuery),
       paginationClause(entityQuery)
-    ).as[CompactEntityRecord]
+    ).as[Entity]
 
   def queryEntitiesWithNoFilter(workspaceId: UUID,
                                 entityType: String,
                                 entityQuery: EntityQuery
-  ): SqlStreamingAction[Seq[CompactEntityRecord], CompactEntityRecord, Read] =
+  ): SqlStreamingAction[Seq[Entity], Entity, Read] =
     concatSqlActions(
-      selectCompactEntityColumns,
+      selectEntityColumns,
       filteredAttributesColumn(entityQuery),
       fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
       orderBy(entityQuery),
       paginationClause(entityQuery)
-    ).as[CompactEntityRecord]
+    ).as[Entity]
 
   // ====================================================================================================
   //  entity query helpers
   //      methods in this section are used for building entity query functions
   // ====================================================================================================
 
-  private val selectCompactEntityColumns =
-    sql"select id, name, entity_type, workspace_id, record_version, deleted, "
+  private val selectEntityColumns =
+    sql"select name, entity_type, "
 
   /**
    * Constructs the SQL fragment to extract specific attributes from the attributes JSON column

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -303,11 +303,12 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   ): SqlStreamingAction[Seq[CompactEntityRecord], CompactEntityRecord, Read] =
     concatSqlActions(
       selectCompactEntityColumns,
+      filteredAttributesColumn(entityQuery),
       fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
       filterTermsCondition(entityQuery),
       orderBy(entityQuery),
       paginationClause(entityQuery)
-    ).as[CompactEntityRecord](entityResultGetterWithFieldsFilter(entityQuery))
+    ).as[CompactEntityRecord]
 
   def queryEntitiesWithColumnFilter(workspaceId: UUID,
                                     entityType: String,
@@ -316,11 +317,12 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   ): SqlStreamingAction[Seq[CompactEntityRecord], CompactEntityRecord, Read] =
     concatSqlActions(
       selectCompactEntityColumns,
+      filteredAttributesColumn(entityQuery),
       fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
       columnFilterCondition(columnFilter),
       orderBy(entityQuery),
       paginationClause(entityQuery)
-    ).as[CompactEntityRecord](entityResultGetterWithFieldsFilter(entityQuery))
+    ).as[CompactEntityRecord]
 
   def queryEntitiesWithNoFilter(workspaceId: UUID,
                                 entityType: String,
@@ -328,10 +330,11 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   ): SqlStreamingAction[Seq[CompactEntityRecord], CompactEntityRecord, Read] =
     concatSqlActions(
       selectCompactEntityColumns,
+      filteredAttributesColumn(entityQuery),
       fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
       orderBy(entityQuery),
       paginationClause(entityQuery)
-    ).as[CompactEntityRecord](entityResultGetterWithFieldsFilter(entityQuery))
+    ).as[CompactEntityRecord]
 
   // ====================================================================================================
   //  entity query helpers
@@ -339,7 +342,39 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   // ====================================================================================================
 
   private val selectCompactEntityColumns =
-    sql"select id, name, entity_type, workspace_id, record_version, deleted, attributes"
+    sql"select id, name, entity_type, workspace_id, record_version, deleted, "
+
+  /**
+   * Constructs the SQL fragment to extract specific attributes from the attributes JSON column
+   * in the database based on the fields specified in the EntityQuery object.
+   *
+   * If specific fields are provided in entityQuery.fields, the method dynamically generates
+   * a JSON object containing only those fields. Each field is extracted from the attributes column
+   * using the -> operator. If no fields are specified, the entire attributes column is selected.
+   *
+   * Example sql produced:
+   * JSON_OBJECT(
+   *   'v', e.attributes -> '$.v',
+   *   'attrs', JSON_OBJECT(
+   *     ?, e.attributes -> ?,
+   *     ?, e.attributes -> ?
+   *   ))
+   */
+  private def filteredAttributesColumn(entityQuery: EntityQuery) =
+    entityQuery.fields.fields match {
+      case Some(fields) =>
+        val fieldSqls = fields.map { field =>
+          sql"$field, e.attributes -> ${slickAttributePath(field)}"
+        }
+        concatSqlActions(
+          sql"""JSON_OBJECT(
+               '#${CompactEntitySerialization.VERSION_KEY}', e.attributes -> '$$.#${CompactEntitySerialization.VERSION_KEY}',
+               '#${CompactEntitySerialization.ATTRS_KEY}', JSON_OBJECT(""",
+          reduceSqlActionsWithDelim(fieldSqls.toSeq, sql","),
+          sql"))"
+        )
+      case _ => sql"attributes"
+    }
 
   private def fromActiveEntitiesOfTypeInWorkspace(workspaceId: UUID, entityType: String) =
     sql" from ENTITY e where e.workspace_id = $workspaceId and e.entity_type = $entityType and e.deleted = 0"
@@ -376,17 +411,6 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
 
   private def paginationClause(entityQuery: EntityQuery): SQLActionBuilder =
     sql" limit ${entityQuery.pageSize} offset ${entityQuery.offset}"
-
-  private def entityResultGetterWithFieldsFilter(entityQuery: EntityQuery) =
-    entityQuery.fields.fields match {
-      case Some(fields) =>
-        // this special GetResult instance is the only way I found to filter the fields and keep this a streaming result
-        val desiredFields = fields.map(AttributeName.fromDelimitedName)
-        val getResultFilteringFields =
-          GetResult(r => CompactEntityRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, keepOnlyFields(r.<<, desiredFields)))
-        getResultFilteringFields
-      case _ => getJsonEntityRecord
-    }
 
   // ====================================================================================================
   //  migration helpers

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -283,9 +283,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         message = s"requested page ${entityQuery.page} is greater than the number of pages $pageCount"
       )
     }
-    (EntityQueryResultMetadata(unfilteredCount, filteredCountAndSource.count, pageCount),
-     filteredCountAndSource.source.map(_.toEntity)
-    )
+    (EntityQueryResultMetadata(unfilteredCount, filteredCountAndSource.count, pageCount), filteredCountAndSource.source)
   }
 
   private def countEntitiesOfType(entityType: LookupExpression) =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
@@ -48,21 +48,6 @@ trait CompactEntitySerialization {
         )
     }
 
-  def keepOnlyFields(attributes: Option[String], fields: Set[AttributeName]): Option[String] =
-    attributes.map { attr =>
-      val attributeMap = attr.parseJson match {
-        case jso: JsObject => deserialize(jso)
-        case otherJsValue =>
-          throw new CompactEntityDeserializationException(
-            s"wanted a JsObject; found a ${otherJsValue.getClass.getName}"
-          )
-      }
-      val filtered = attributeMap.filter { case (k, _) =>
-        fields.contains(k)
-      }
-      toSql(filtered).compactPrint
-    }
-
   val slickAttrsPath: String = s"$$.${ATTRS_KEY}"
   def slickAttributePath(attributeName: String): String = s"${slickAttrsPath}.${attributeName}"
   def slickAttributePath(attributeName: AttributeName): String = slickAttributePath(toDelimitedName(attributeName))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategy.scala
@@ -63,8 +63,8 @@ object EntityQueryStrategy {
     val idAttributeName = AttributeName.withDefaultNS(entityType + Attributable.entityIdAttributeSuffix)
 
     (entityQuery.filterTerms, entityQuery.columnFilter) match {
-      case (Some(_), _) =>
-        new SearchStrategy(repository, workspaceId, entityType, entityQuery)
+      case (Some(filterTerms), _) =>
+        new SearchStrategy(repository, workspaceId, entityType, entityQuery, filterTerms.split(" ").toSeq)
       case (_, Some(EntityColumnFilter(`idAttributeName`, _))) =>
         new FilterByNameStrategy(repository, workspaceId, entityType, entityQuery)
       case (_, Some(_)) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategy.scala
@@ -4,7 +4,7 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 import org.broadinstitute.dsde.rawls.dataaccess.slick.CompactEntityRecord
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeName, EntityColumnFilter, EntityQuery}
+import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeName, Entity, EntityColumnFilter, EntityQuery}
 import slick.dbio.Effect
 import slick.jdbc.TransactionIsolation.ReadCommitted
 import slick.jdbc.{ResultSetConcurrency, ResultSetType}
@@ -13,7 +13,7 @@ import slick.sql.SqlStreamingAction
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
-case class CountAndSource(count: Int, source: Source[CompactEntityRecord, _])
+case class CountAndSource(count: Int, source: Source[Entity, _])
 
 trait EntityQueryStrategy {
   val repository: CompactEntityRepository
@@ -22,8 +22,8 @@ trait EntityQueryStrategy {
 
   protected def streamQuery(
     count: Int,
-    query: SqlStreamingAction[Seq[CompactEntityRecord], CompactEntityRecord, Effect.Read]
-  ): Source[CompactEntityRecord, NotUsed] = {
+    query: SqlStreamingAction[Seq[Entity], Entity, Effect.Read]
+  ): Source[Entity, NotUsed] = {
     import repository.dataSource.dataAccess.driver.api._
     if (count == 0) {
       // if there are no results, we can just return an empty source

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByNameStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByNameStrategy.scala
@@ -22,7 +22,7 @@ class FilterByNameStrategy(override val repository: CompactEntityRepository,
     repository.dataSource.inTransaction(ReadCommitted) { _ =>
       repository.queries.getEntity(workspaceId, entityType, entityName)
     } map {
-      case Some(entityRec) => CountAndSource(1, Source.single(entityRec))
+      case Some(entityRec) => CountAndSource(1, Source.single(entityRec.toEntity))
       case None            => CountAndSource(0, Source.empty)
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategy.scala
@@ -1,7 +1,9 @@
 package org.broadinstitute.dsde.rawls.entities.compact.entityQuery
 
+import akka.http.scaladsl.model.StatusCodes
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
-import org.broadinstitute.dsde.rawls.model.EntityQuery
+import org.broadinstitute.dsde.rawls.model.{EntityQuery, ErrorReport}
 import slick.jdbc.TransactionIsolation.ReadCommitted
 
 import java.util.UUID
@@ -13,18 +15,27 @@ import scala.concurrent.{ExecutionContext, Future}
 class SearchStrategy(override val repository: CompactEntityRepository,
                      workspaceId: UUID,
                      entityType: String,
-                     entityQuery: EntityQuery
+                     entityQuery: EntityQuery,
+                     filterTerms: Seq[String]
 )(implicit val executionContext: ExecutionContext)
     extends EntityQueryStrategy {
-  override def getCountAndSource: Future[CountAndSource] =
+  override def getCountAndSource: Future[CountAndSource] = {
+    if (filterTerms.isEmpty) {
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.BadRequest, "filterTerms must be defined for SearchStrategy")
+      )
+    }
     repository.dataSource
       .inTransaction(ReadCommitted) { _ =>
-        repository.queries.countEntitiesWithFilterTerms(workspaceId, entityType, entityQuery)
+        repository.queries.countEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, filterTerms)
       }
       .map { count =>
         CountAndSource(
           count,
-          streamQuery(count, repository.queries.queryEntitiesWithFilterTerms(workspaceId, entityType, entityQuery))
+          streamQuery(count,
+                      repository.queries.queryEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, filterTerms)
+          )
         )
       }
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -6,6 +6,7 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeEntityReference,
   AttributeEntityReferenceList,
   AttributeName,
+  AttributeNull,
   AttributeNumber,
   AttributeString,
   AttributeValue,
@@ -14,8 +15,11 @@ import org.broadinstitute.dsde.rawls.model.{
   EntityColumnFilter,
   EntityQuery,
   FilterOperators,
-  SortDirections
+  SortDirections,
+  WorkspaceFieldSpecs
 }
+import slick.dbio.Effect.Read
+import slick.sql.SqlStreamingAction
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
@@ -593,6 +597,18 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     actual.map(_.toEntity) should contain theSameElementsInOrderAs List(entity4, entity2, entity1, entity3)
   }
 
+  it should "respect desired fields" in withMinimalTestDatabase { _ =>
+    val columnFilter = EntityColumnFilter(AttributeName.withDefaultNS("foo"), "foo")
+    testDesiredFields(None, Some(columnFilter)) { (entityType, entityQuery) =>
+      q.queryEntitiesWithColumnFilter(
+        wsid,
+        entityType,
+        entityQuery,
+        columnFilter
+      )
+    }
+  }
+
   behavior of "queryEntitiesWithFilterTerms"
 
   it should "return the entities with filter terms FilterOperators.And sorted by name" in withMinimalTestDatabase { _ =>
@@ -741,6 +757,16 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       actual.map(_.toEntity) should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(
         _.attributes(sortAttrName).asInstanceOf[AttributeNumber].value
       )
+  }
+
+  it should "respect desired fields" in withMinimalTestDatabase { _ =>
+    testDesiredFields(Some("foo"), None) { (entityType, entityQuery) =>
+      q.queryEntitiesWithFilterTerms(
+        wsid,
+        entityType,
+        entityQuery
+      )
+    }
   }
 
   behavior of "countEntitiesWithFilterTerms"
@@ -941,6 +967,16 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     actual.map(_.toEntity) should contain theSameElementsInOrderAs List(entity4, entity2, entity1, entity3)
   }
 
+  it should "respect desired fields" in withMinimalTestDatabase { _ =>
+    testDesiredFields(None, None) { (entityType, entityQuery) =>
+      q.queryEntitiesWithNoFilter(
+        wsid,
+        entityType,
+        entityQuery
+      )
+    }
+  }
+
   // ====================================================================================================
   //  helpers for tests
   // ====================================================================================================
@@ -990,4 +1026,47 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     }
   }
 
+  def testDesiredFields(filterTerms: Option[String], columnFilter: Option[EntityColumnFilter])(
+    testQuery: (String, EntityQuery) => SqlStreamingAction[Seq[CompactEntityRecord], CompactEntityRecord, Read]
+  ): Unit = {
+    val entityType = "entityType"
+    val columnFilterAttr = AttributeName.withDefaultNS("foo")
+    val desiredColumnAttr1 = AttributeName.withDefaultNS("bar")
+    val desiredColumnAttr2 = AttributeName.withDefaultNS("baz")
+    val entity1 =
+      Entity(UUID.randomUUID().toString,
+        entityType,
+        Map(columnFilterAttr -> AttributeString("foo"), desiredColumnAttr1 -> AttributeString("bar"))
+      )
+    val entity2 =
+      Entity(
+        UUID.randomUUID().toString,
+        entityType,
+        Map(columnFilterAttr -> AttributeString("foo"),
+          desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux")))
+        )
+      )
+    insertAndGet(entity1)
+    insertAndGet(entity2)
+
+    val entityQuery = EntityQuery(
+      1,
+      10,
+      Attributable.nameReservedAttribute,
+      SortDirections.Ascending,
+      filterTerms,
+      columnFilter = columnFilter,
+      fields = WorkspaceFieldSpecs(Some(Set(toDelimitedName(desiredColumnAttr1), toDelimitedName(desiredColumnAttr2))))
+    )
+    val actual = runAndWait(testQuery(entityType, entityQuery))
+
+    actual.map(_.toEntity) should contain theSameElementsAs List(
+      entity1.copy(attributes = Map(desiredColumnAttr1 -> AttributeString("bar"), desiredColumnAttr2 -> AttributeNull)),
+      entity2.copy(attributes =
+        Map(desiredColumnAttr1 -> AttributeNull,
+          desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux")))
+        )
+      )
+    )
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -480,7 +480,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
           columnFilter
         )
       )
-      actual.map(_.toEntity) should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(_.name)
+      actual should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(_.name)
     }
   }
 
@@ -535,7 +535,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
           columnFilter
         )
       )
-      actual.map(_.toEntity) should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(
+      actual should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(
         _.attributes(sortAttrName).asInstanceOf[AttributeNumber].value
       )
     }
@@ -594,7 +594,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
         columnFilter
       )
     )
-    actual.map(_.toEntity) should contain theSameElementsInOrderAs List(entity4, entity2, entity1, entity3)
+    actual should contain theSameElementsInOrderAs List(entity4, entity2, entity1, entity3)
   }
 
   it should "respect desired fields" in withMinimalTestDatabase { _ =>
@@ -655,7 +655,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
         )
       )
     )
-    actual.map(_.toEntity) should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(_.name)
+    actual should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(_.name)
   }
 
   it should "return the entities with filter terms FilterOperators.Or sorted by name" in withMinimalTestDatabase { _ =>
@@ -689,7 +689,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
         )
       )
     )
-    actual.map(_.toEntity) should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(_.name)
+    actual should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(_.name)
   }
 
   it should "return the entities with filter terms FilterOperators.And sorted by attribute" in withMinimalTestDatabase {
@@ -754,7 +754,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
           )
         )
       )
-      actual.map(_.toEntity) should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(
+      actual should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(
         _.attributes(sortAttrName).asInstanceOf[AttributeNumber].value
       )
   }
@@ -896,7 +896,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
         EntityQuery(1, 10, Attributable.nameReservedAttribute, SortDirections.Ascending, None)
       )
     )
-    actual.map(_.toEntity) should contain theSameElementsInOrderAs List(entity1, entity3, entity4).sortBy(_.name)
+    actual should contain theSameElementsInOrderAs List(entity1, entity3, entity4).sortBy(_.name)
   }
 
   it should "return the entities with no filter sorted by attribute" in withMinimalTestDatabase { _ =>
@@ -924,7 +924,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
         EntityQuery(1, 10, toDelimitedName(sortAttrName), SortDirections.Ascending, None)
       )
     )
-    actual.map(_.toEntity) should contain theSameElementsInOrderAs List(entity1, entity3, entity4).sortBy(
+    actual should contain theSameElementsInOrderAs List(entity1, entity3, entity4).sortBy(
       _.attributes(sortAttrName).asInstanceOf[AttributeNumber].value
     )
   }
@@ -964,7 +964,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
         EntityQuery(1, 10, toDelimitedName(sortAttrName), SortDirections.Ascending, None)
       )
     )
-    actual.map(_.toEntity) should contain theSameElementsInOrderAs List(entity4, entity2, entity1, entity3)
+    actual should contain theSameElementsInOrderAs List(entity4, entity2, entity1, entity3)
   }
 
   it should "respect desired fields" in withMinimalTestDatabase { _ =>
@@ -1027,7 +1027,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
   }
 
   def testDesiredFields(filterTerms: Option[String], columnFilter: Option[EntityColumnFilter])(
-    testQuery: (String, EntityQuery) => SqlStreamingAction[Seq[CompactEntityRecord], CompactEntityRecord, Read]
+    testQuery: (String, EntityQuery) => SqlStreamingAction[Seq[Entity], Entity, Read]
   ): Unit = {
     val entityType = "entityType"
     val columnFilterAttr = AttributeName.withDefaultNS("foo")
@@ -1035,15 +1035,15 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val desiredColumnAttr2 = AttributeName.withDefaultNS("baz")
     val entity1 =
       Entity(UUID.randomUUID().toString,
-        entityType,
-        Map(columnFilterAttr -> AttributeString("foo"), desiredColumnAttr1 -> AttributeString("bar"))
+             entityType,
+             Map(columnFilterAttr -> AttributeString("foo"), desiredColumnAttr1 -> AttributeString("bar"))
       )
     val entity2 =
       Entity(
         UUID.randomUUID().toString,
         entityType,
         Map(columnFilterAttr -> AttributeString("foo"),
-          desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux")))
+            desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux")))
         )
       )
     insertAndGet(entity1)
@@ -1060,11 +1060,11 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     )
     val actual = runAndWait(testQuery(entityType, entityQuery))
 
-    actual.map(_.toEntity) should contain theSameElementsAs List(
+    actual should contain theSameElementsAs List(
       entity1.copy(attributes = Map(desiredColumnAttr1 -> AttributeString("bar"), desiredColumnAttr2 -> AttributeNull)),
       entity2.copy(attributes =
         Map(desiredColumnAttr1 -> AttributeNull,
-          desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux")))
+            desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux")))
         )
       )
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -652,7 +652,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
                     SortDirections.Ascending,
                     Some("foo bAr"),
                     FilterOperators.And
-        )
+        ),
+        Seq("foo", "bAr")
       )
     )
     actual should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(_.name)
@@ -686,7 +687,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
                     SortDirections.Ascending,
                     Some("foo bAr"),
                     FilterOperators.Or
-        )
+        ),
+        Seq("foo", "bAr")
       )
     )
     actual should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(_.name)
@@ -751,7 +753,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
                       SortDirections.Ascending,
                       Some("foo bAr"),
                       FilterOperators.And
-          )
+          ),
+          Seq("foo", "bAr")
         )
       )
       actual should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(
@@ -764,7 +767,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       q.queryEntitiesWithFilterTerms(
         wsid,
         entityType,
-        entityQuery
+        entityQuery,
+        entityQuery.filterTerms.map(_.split(" ").toSeq).getOrElse(Seq.empty)
       )
     }
   }
@@ -812,7 +816,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
                     SortDirections.Ascending,
                     Some("foo bAr"),
                     FilterOperators.And
-        )
+        ),
+        Seq("foo", "bAr")
       )
     )
     actual shouldBe 2
@@ -846,7 +851,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
                     SortDirections.Ascending,
                     Some("foo bAr"),
                     FilterOperators.Or
-        )
+        ),
+        Seq("foo", "bAr")
       )
     )
     actual shouldBe 2

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/AllEntitiesStrategySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/AllEntitiesStrategySpec.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.stream.scaladsl.Sink
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{CompactEntityRecord, TestDriverComponentWithFlatSpecAndMatchers}
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
-import org.broadinstitute.dsde.rawls.model.{EntityQuery, SortDirections}
+import org.broadinstitute.dsde.rawls.model.{Entity, EntityQuery, SortDirections}
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.mockito.Mockito.when
 import slick.jdbc.GetResult
@@ -26,8 +26,8 @@ class AllEntitiesStrategySpec
     when(mockRepository.dataSource).thenReturn(slickDataSource)
     when(mockRepository.queries).thenReturn(mockQuery)
 
-    val testValue = CompactEntityRecord(0, "name", "type", UUID.randomUUID(), 1, false, None)
-    implicit val testCompactEntityGetter: GetResult[CompactEntityRecord] = GetResult(_ => testValue)
+    val testValue = Entity("name", "type", Map.empty)
+    implicit val testCompactEntityGetter: GetResult[Entity] = GetResult(_ => testValue)
 
     val entityQuery = EntityQuery(0, 0, "", SortDirections.Ascending, None)
     val workspaceId = UUID.randomUUID()
@@ -35,7 +35,7 @@ class AllEntitiesStrategySpec
     val strategy = new AllEntitiesStrategy(mockRepository, workspaceId, entityType, entityQuery, 10)
 
     when(mockRepository.queries.queryEntitiesWithNoFilter(workspaceId, entityType, entityQuery))
-      .thenReturn(sql"SELECT 1".as[CompactEntityRecord])
+      .thenReturn(sql"SELECT 1".as[Entity])
 
     val testFuture = for {
       countAndSource <- strategy.getCountAndSource

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategySpec.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
 import org.broadinstitute.dsde.rawls.model.{
   Attributable,
   AttributeName,
+  Entity,
   EntityColumnFilter,
   EntityQuery,
   SortDirections
@@ -87,14 +88,14 @@ class EntityQueryStrategySpec
 
   it should "return a non-empty source when count is greater than 0" in {
     import slick.jdbc.MySQLProfile.api._
-    val testValue = CompactEntityRecord(0, "name", "type", UUID.randomUUID(), 1, false, None)
-    implicit val testCompactEntityGetter: GetResult[CompactEntityRecord] = GetResult(_ => testValue)
+    val testValue = Entity("name", "type", Map.empty)
+    implicit val testCompactEntityGetter: GetResult[Entity] = GetResult(_ => testValue)
 
     val strategy = new EntityQueryStrategy {
       override val repository: CompactEntityRepository = mock[CompactEntityRepository]
       override def getCountAndSource: Future[CountAndSource] = {
         when(repository.dataSource).thenReturn(slickDataSource)
-        Future.successful(CountAndSource(1, streamQuery(1, sql"SELECT 1".as[CompactEntityRecord])))
+        Future.successful(CountAndSource(1, streamQuery(1, sql"SELECT 1".as[Entity])))
       }
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByColumnStrategySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByColumnStrategySpec.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.stream.scaladsl.Sink
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{CompactEntityRecord, TestDriverComponentWithFlatSpecAndMatchers}
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
-import org.broadinstitute.dsde.rawls.model.{AttributeName, EntityColumnFilter, EntityQuery, SortDirections}
+import org.broadinstitute.dsde.rawls.model.{AttributeName, Entity, EntityColumnFilter, EntityQuery, SortDirections}
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.mockito.Mockito.when
 import slick.jdbc.GetResult
@@ -26,8 +26,8 @@ class FilterByColumnStrategySpec
     when(mockRepository.dataSource).thenReturn(slickDataSource)
     when(mockRepository.queries).thenReturn(mockQuery)
 
-    val testValue = CompactEntityRecord(0, "name", "type", UUID.randomUUID(), 1, false, None)
-    implicit val testCompactEntityGetter: GetResult[CompactEntityRecord] = GetResult(_ => testValue)
+    val testValue = Entity("name", "type", Map.empty)
+    implicit val testCompactEntityGetter: GetResult[Entity] = GetResult(_ => testValue)
 
     val columnFilter = EntityColumnFilter(AttributeName.withDefaultNS("name"), "test")
     val entityQuery = EntityQuery(0, 0, "", SortDirections.Ascending, None, columnFilter = Some(columnFilter))
@@ -38,7 +38,7 @@ class FilterByColumnStrategySpec
     when(mockRepository.queries.countEntitiesWithColumnFilter(workspaceId, entityType, columnFilter))
       .thenReturn(DBIO.successful(10))
     when(mockRepository.queries.queryEntitiesWithColumnFilter(workspaceId, entityType, entityQuery, columnFilter))
-      .thenReturn(sql"SELECT 1".as[CompactEntityRecord])
+      .thenReturn(sql"SELECT 1".as[Entity])
 
     val testFuture = for {
       countAndSource <- strategy.getCountAndSource

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByNameStrategySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByNameStrategySpec.scala
@@ -42,7 +42,7 @@ class FilterByNameStrategySpec
       results <- countAndSource.source.runWith(Sink.seq)
     } yield (countAndSource.count, results)
     Await.result(testFuture, Duration.Inf)._1 shouldBe 1
-    Await.result(testFuture, Duration.Inf)._2 should contain theSameElementsAs Seq(testValue)
+    Await.result(testFuture, Duration.Inf)._2 should contain theSameElementsAs Seq(testValue.toEntity)
   }
 
   it should "return 0 and empty when there is no match" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategySpec.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.stream.scaladsl.Sink
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{CompactEntityRecord, TestDriverComponentWithFlatSpecAndMatchers}
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
-import org.broadinstitute.dsde.rawls.model.{EntityQuery, SortDirections}
+import org.broadinstitute.dsde.rawls.model.{Entity, EntityQuery, SortDirections}
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.mockito.Mockito.when
 import slick.jdbc.GetResult
@@ -26,8 +26,8 @@ class SearchStrategySpec
     when(mockRepository.dataSource).thenReturn(slickDataSource)
     when(mockRepository.queries).thenReturn(mockQuery)
 
-    val testValue = CompactEntityRecord(0, "name", "type", UUID.randomUUID(), 1, false, None)
-    implicit val testCompactEntityGetter: GetResult[CompactEntityRecord] = GetResult(_ => testValue)
+    val testValue = Entity("name", "type", Map.empty)
+    implicit val testCompactEntityGetter: GetResult[Entity] = GetResult(_ => testValue)
 
     val entityQuery = EntityQuery(0, 0, "", SortDirections.Ascending, Some("test"))
     val workspaceId = UUID.randomUUID()
@@ -37,7 +37,7 @@ class SearchStrategySpec
     when(mockRepository.queries.countEntitiesWithFilterTerms(workspaceId, entityType, entityQuery))
       .thenReturn(DBIO.successful(10))
     when(mockRepository.queries.queryEntitiesWithFilterTerms(workspaceId, entityType, entityQuery))
-      .thenReturn(sql"SELECT 1".as[CompactEntityRecord])
+      .thenReturn(sql"SELECT 1".as[Entity])
 
     val testFuture = for {
       countAndSource <- strategy.getCountAndSource

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategySpec.scala
@@ -32,11 +32,11 @@ class SearchStrategySpec
     val entityQuery = EntityQuery(0, 0, "", SortDirections.Ascending, Some("test"))
     val workspaceId = UUID.randomUUID()
     val entityType = "testType"
-    val strategy = new SearchStrategy(mockRepository, workspaceId, entityType, entityQuery)
+    val strategy = new SearchStrategy(mockRepository, workspaceId, entityType, entityQuery, Seq("test"))
 
-    when(mockRepository.queries.countEntitiesWithFilterTerms(workspaceId, entityType, entityQuery))
+    when(mockRepository.queries.countEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, Seq("test")))
       .thenReturn(DBIO.successful(10))
-    when(mockRepository.queries.queryEntitiesWithFilterTerms(workspaceId, entityType, entityQuery))
+    when(mockRepository.queries.queryEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, Seq("test")))
       .thenReturn(sql"SELECT 1".as[Entity])
 
     val testFuture = for {

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -437,7 +437,6 @@ case class EntityQuery(page: Int,
 ) {
   // these are defs so the json formatter will ignore them
   def offset: Int = (page - 1) * pageSize
-  def filterTermsList: Seq[String] = filterTerms.map(_.split(" ").toSeq).getOrElse(Seq.empty)
 }
 
 case class EntityQueryResultMetadata(unfilteredCount: Int, filteredCount: Int, filteredPageCount: Int)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-425

2 changes:
1. When a list of fields are specified by the entity query, return a json object from the database with only those fields. The prior code returned all fields from the database then filtered within the application. This prevents possibly lengthy arrays, etc. from being returned from the database only to be ignored 
2. Reduce the fields selected from the entity table. Drop `id`, `workspace_id`, `record_version` and `deleted` which are unused. This is minor but electrons cost money.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
