### PR TITLE
CORE-498: quicksilver perf tests for batchUpsert and delete

### DIFF
--- a/k6/batchOperations.js
+++ b/k6/batchOperations.js
@@ -16,7 +16,6 @@ export const generateBatchUpsert = (entityType, numEntities) => {
  * Create a new EntityUpdateDefinition using specified parameters.
  */
 const generateUpdateDefinition = (entityType, entityName) => {
-  // append two arrays
   const operations = constantOperations
                       .concat(semiConstantOperations())
                       .concat(customizedOperations(entityName));
@@ -32,12 +31,7 @@ const generateUpdateDefinition = (entityType, entityName) => {
  * Generate a few operations whose values depend on the input.
  */
 const customizedOperations = (id) => {
-  // Randomly select a few values from a small set of possible values
-  const activity = ["Indexing", "Alignment", "Variant Calling", "Variant Annotation"][Math.floor(Math.random() * 4)];
-  const sampleType = ["Tumor", "Normal"][Math.floor(Math.random() * 2)];
-  const age = Math.floor(Math.random() * 100);
-  const qcPassed = ["true", "false"][Math.floor(Math.random() * 2)];
-  // return operations using the selected values
+  // return operations customized to the input id
   return [{
     "op": "AddUpdateAttribute",
     "attributeName": "bai",

--- a/k6/batchOperations.js
+++ b/k6/batchOperations.js
@@ -1,0 +1,138 @@
+/**
+ * Generate a batchUpsert payload for the specified entityType and number of entities. 
+ */
+export const generateBatchUpsert = (entityType, numEntities) => {
+  // Create a batch of upsert operations
+  const batchUpsert = [];
+  for (let i = 0; i < numEntities; i++) {
+    const entityName = `entity-${i}`;
+    const entityUpdateDefinition = generateUpdateDefinition(entityType, entityName);
+    batchUpsert.push(entityUpdateDefinition);
+  }
+  return batchUpsert;
+}
+
+/**
+ * Create a new EntityUpdateDefinition using specified parameters.
+ */
+const generateUpdateDefinition = (entityType, entityName) => {
+  // append two arrays
+  const operations = constantOperations
+                      .concat(semiConstantOperations())
+                      .concat(customizedOperations(entityName));
+
+  return {
+    "entityType": entityType,
+    "name": entityName,
+    "operations": operations
+  };
+}
+
+/**
+ * Generate a few operations whose values depend on the input.
+ */
+const customizedOperations = (id) => {
+  // Randomly select a few values from a small set of possible values
+  const activity = ["Indexing", "Alignment", "Variant Calling", "Variant Annotation"][Math.floor(Math.random() * 4)];
+  const sampleType = ["Tumor", "Normal"][Math.floor(Math.random() * 2)];
+  const age = Math.floor(Math.random() * 100);
+  const qcPassed = ["true", "false"][Math.floor(Math.random() * 2)];
+  // return operations using the selected values
+  return [{
+    "op": "AddUpdateAttribute",
+    "attributeName": "bai",
+    "addUpdateAttribute": `gs://fake-bucket-name/sample-${id}.bai`
+  }, {
+    "op": "AddUpdateAttribute",
+    "attributeName": "bam",
+    "addUpdateAttribute": `gs://fake-bucket-name/sample-${id}.bam`
+  },
+  {
+    "op": "AddUpdateAttribute",
+    "attributeName": "fastq1",
+    "addUpdateAttribute": `gs://fake-bucket-name/${id}_1.fastq`
+  }, {
+    "op": "AddUpdateAttribute",
+    "attributeName": "fastq2",
+    "addUpdateAttribute": `gs://fake-bucket-name/${id}_2.fastq`
+  },
+  {
+    "op": "AddUpdateAttribute",
+    "attributeName": "participant",
+    "addUpdateAttribute": `${id}`
+  }, {
+    "op": "AddUpdateAttribute",
+    "attributeName": "sample",
+    "addUpdateAttribute": `${id}`
+  }];
+};
+
+
+/**
+ * Generate a few operations which choose randomly from a small set of possible values.
+ */
+const semiConstantOperations = () => {
+  // Randomly select a few values from a small set of possible values
+  const activity = ["Indexing", "Alignment", "Variant Calling", "Variant Annotation"][Math.floor(Math.random() * 4)];
+  const sampleType = ["Tumor", "Normal"][Math.floor(Math.random() * 2)];
+  const age = Math.floor(Math.random() * 100);
+  const qcPassed = ["true", "false"][Math.floor(Math.random() * 2)];
+  // return operations using the selected values
+  return [{
+    "op": "AddUpdateAttribute",
+    "attributeName": "activity",
+    "addUpdateAttribute": activity
+  },
+  {
+    "op": "AddUpdateAttribute",
+    "attributeName": "sampleType",
+    "addUpdateAttribute": sampleType
+  },
+  {
+    "op": "AddUpdateAttribute",
+    "attributeName": "age",
+    "addUpdateAttribute": age
+  },
+{
+    "op": "AddUpdateAttribute",
+    "attributeName": "qcPassed",
+    "addUpdateAttribute": qcPassed
+  }];
+};
+
+/** Truly constant operations; these never change */
+const constantOperations = [
+  {
+    "op": "AddUpdateAttribute",
+    "attributeName": "ref_amb",
+    "addUpdateAttribute": "gs://fake-bucket-name/Homo_sapiens_assembly19.fasta.64.amb"
+  }, {
+    "op": "AddUpdateAttribute",
+    "attributeName": "ref_ann",
+    "addUpdateAttribute": "gs://fake-bucket-name/Homo_sapiens_assembly19.fasta.64.ann"
+  }, {
+    "op": "AddUpdateAttribute",
+    "attributeName": "ref_bwt",
+    "addUpdateAttribute": "gs://fake-bucket-name/Homo_sapiens_assembly19.fasta.64.bwt"
+  }, {
+    "op": "AddUpdateAttribute",
+    "attributeName": "ref_dict",
+    "addUpdateAttribute": "gs://fake-bucket-name/Homo_sapiens_assembly19.dict"
+  }, {
+    "op": "AddUpdateAttribute",
+    "attributeName": "ref_fasta",
+    "addUpdateAttribute": "gs://fake-bucket-name/Homo_sapiens_assembly19.fasta"
+  }, {
+    "op": "AddUpdateAttribute",
+    "attributeName": "ref_intervals",
+    "addUpdateAttribute": "gs://fake-bucket-name/panel_100_genes.interval_list"
+  }, {
+    "op": "AddUpdateAttribute",
+    "attributeName": "ref_pac",
+    "addUpdateAttribute": "gs://fake-bucket-name/Homo_sapiens_assembly19.fasta.64.pac"
+  }, {
+    "op": "AddUpdateAttribute",
+    "attributeName": "ref_sa",
+    "addUpdateAttribute": "gs://fake-bucket-name/Homo_sapiens_assembly19.fasta.64.sa"
+  }
+];

--- a/k6/quicksilver.js
+++ b/k6/quicksilver.js
@@ -1,5 +1,10 @@
 import http from 'k6/http';
 import { group, sleep, check } from 'k6';
+import { generateBatchUpsert } from './batchOperations.js';
+
+/**********************************************************************
+ * Test scenarios
+ **********************************************************************/
 
 export const options = {
   // define each test scenario to be run
@@ -60,7 +65,6 @@ export const options = {
       duration: '20s',
       startTime: '44s'
     },
-
     // getEntity baseline and test run in parallel; each has three virtual users and makes as many requests as possible
     // within 20 seconds. The getEntity scenarios start after the entityQuery scenarios finish, by specifying startTime.
     getEntityBaseline: {
@@ -112,6 +116,7 @@ export const options = {
     },
     // putEntity baseline and test run in parallel; each makes a total of 20 requests, using 2 virtual users.
     // The putEntity scenarios start after the getEntityMetadata scenarios finish, by specifying startTime.
+    // the putEntity scenarios require < 5s to complete
     putEntityBaseline: {
       exec: 'putEntity',
       tags: { rawlsApi: 'putEntity' },
@@ -119,7 +124,8 @@ export const options = {
       executor: 'shared-iterations',
       vus: 2,
       iterations: 20,
-      startTime: '110s'
+      startTime: '110s',
+      maxDuration: '10s'
     },
     putEntityTest: {
       exec: 'putEntity',
@@ -129,9 +135,34 @@ export const options = {
       vus: 2,
       iterations: 20,
       startTime: '110s',
+      maxDuration: '10s'
+    },
+    // batchUpserts. These use 1 VU to serialize requests to avoid lock contention.
+    // run these tests last; they are the longest to execute.
+    batchUpsertBaseline: {
+      exec: 'batchUpsertAndDelete',
+      env: { TEST_GROUP: 'baseline' },
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 10,
+      startTime: '120s',
+      maxDuration: '15m' // baseline test may not complete in this time; we cut it off anyway
+    },
+    batchUpsertTest: {
+      exec: 'batchUpsertAndDelete',
+      env: { TEST_GROUP: 'test' },
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 10,
+      startTime: '120s',
+      maxDuration: '15m'
     },
   }
 }
+
+/**********************************************************************
+ * entityQuery
+ **********************************************************************/
 
 // paginated search; this is the API that populates data tables in the UI
 export function entityQuery() {
@@ -159,6 +190,9 @@ function entityQueryImpl(entityType, queryString) {
   });
 }
 
+/**********************************************************************
+ * get/put single entity
+ **********************************************************************/
 
 // get a single entity
 export function getEntity() {
@@ -210,6 +244,89 @@ export function putEntity() {
   });
 }
 
+/**********************************************************************
+ * batchUpsert and delete
+ **********************************************************************/
+
+/**
+ * Tests batchUpsert from empty, batchUpsert to modify existing entities,
+ * delete-by-pointer, and delete-by-type all in one go.
+ * 
+ * Since we want to test batchUpsert from empty, we need to constantly be deleting entities,
+ * otherwise we'd always be testing updates, not inserts. And since we want to test deletes,
+ * we always need entities to delete. So these go together well.
+ */
+export function batchUpsertAndDelete() {
+  const testType = "batchUpsertTest";
+  const smallUpsertSize = 250;
+  const largeUpsertSize = 4000;
+
+  // note that each request below sends a separate set of tags
+
+  // generate a small batchUpsert payload and insert it
+  const smallInitialUpsert = generateBatchUpsert(testType, smallUpsertSize);
+  const res1 = http.post(
+    `${workspaceRoot(__ENV.TEST_GROUP)}/entities/batchUpsert`,
+    JSON.stringify(smallInitialUpsert),
+    {headers: defaultHeaders, tags: { rawlsApi: 'batchUpsert', feature: 'insert', size: smallUpsertSize }});
+  check(res1, { "status is 204": (res) => res.status === 204 });
+  sleep(.1);
+
+  // re-generate the small batchUpsert payload to get some changes, and update it
+  const smallUpdate = generateBatchUpsert(testType, smallUpsertSize);
+  const res2 = http.post(
+    `${workspaceRoot(__ENV.TEST_GROUP)}/entities/batchUpsert`,
+    JSON.stringify(smallUpdate),
+    {headers: defaultHeaders, tags: { rawlsApi: 'batchUpsert', feature: 'update', size: smallUpsertSize }});
+  check(res2, { "status is 204": (res) => res.status === 204 });
+  sleep(.1);
+
+  // translate the smallUpdate into {entityType, entityName} pairs
+  // for deleteByPointer
+  const deleteByPointer = smallUpdate.map((entity) => {
+     return {
+      entityType: entity.entityType,
+      entityName: entity.name
+    }
+  });
+  const res3 = http.post(
+    `${workspaceRoot(__ENV.TEST_GROUP)}/entities/delete`,
+    JSON.stringify(deleteByPointer),
+    {headers: defaultHeaders, tags: { rawlsApi: 'deleteEntities', size: smallUpsertSize }});
+  check(res3, { "status is 204": (res) => res.status === 204 });
+  sleep(.1);
+
+  // generate a small batchUpsert payload and insert it
+  const largeInitialUpsert = generateBatchUpsert(testType, largeUpsertSize);
+  const res4 = http.post(
+    `${workspaceRoot(__ENV.TEST_GROUP)}/entities/batchUpsert`,
+    JSON.stringify(largeInitialUpsert),
+    {headers: defaultHeaders, tags: { rawlsApi: 'batchUpsert', feature: 'insert', size: largeUpsertSize }});
+  check(res4, { "status is 204": (res) => res.status === 204 });
+  sleep(.1);
+
+  // re-generate the small batchUpsert payload to get some changes, and update it
+  const largeUpdate = generateBatchUpsert(testType, largeUpsertSize);
+  const res5 = http.post(
+    `${workspaceRoot(__ENV.TEST_GROUP)}/entities/batchUpsert`,
+    JSON.stringify(largeUpdate),
+    {headers: defaultHeaders, tags: { rawlsApi: 'batchUpsert', feature: 'update', size: largeUpsertSize }});
+  check(res5, { "status is 204": (res) => res.status === 204 });
+  sleep(.1);
+
+  // delete by type
+  const res6 = http.del(
+    `${workspaceRoot(__ENV.TEST_GROUP)}/entityTypes/${testType}`, null,
+    {headers: defaultHeaders, tags: { rawlsApi: 'deleteEntitiesOfType' }});
+  check(res6, { "status is 204": (res) => res.status === 204 });
+  sleep(.1);
+}
+
+
+/**********************************************************************
+ * entity type metadata
+ **********************************************************************/
+
 // get entity type metadata
 export function getEntityMetadata() {
   metadataTest(true);
@@ -228,22 +345,18 @@ function metadataTest(useCache) {
   });
 }
 
-// delete all entities of a given type
-export function deleteTable(testGroup, tableName) {
-  let res = http.del(
-      `${workspaceRoot(testGroup)}/entityTypes/${tableName}`, null, defaultParams);
-  return res.status;
-}
+/**********************************************************************
+ * before-all / after-all callbacks
+ **********************************************************************/
+// setup code, such as inserting test data before the test scenarios run
+export function setup() {}
 
-export function setup() {
-  // setup code, such as inserting test data before the test scenarios run
-}
-
-// teardown code, runs after all test scenarios are done
+// teardown code, deletes test data after the test scenarios run
 export function teardown(data) {
 
+  // batchUpsertTest should clean up after itself; it's handled here too just in case
   const testGroups = ['baseline', 'test'];
-  const tablesToDelete = ['loadTestPuts'];
+  const tablesToDelete = ['loadTestPuts', 'batchUpsertTest'];
 
   for (const testGroup of testGroups) {
     for (const table of tablesToDelete) {
@@ -254,15 +367,28 @@ export function teardown(data) {
   }
 }
 
-// helper functions
+// delete all entities of a given type
+export function deleteTable(testGroup, tableName) {
+  let res = http.del(
+      `${workspaceRoot(testGroup)}/entityTypes/${tableName}`, null, defaultParams);
+  return res.status;
+}
+
+/**********************************************************************
+ * helper functions
+ **********************************************************************/
+
+// auth using a bearer token and send/receive JSON
 const defaultHeaders = {
     'Accept': 'application/json',
     'Content-Type': 'application/json',
     'Authorization': `Bearer ${__ENV.QUICKSILVER_USER_TOKEN}`
   };
 
+// default request parameters: include the default headers
 const defaultParams = {headers: defaultHeaders}
 
+// determine the workspace for the current request based on the testGroup
 const workspaceRoot = (testGroup) => {
   // take everything up to the first comma, allowing for "annotations" to the testGroup
   const groupBase = testGroup.split(",")[0];


### PR DESCRIPTION
Ticket: CORE-498

Adds Quicksilver perf tests for:
* batchUpsert from empty, i.e. insert, with 250 entities
* batchUpsert against existing entities, i.e. update, with 250 entities
* delete entities by type&name, for 250 entities
* batchUpsert from empty, i.e. insert, with 4000 entities
* batchUpsert against existing entities, i.e. update, with 4000 entities
* delete entities by type

In my local testing, this added 6-8 minutes to the total test time for Quicksilver, but adds 15 minutes to the total test time for legacy. Perf tests just got a lot slower! But I think it's really valuable metrics to be capturing.

Once this merges I will update the Grafana dashboard to visualize the results.

