### PR TITLE
[AN-558] Fix `owner can abort a launched submission` test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala
@@ -147,7 +147,7 @@ class MethodLaunchSpec
             val status = Rawls.submissions.getSubmissionStatus(billingProject, workspaceName, submissionId)
             logger.info(s"Status is $status in Submission $billingProject/$workspaceName/$submissionId")
             withClue(
-              s"Monitoring Submission $billingProject/$workspaceName/$submissionId. Waited for status Aborted."
+              s"Monitoring Submission $billingProject/$workspaceName/$submissionId. Waited for status Aborted or Aborting."
             ) {
               status._1 shouldBe "Aborted" or "Aborting"
             }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala
@@ -149,7 +149,7 @@ class MethodLaunchSpec
             withClue(
               s"Monitoring Submission $billingProject/$workspaceName/$submissionId. Waited for status Aborted or Aborting."
             ) {
-              status._1 shouldBe status._1 should (be("Aborted") or be("Aborting"))
+              status._1 should (be("Aborted") or be("Aborting"))
             }
           }
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala
@@ -149,7 +149,7 @@ class MethodLaunchSpec
             withClue(
               s"Monitoring Submission $billingProject/$workspaceName/$submissionId. Waited for status Aborted or Aborting."
             ) {
-              status._1 shouldBe "Aborted" or "Aborting"
+              status._1 shouldBe status._1 should (be("Aborted") or be("Aborting"))
             }
           }
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala
@@ -141,7 +141,7 @@ class MethodLaunchSpec
           Rawls.submissions.abortSubmission(billingProject, workspaceName, submissionId)
 
           implicit val patienceConfig: PatienceConfig =
-            PatienceConfig(timeout = scaled(Span(5, Minutes)), interval = scaled(Span(20, Seconds)))
+            PatienceConfig(timeout = scaled(Span(2, Minutes)), interval = scaled(Span(20, Seconds)))
 
           eventually {
             val status = Rawls.submissions.getSubmissionStatus(billingProject, workspaceName, submissionId)
@@ -149,7 +149,7 @@ class MethodLaunchSpec
             withClue(
               s"Monitoring Submission $billingProject/$workspaceName/$submissionId. Waited for status Aborted."
             ) {
-              status._1 shouldBe "Aborted"
+              status._1 shouldBe "Aborted" or "Aborting"
             }
           }
         }


### PR DESCRIPTION
Ticket: (https://broadworkbench.atlassian.net/browse/AN-558)
(https://broadinstitute.slack.com/archives/C07RK8KNWMV/p1747404419379529)

This test was failing with `"Abort[ing]" was not equal to "Abort[ed]"` --> if a submission is `aborting` then it satisfies the test condition that an owner can abort a submission, so this change is to test for either status and reduce the waiting window
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
