### PR TITLE
CORE-428: refactor batchUpsert code to standalone trait

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -3,43 +3,19 @@ package org.broadinstitute.dsde.rawls.entities.compact
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.Source
 import com.google.common.annotations.VisibleForTesting
-import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.LookupExpression
 import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, ExpressionEvaluationContext, ExpressionValidator}
+import org.broadinstitute.dsde.rawls.entities.compact.batch.BatchHandling
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.{CountAndSource, EntityQueryStrategy}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{
-  DataEntityException,
-  EntityNotFoundException,
-  EntityReferenceNotFoundException
-}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityNotFoundException, EntityReferenceNotFoundException}
 import org.broadinstitute.dsde.rawls.entities.{EntityRequestArguments, EntityUtils}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
-import org.broadinstitute.dsde.rawls.model.{
-  Attributable,
-  AttributeEntityReference,
-  AttributeEntityReferenceList,
-  AttributeName,
-  AttributeRename,
-  AttributeUpdateOperations,
-  AttributeValue,
-  Entity,
-  EntityCopyResponse,
-  EntityQuery,
-  EntityQueryResponse,
-  EntityQueryResultMetadata,
-  EntityTypeMetadata,
-  EntityTypeRename,
-  ErrorReport,
-  RawlsRequestContext,
-  SubmissionValidationEntityInputs,
-  Workspace
-}
-import org.broadinstitute.dsde.rawls.util.AttributeSupport
+import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeRename, AttributeUpdateOperations, AttributeValue, Entity, EntityCopyResponse, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntityTypeMetadata, EntityTypeRename, ErrorReport, RawlsRequestContext, SubmissionValidationEntityInputs, Workspace}
 import slick.dbio.DBIO
 import slick.jdbc.ResultSetConcurrency.ReadOnly
 import slick.jdbc.TransactionIsolation.ReadCommitted
@@ -56,14 +32,13 @@ import scala.util.Try
   * @param executionContext scala concurrency context
   */
 class CompactEntityProvider(requestArguments: EntityRequestArguments,
-                            repository: CompactEntityRepository,
+                            val repository: CompactEntityRepository,
                             config: CompactEntityProviderConfig = CompactEntityProviderConfig()
 )(implicit
   protected val executionContext: ExecutionContext,
-  actorSystem: ActorSystem
+  implicit val actorSystem: ActorSystem
 ) extends EntityProvider
-    with AttributeSupport
-    with LazyLogging {
+    with BatchHandling {
   override def entityStoreId: Option[String] = None // unused
 
   val workspaceId: UUID = requestArguments.workspace.workspaceIdAsUUID // shorthand for methods below
@@ -78,46 +53,10 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
     entityUpdates: Source[EntityUpdateDefinition, _],
     parentContext: RawlsRequestContext
   ): Future[Int] = {
-
-    // Translate the input stream entityUpdates to a stream of Entity by applying the updates to
-    // a pre-existing entity (for updates) or a blank entity (for inserts)
-    val entitySource: Source[Entity, _] = entityUpdates.map { updateDefinition =>
-      // TODO CORE-428: for updates, look ahead (some quantity) in the update definitions and
-      //   retrieve the existing entities from the db
-      // for inserts, start with an empty entity
-      val baseEntity = Entity(updateDefinition.name, updateDefinition.entityType, Map())
-      // update the starting entity with the user's operations
-      applyOperationsToEntity(baseEntity, updateDefinition.operations)
-    }
-
-    // Group the entities-to-be-saved into batches to optimize our SQL interactions
-    val batches: Source[Seq[Entity], _] = entitySource.groupedWeighted(config.maxSqlBatchSizeBytes)(calculateEntitySize)
-
-    // For each batch, generate the db action to write it to the database
-    val batchActionsSource: Source[ReadWriteAction[Int], _] = batches
-      .map { batch =>
-        logger.info(s"batch upsert: batch of ${batch.size} entities")
-        insertBatch(batch)
-      }
-
-    // Materialize the batch actions into a sequence and convert to a single DBIO action
-    val batchActionsF: Future[ReadWriteAction[Int]] = batchActionsSource
-      .runWith(Sink.seq)
-      .map(DBIO.sequence(_).map(_.sum))
-
-    // Convert the Future[ReadWriteAction] to a Source[Int] by executing the db actions.
-    // Note that since all the ReadWriteActions are fused via DBIO.sequence above,
-    // there is only one action to execute inside a transaction.
-    val dbResultsSource: Source[Int, _] = Source.futureSource(batchActionsF.map { dbAction =>
-      Source.future(repository.dataSource.inTransaction(_ => dbAction))
-    })
-
-    // Finally, run the Source.
-    val dbResults: Future[Int] = dbResultsSource.runWith(Sink.head)
-
+    // perform the upserts
+    val dbResults: Future[Int] = handleUpdates(entityUpdates, allowUpsert = true, config, parentContext)
     // Fire-and-forget an update to the workspace's last-modified date; no need to wait for it to complete
     withWorkspaceLastModified(dbResults)
-
     // and return
     dbResults
   }
@@ -393,67 +332,5 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
           )
         }
     )
-
-  // approximate the byte size of this entity by looking at the character length of its JSONized attributes
-  private def calculateEntitySize(entity: Entity): Int =
-    CompactEntitySerialization.toSql(entity.attributes).compactPrint.length
-
-  private def insertBatch(batch: Seq[Entity]): ReadWriteAction[Int] = {
-
-    // nested helper method for building error responses
-    def generateReferenceError(message: String, notFounds: Set[AttributeEntityReference]) =
-      new RawlsExceptionWithErrorReport(
-        ErrorReport(
-          StatusCodes.BadRequest,
-          message,
-          notFounds.map { notFound =>
-            ErrorReport(s"${notFound.entityType} ${notFound.entityName} not found", Seq.empty)
-          }.toSeq
-        )
-      )
-
-    for {
-      // Batch insert to ENTITY table. Save the whole batch first to handle cases where an entity in this batch
-      // has a reference to another entity in the same batch.
-      entitiesCreated <- repository.queries.batchCreateEntities(workspaceId, batch)
-
-      // find all requested references within this batch
-      allReferences = findAllReferences(batch)
-
-      // generate a combined list of entity type/name pairs for both reference sources and targets
-      lookupCriteria: Set[AttributeEntityReference] = allReferences.keys.toSet ++ allReferences.values.flatten.toSet
-
-      // look up the ids for both reference sources and targets
-      foundIds <- repository.queries.getEntityRefs(workspaceId, lookupCriteria)
-
-      // did we find all the reference sources and targets?
-      _ = if (foundIds.size != lookupCriteria.size) {
-        // here's what the query actually returned; turn this into a Set
-        val actuallyFound = foundIds.map(_.toAttributeEntityReference).toSet
-        // did we find all the reference targets?
-        val notFoundReferenceTargets = allReferences.values.flatten.toSet diff actuallyFound
-        if (notFoundReferenceTargets.nonEmpty) {
-          throw generateReferenceError("Could not resolve some entity references", notFoundReferenceTargets)
-        }
-        // did we find all the reference sources? This should never happen, but let's be defensive
-        val notFoundReferenceSources = allReferences.keys.toSet diff actuallyFound
-        if (notFoundReferenceSources.nonEmpty)
-          throw generateReferenceError("Could not resolve some entity sources", notFoundReferenceSources)
-      }
-
-      // build a lookup table for the ids we found
-      idLookup: Map[AttributeEntityReference, Long] = foundIds.map { rec =>
-        rec.toAttributeEntityReference -> rec.id
-      }.toMap
-
-      // rehydrate the looked-up ids into sources and targets (from_id, to_id)
-      referencesToInsert: Set[RefPointers] = allReferences.map { case (from, tos) =>
-        val toIds = tos.map(idLookup).toSet
-        RefPointers(idLookup(from), toIds)
-      }.toSet
-      // insert the references into the ENTITY_REFS table.
-      _ <- repository.queries.upsertReferences(referencesToInsert)
-    } yield entitiesCreated
-  }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -21,7 +21,26 @@ import org.broadinstitute.dsde.rawls.entities.exceptions.{
 import org.broadinstitute.dsde.rawls.entities.{EntityRequestArguments, EntityUtils}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeRename, AttributeUpdateOperations, AttributeValue, Entity, EntityCopyResponse, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntityTypeMetadata, EntityTypeRename, ErrorReport, RawlsRequestContext, SubmissionValidationEntityInputs, Workspace}
+import org.broadinstitute.dsde.rawls.model.{
+  Attributable,
+  AttributeEntityReference,
+  AttributeEntityReferenceList,
+  AttributeName,
+  AttributeRename,
+  AttributeUpdateOperations,
+  AttributeValue,
+  Entity,
+  EntityCopyResponse,
+  EntityQuery,
+  EntityQueryResponse,
+  EntityQueryResultMetadata,
+  EntityTypeMetadata,
+  EntityTypeRename,
+  ErrorReport,
+  RawlsRequestContext,
+  SubmissionValidationEntityInputs,
+  Workspace
+}
 import slick.dbio.DBIO
 import slick.jdbc.ResultSetConcurrency.ReadOnly
 import slick.jdbc.TransactionIsolation.ReadCommitted

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -1,0 +1,143 @@
+package org.broadinstitute.dsde.rawls.entities.compact.batch
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.StatusCodes
+import akka.stream.scaladsl.{Sink, Source}
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{ReadWriteAction, RefPointers}
+import org.broadinstitute.dsde.rawls.entities.compact.{
+  CompactEntityProvider,
+  CompactEntityProviderConfig,
+  CompactEntityRepository,
+  CompactEntitySerialization
+}
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, ErrorReport, RawlsRequestContext}
+import org.broadinstitute.dsde.rawls.util.AttributeSupport
+import slick.dbio.DBIO
+
+import scala.concurrent.Future
+
+/**
+  * Support for batchUpsert/batchUpdate; to be mixed in to CompactEntityProvider
+  */
+trait BatchHandling extends LazyLogging with AttributeSupport {
+
+  // this trait is only extended by CompactEntityProvider
+  this: CompactEntityProvider =>
+
+  implicit val actorSystem: ActorSystem
+  val repository: CompactEntityRepository
+
+  /**
+    * process the incoming EntityUpdateDefinitions and persist to the database
+    */
+  def handleUpdates(entityUpdates: Source[EntityUpdateDefinition, _],
+                    allowUpsert: Boolean,
+                    config: CompactEntityProviderConfig,
+                    parentContext: RawlsRequestContext
+  ): Future[Int] = {
+    // Translate the input stream entityUpdates to a stream of Entity by applying the updates to
+    // a pre-existing entity (for updates) or a blank entity (for inserts)
+    val entitySource: Source[Entity, _] = entityUpdates.map { updateDefinition =>
+      // TODO CORE-428: for updates, look ahead (some quantity) in the update definitions and
+      //   retrieve the existing entities from the db
+      // for inserts, start with an empty entity
+      val baseEntity = Entity(updateDefinition.name, updateDefinition.entityType, Map())
+      // update the starting entity with the user's operations
+      applyOperationsToEntity(baseEntity, updateDefinition.operations)
+    }
+
+    // Group the entities-to-be-saved into batches to optimize our SQL interactions
+    val batches: Source[Seq[Entity], _] = entitySource.groupedWeighted(config.maxSqlBatchSizeBytes)(calculateEntitySize)
+
+    // For each batch, generate the db action to write it to the database
+    val batchActionsSource: Source[ReadWriteAction[Int], _] = batches
+      .map { batch =>
+        logger.info(s"batch upsert: batch of ${batch.size} entities")
+        insertBatch(batch)
+      }
+
+    // Materialize the batch actions into a sequence and convert to a single DBIO action
+    val batchActionsF: Future[ReadWriteAction[Int]] = batchActionsSource
+      .runWith(Sink.seq)
+      .map(DBIO.sequence(_).map(_.sum))
+
+    // Convert the Future[ReadWriteAction] to a Source[Int] by executing the db actions.
+    // Note that since all the ReadWriteActions are fused via DBIO.sequence above,
+    // there is only one action to execute inside a transaction.
+    val dbResultsSource: Source[Int, _] = Source.futureSource(batchActionsF.map { dbAction =>
+      Source.future(repository.dataSource.inTransaction(_ => dbAction))
+    })
+
+    // Finally, run the Source.
+    val dbResults: Future[Int] = dbResultsSource.runWith(Sink.head)
+
+    dbResults
+  }
+
+  /** approximate the byte size of this entity by looking at the character length of its JSONized attributes */
+  private def calculateEntitySize(entity: Entity): Int =
+    CompactEntitySerialization.toSql(entity.attributes).compactPrint.length
+
+  /** write this batch of Entity to the database */
+  private def insertBatch(batch: Seq[Entity]): ReadWriteAction[Int] = {
+
+    // nested helper method for building error responses
+    def generateReferenceError(message: String, notFounds: Set[AttributeEntityReference]) =
+      new RawlsExceptionWithErrorReport(
+        ErrorReport(
+          StatusCodes.BadRequest,
+          message,
+          notFounds.map { notFound =>
+            ErrorReport(s"${notFound.entityType} ${notFound.entityName} not found", Seq.empty)
+          }.toSeq
+        )
+      )
+
+    for {
+      // Batch insert to ENTITY table. Save the whole batch first to handle cases where an entity in this batch
+      // has a reference to another entity in the same batch.
+      entitiesCreated <- repository.queries.batchCreateEntities(workspaceId, batch)
+
+      // find all requested references within this batch
+      allReferences = findAllReferences(batch)
+
+      // generate a combined list of entity type/name pairs for both reference sources and targets
+      lookupCriteria: Set[AttributeEntityReference] = allReferences.keys.toSet ++ allReferences.values.flatten.toSet
+
+      // look up the ids for both reference sources and targets
+      foundIds <- repository.queries.getEntityRefs(workspaceId, lookupCriteria)
+
+      // did we find all the reference sources and targets?
+      _ = if (foundIds.size != lookupCriteria.size) {
+        // here's what the query actually returned; turn this into a Set
+        val actuallyFound = foundIds.map(_.toAttributeEntityReference).toSet
+        // did we find all the reference targets?
+        val notFoundReferenceTargets = allReferences.values.flatten.toSet diff actuallyFound
+        if (notFoundReferenceTargets.nonEmpty) {
+          throw generateReferenceError("Could not resolve some entity references", notFoundReferenceTargets)
+        }
+        // did we find all the reference sources? This should never happen, but let's be defensive
+        val notFoundReferenceSources = allReferences.keys.toSet diff actuallyFound
+        if (notFoundReferenceSources.nonEmpty)
+          throw generateReferenceError("Could not resolve some entity sources", notFoundReferenceSources)
+      }
+
+      // build a lookup table for the ids we found
+      idLookup: Map[AttributeEntityReference, Long] = foundIds.map { rec =>
+        rec.toAttributeEntityReference -> rec.id
+      }.toMap
+
+      // rehydrate the looked-up ids into sources and targets (from_id, to_id)
+      referencesToInsert: Set[RefPointers] = allReferences.map { case (from, tos) =>
+        val toIds = tos.map(idLookup).toSet
+        RefPointers(idLookup(from), toIds)
+      }.toSet
+      // insert the references into the ENTITY_REFS table.
+      _ <- repository.queries.upsertReferences(referencesToInsert)
+    } yield entitiesCreated
+  }
+
+}


### PR DESCRIPTION
Ticket: CORE-428

Moves the implementation for batchUpsert into a separate trait for organization. No functional changes.