### PR TITLE
CORE-494: k6 test cleanup

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -35,5 +35,7 @@ To test against different workspaces, change the value of the
 *IMPORTANT:*
 * The performance tests assume that three entities of type `target` with names `one`, `two`,
 and `three` already exist in the workspaces under test. Without those entities, tests will fail.
+* The performance tests assume that some entities of type `file_inventory` already exist in the
+workspaces under test. Without those entities, tests will fail.
 * The performance tests assume that the "test" workspace has Quicksilver data tables enabled; you can
 enable them via the `CompactDataTables` workspace setting.

--- a/k6/quicksilver.js
+++ b/k6/quicksilver.js
@@ -88,8 +88,9 @@ export const options = {
 // paginated search; this is the API that populates data tables in the UI
 export function entityQuery() {
   group(`${__ENV.TEST_GROUP}`, function() {
+    // page size 100 replicates what Terra UI asks for
     let res = http.get(
-      `${workspaceRoot(__ENV.TEST_GROUP)}/entityQuery/target?page=1&pageSize=10&sortField=name&sortDirection=asc&filterOperator=and`,
+      `${workspaceRoot(__ENV.TEST_GROUP)}/entityQuery/file_inventory?page=1&pageSize=100&sortField=name&sortDirection=asc&filterOperator=and`,
       defaultParams);
     check(res, { "status is 200": (res) => res.status === 200 });
     sleep(.1);

--- a/k6/quicksilver.js
+++ b/k6/quicksilver.js
@@ -158,12 +158,30 @@ export function getEntityMetadata() {
   });
 }
 
+// delete all entities of a given type
+export function deleteTable(testGroup, tableName) {
+  let res = http.del(
+      `${workspaceRoot(testGroup)}/entityTypes/${tableName}`, null, defaultParams);
+  return res.status;
+}
+
 export function setup() {
   // setup code, such as inserting test data before the test scenarios run
 }
 
+// teardown code, runs after all test scenarios are done
 export function teardown(data) {
-  // teardown code, such as deleting data created by test scenarios
+
+  const testGroups = ['baseline', 'test'];
+  const tablesToDelete = ['loadTestPuts'];
+
+  for (const testGroup of testGroups) {
+    for (const table of tablesToDelete) {
+      console.log(`deleting table '${table}' for test group '${testGroup}' ...`)
+      const statusCode = deleteTable(testGroup, table);
+      console.log(`... deleteTable ${testGroup}/${table} result is ${statusCode}`)
+    }
+  }
 }
 
 // helper functions


### PR DESCRIPTION
Ticket: CORE-494

* adds code inside the `teardown()` method to clean up the entities created by the `putEntity` test scenarios
* slightly tweaks the `entityQuery` scenarios to use more realistic data and use a larger page size

As part of CORE-494 I also updated the test workspaces in staging to have more data:
* https://bvdp-saturn-staging.appspot.com/#workspaces/saturn-integration-test-stage/DO-NOT-DELETE-quicksilver-baseline/data
* https://bvdp-saturn-staging.appspot.com/#workspaces/saturn-integration-test-stage/DO-NOT-DELETE-quicksilver-test/data

running the perf tests shows output from the `teardown()` method like this:
```
DEBU[0069] Running teardown()...                        
INFO[0069] deleting table 'loadTestPuts' for test group 'baseline' ...  source=console
INFO[0069] ... deleteTable baseline/loadTestPuts result is 204  source=console
INFO[0069] deleting table 'loadTestPuts' for test group 'test' ...  source=console
INFO[0069] ... deleteTable test/loadTestPuts result is 204  source=console
DEBU[0069] Test finished cleanly
```

and the test workspaces look like this:
![Screenshot 14-05-2025 at 16 04](https://github.com/user-attachments/assets/f09ff56d-d8ae-4675-89ac-c5cae43bd202)
