### PR TITLE
CORE-469: rename attribute

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsde.rawls.model.FilterOperators.FilterOperator
 import org.broadinstitute.dsde.rawls.model.{
   Attributable,
   AttributeName,
+  AttributeRename,
   Entity,
   EntityColumnFilter,
   EntityPointer,
@@ -474,10 +475,10 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   def renameEntityType(workspaceId: UUID, oldType: String, newType: String): ReadWriteAction[Int] = {
     // Update the entity type in the ENTITY table
     // explain plan: index range scan on idx_entity_type_name
-    val updateEntityTypeSql = 
+    val updateEntityTypeSql =
       sql"""update ENTITY set entity_type = $newType, record_version = record_version + 1
             where workspace_id = $workspaceId and entity_type = $oldType and deleted = 0"""
-    
+
     // Update entity references in the attributes JSON column
     // This requires a custom function that can do complex JSON updates which MySQL doesn't provide natively
     // The best approach would be to add a custom MySQL function for JSON path replacement
@@ -490,7 +491,7 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
             set from_entity_type = $newType
             where workspace_id = $workspaceId
             and from_entity_type = $oldType"""
-            
+
     // Update to_entity_type in ENTITY_REFS table
     // explain plan: index range scan on unq_from_to
     val updateToReferencesSql =
@@ -539,24 +540,34 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
         reduceSqlActionsWithDelim(replaceParamsSqls.toSeq, sql","),
         sql""") where er.workspace_id = $workspaceId and er.to_entity_type = $oldType"""
       )
-  }
-    
+    }
+
     // Execute all updates in same transaction
     for {
       paths <- getReferencePathsInAttributesSql.as[String]
-      _ <- if(paths.isEmpty) {
-        DBIO.successful(0)
-      } else {
-        DBIO.seq(
-          updateReferencesInAttributesSql(paths).asUpdate,
-          updateToReferencesSql.asUpdate
-        )
-      }
+      _ <-
+        if (paths.isEmpty) {
+          DBIO.successful(0)
+        } else {
+          DBIO.seq(
+            updateReferencesInAttributesSql(paths).asUpdate,
+            updateToReferencesSql.asUpdate
+          )
+        }
       _ <- updateFromReferencesSql.asUpdate
       entityRowsUpdated <- updateEntityTypeSql.asUpdate
     } yield entityRowsUpdated
   }
-  
+
+  def renameAttribute(workspaceId: UUID,
+                      entityType: String,
+                      oldName: AttributeName,
+                      newName: AttributeRename
+  ): ReadWriteAction[Int] = ???
+
+  def attributeExists(workspaceId: UUID, entityType: String, attributeName: AttributeName): ReadAction[Boolean] =
+    ???
+
   // ====================================================================================================
   //  entity query helpers
   //      methods in this section are used for building entity query functions

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -579,9 +579,9 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
           attributes = JSON_REMOVE(
                          JSON_SET(
                            attributes,
-                           '#${slickAttributePath(renameRequest.newAttributeName)}',
-                           JSON_EXTRACT(attributes, '#${slickAttributePath(oldAttributeName)}')),
-                         '#${slickAttributePath(oldAttributeName)}'
+                           ${slickAttributePath(renameRequest.newAttributeName)},
+                           JSON_EXTRACT(attributes, ${slickAttributePath(oldAttributeName)})),
+                         ${slickAttributePath(oldAttributeName)}
                        )
           where workspace_id = $workspaceId
           and entity_type = $entityType

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -563,10 +563,15 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
                       entityType: String,
                       oldName: AttributeName,
                       newName: AttributeRename
-  ): ReadWriteAction[Int] = ???
+  ): ReadWriteAction[Int] = DBIO.failed(new RuntimeException("not implemented"))
 
   def attributeExists(workspaceId: UUID, entityType: String, attributeName: AttributeName): ReadAction[Boolean] =
-    ???
+    sql"""select exists (select 1 from ENTITY_KEYS
+         where workspace_id = $workspaceId
+          and entity_type = $entityType
+          and JSON_CONTAINS(attribute_keys, JSON_QUOTE(${AttributeName.toDelimitedName(attributeName)})))"""
+      .as[Boolean]
+      .head
 
   // ====================================================================================================
   //  entity query helpers

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -559,12 +559,41 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
     } yield entityRowsUpdated
   }
 
+  /**
+    * Renames a single attribute across all entities of the given type and workspace.
+    * This method assumes the old and new attribute names have already been validated!
+    *
+    * `Using where. Index used: idx_entity_type_name`
+    */
   def renameAttribute(workspaceId: UUID,
                       entityType: String,
-                      oldName: AttributeName,
-                      newName: AttributeRename
-  ): ReadWriteAction[Int] = DBIO.failed(new RuntimeException("not implemented"))
+                      oldAttributeName: AttributeName,
+                      renameRequest: AttributeRename
+  ): ReadWriteAction[Int] =
+    // rename is implemented as JSON_REMOVE(JSON_SET(JSON_EXTRACT))
+    // JSON_EXTRACT gets the value of the old attribute
+    // JSON_SET creates the new attribute with that value
+    // JSON_REMOVE deletes the old attribute
+    sql"""update ENTITY
+          set record_version = record_version + 1,
+          attributes = JSON_REMOVE(
+                         JSON_SET(
+                           attributes,
+                           '#${slickAttributePath(renameRequest.newAttributeName)}',
+                           JSON_EXTRACT(attributes, '#${slickAttributePath(oldAttributeName)}')),
+                         '#${slickAttributePath(oldAttributeName)}'
+                       )
+          where workspace_id = $workspaceId
+          and entity_type = $entityType
+          and deleted = 0
+          and JSON_CONTAINS_PATH(attributes, 'one', '#${slickAttributePath(oldAttributeName)}')
+       """.asUpdate
 
+  /**
+    * Determine if an attribute exists in any entity of the given type and workspace.
+    *
+    * `Using index condition; Using where. Index used: idx_entity_keys_workspace_and_entity_type`
+    */
   def attributeExists(workspaceId: UUID, entityType: String, attributeName: AttributeName): ReadAction[Boolean] =
     sql"""select exists (select 1 from ENTITY_KEYS
          where workspace_id = $workspaceId

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -586,7 +586,7 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
           where workspace_id = $workspaceId
           and entity_type = $entityType
           and deleted = 0
-          and JSON_CONTAINS_PATH(attributes, 'one', '#${slickAttributePath(oldAttributeName)}')
+          and JSON_CONTAINS_PATH(attributes, 'one', ${slickAttributePath(oldAttributeName)})
        """.asUpdate
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityUtils.scala
@@ -1,17 +1,19 @@
 package org.broadinstitute.dsde.rawls.entities
 
 import org.broadinstitute.dsde.rawls.StringValidationUtils
-import org.broadinstitute.dsde.rawls.model.{Entity, ErrorReportSource}
+import org.broadinstitute.dsde.rawls.model.{AttributeName, Entity, ErrorReportSource}
 
 object EntityUtils extends StringValidationUtils {
   implicit override val errorReportSource: ErrorReportSource = ErrorReportSource("rawls")
 
+  def validateAttrName(attrName: AttributeName, entityType: String): Unit = {
+    validateUserDefinedString(attrName.name)
+    validateAttributeName(attrName, entityType)
+  }
+
   def validateEntity(entity: Entity): Unit = {
     validateEntityType(entity.entityType)
     validateEntityName(entity.name)
-    entity.attributes.keys.foreach { attrName =>
-      validateUserDefinedString(attrName.name)
-      validateAttributeName(attrName, entity.entityType)
-    }
+    entity.attributes.keys.foreach(attrName => validateAttrName(attrName, entity.entityType))
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -12,6 +12,7 @@ import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, ExpressionEv
 import org.broadinstitute.dsde.rawls.entities.compact.batch.BatchHandling
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.{CountAndSource, EntityQueryStrategy}
 import org.broadinstitute.dsde.rawls.entities.exceptions.{
+  AttributeException,
   DataEntityException,
   DeleteEntitiesConflictException,
   DeleteEntitiesOfTypeConflictException,
@@ -311,10 +312,52 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
       }
 
   override def renameAttribute(entityType: String,
-                               oldAttributeName: AttributeName,
+                               oldName: AttributeName,
                                attributeRenameRequest: AttributeRename,
                                parentContext: RawlsRequestContext
-  ): Future[Int] = ???
+  ): Future[Int] = {
+    val newName = attributeRenameRequest.newAttributeName
+
+    // nested helper function to validate and perform the renaming all in one transaction
+    def renameInTransaction: Future[Int] = repository.dataSource.inTransaction { _ =>
+      for {
+        // does new name already exist? fail if it does.
+        newNameExists <- repository.queries.attributeExists(workspaceId, entityType, newName)
+        _ = if (newNameExists)
+          throw new AttributeException(
+            message = s"${AttributeName.toDelimitedName(newName)} already exists.",
+            code = StatusCodes.BadRequest
+          )
+        // does old name already exist? fail if it does not.
+        oldNameExists <- repository.queries.attributeExists(workspaceId, entityType, oldName)
+        _ = if (!oldNameExists)
+          throw new AttributeException(
+            message = s"${AttributeName.toDelimitedName(oldName)} does not exist.",
+            code = StatusCodes.BadRequest
+          )
+        // perform the rename
+        numEntitiesAffected <- repository.queries.renameAttribute(workspaceId,
+                                                                  entityType,
+                                                                  oldName,
+                                                                  attributeRenameRequest
+        )
+      } yield numEntitiesAffected
+    }
+
+    val renameFuture = for {
+      // validate both old and new names for syntax
+      _ <- Future(EntityUtils.validateAttrName(oldName, entityType))
+      _ <- Future(EntityUtils.validateAttrName(newName, entityType))
+      // perform the rename in a transaction
+      numEntitiesAffected <- renameInTransaction
+    } yield numEntitiesAffected
+
+    // Fire-and-forget an update to the workspace's last-modified date; no need to wait for it to complete
+    withWorkspaceLastModified(renameFuture)
+
+    // return the future
+    renameFuture
+  }
 
   override def renameEntity(entityType: String,
                             entityName: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -348,6 +348,12 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
       // validate both old and new names for syntax
       _ <- Future(EntityUtils.validateAttrName(oldName, entityType))
       _ <- Future(EntityUtils.validateAttrName(newName, entityType))
+      _ = if (oldName == newName) {
+        throw new AttributeException(
+          message = s"Old and new names are the same: ${AttributeName.toDelimitedName(oldName)}",
+          code = StatusCodes.BadRequest
+        )
+      }
       // perform the rename in a transaction
       numEntitiesAffected <- renameInTransaction
     } yield numEntitiesAffected

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
@@ -49,7 +49,7 @@ trait CompactEntitySerialization {
     }
 
   val slickAttrsPath: String = s"$$.${ATTRS_KEY}"
-  def slickAttributePath(attributeName: String): String = s"${slickAttrsPath}.${attributeName}"
+  def slickAttributePath(attributeName: String): String = s"""${slickAttrsPath}."${attributeName}""""
   def slickAttributePath(attributeName: AttributeName): String = slickAttributePath(toDelimitedName(attributeName))
 
   // retrieve the version number from the database's JSON

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/AttributeException.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/AttributeException.scala
@@ -1,0 +1,6 @@
+package org.broadinstitute.dsde.rawls.entities.exceptions
+
+import akka.http.scaladsl.model.StatusCode
+
+class AttributeException(message: String, cause: Throwable = null, override val code: StatusCode)
+    extends DataEntityException(message, cause, code)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -436,6 +436,91 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     }
   }
 
+  behavior of "attributeExists"
+
+  it should "find attributes" in withMinimalTestDatabase { _ =>
+    val attr1 = AttributeName.withDefaultNS("foo")
+    val attr2 = AttributeName.fromDelimitedName("import:bar")
+    val attr3 = AttributeName.fromDelimitedName("library:baz")
+
+    val entity1 = Entity("entityName1",
+                         "entityType",
+                         Map(
+                           attr1 -> AttributeNumber(1)
+                         )
+    )
+    val entity2 = Entity("entityName2",
+                         "entityType",
+                         Map(
+                           attr2 -> AttributeNumber(1)
+                         )
+    )
+    val entity3 = Entity("entityName3",
+                         "entityType",
+                         Map(
+                           attr3 -> AttributeNumber(1)
+                         )
+    )
+
+    insertAndGetAll(Seq(entity1, entity2, entity3))
+
+    Seq(attr1, attr2, attr3) foreach { attributeName =>
+      withClue(s"attribute $attributeName should exist") {
+        val actual = runAndWait(q.attributeExists(wsid, "entityType", attributeName))
+        actual shouldBe true
+      }
+    }
+
+    // some attributes that don't exist
+    Seq(AttributeName.fromDelimitedName("import:foo"),
+        AttributeName.withDefaultNS("bar"),
+        AttributeName.withDefaultNS("boo")
+    ) foreach { attributeName =>
+      withClue(s"attribute $attributeName should not exist") {
+        val actual = runAndWait(q.attributeExists(wsid, "entityType", attributeName))
+        actual shouldBe false
+      }
+    }
+  }
+
+  it should "respect the workspace and entity type" in withMinimalTestDatabase { _ =>
+    val attr1 = AttributeName.withDefaultNS("one")
+    val attr2 = AttributeName.withDefaultNS("two")
+    val attr3 = AttributeName.withDefaultNS("three")
+    val attr4 = AttributeName.withDefaultNS("four")
+    val wsid2 = minimalTestData.workspace2.workspaceIdAsUUID
+
+    insertAndGet(Entity("entityName", "entityType1", Map(attr1 -> AttributeNumber(1))), wsid)
+    insertAndGet(Entity("entityName", "entityType2", Map(attr2 -> AttributeNumber(2))), wsid)
+    insertAndGet(Entity("entityName", "entityType1", Map(attr3 -> AttributeNumber(3))), wsid2)
+    insertAndGet(Entity("entityName", "entityType2", Map(attr4 -> AttributeNumber(4))), wsid2)
+
+    // helper function to check if the attribute exists in the given workspace and entity type
+    def check(attributeName: AttributeName, expectedWorkspaceId: UUID, expectedEntityType: String): Unit =
+      Seq(wsid, wsid2) foreach { workspaceId =>
+        Seq("entityType1", "entityType2") foreach { entityType =>
+          withClue(
+            s"attribute $attributeName should only exist in workspace $expectedWorkspaceId and entity type $expectedEntityType;" +
+              s" error while checking $workspaceId and $entityType"
+          ) {
+            val actual = runAndWait(q.attributeExists(workspaceId, entityType, attributeName))
+            val expected = workspaceId == expectedWorkspaceId && entityType == expectedEntityType
+            actual shouldBe expected
+          }
+        }
+      }
+
+    check(attr1, wsid, "entityType1")
+    check(attr2, wsid, "entityType2")
+    check(attr3, wsid2, "entityType1")
+    check(attr4, wsid2, "entityType2")
+
+  }
+
+  behavior of "renameAttribute"
+
+  it should "be implemented" is pending
+
   /**
    * Creates 1 entity with the first half of keys, 1 entity with the second half of keys, and 1 entity with no keys.
    */

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeName,
   AttributeNull,
   AttributeNumber,
+  AttributeRename,
   AttributeString,
   AttributeValueList,
   Entity,
@@ -514,12 +515,99 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     check(attr2, wsid, "entityType2")
     check(attr3, wsid2, "entityType1")
     check(attr4, wsid2, "entityType2")
-
   }
 
   behavior of "renameAttribute"
 
-  it should "be implemented" is pending
+  it should "change the attribute name" in withMinimalTestDatabase { _ =>
+    val attr1 = AttributeName.withDefaultNS("foo")
+    val attr2 = AttributeName.fromDelimitedName("import:bar")
+    val attr3 = AttributeName.fromDelimitedName("library:baz")
+
+    val renameAttr = AttributeName.withDefaultNS("bar")
+
+    val entity1 = Entity("entityName1",
+                         "entityType",
+                         Map(
+                           attr1 -> AttributeNumber(1),
+                           attr2 -> AttributeNumber(2)
+                         )
+    )
+    val entity2 = Entity("entityName2",
+                         "entityType",
+                         Map(
+                           attr2 -> AttributeNumber(2),
+                           attr3 -> AttributeNumber(3)
+                         )
+    )
+
+    insertAndGetAll(Seq(entity1, entity2))
+
+    // rename attr2 ("import:bar") to renameAttr ("bar")
+    val rename = runAndWait(q.renameAttribute(wsid, "entityType", attr2, AttributeRename(renameAttr)))
+    rename shouldBe 2
+
+    runAndWait(q.getEntity(wsid, "entityType", entity1.name)).get.toEntity.attributes shouldBe Map(
+      attr1 -> AttributeNumber(1),
+      renameAttr -> AttributeNumber(2)
+    )
+
+    runAndWait(q.getEntity(wsid, "entityType", entity2.name)).get.toEntity.attributes shouldBe Map(
+      renameAttr -> AttributeNumber(2),
+      attr3 -> AttributeNumber(3)
+    )
+  }
+
+  it should "respect the workspace and entity type" in withMinimalTestDatabase { _ =>
+    val attr1 = AttributeName.withDefaultNS("one")
+    val attr2 = AttributeName.withDefaultNS("two")
+    val attr3 = AttributeName.withDefaultNS("three")
+    val wsid2 = minimalTestData.workspace2.workspaceIdAsUUID
+
+    insertAndGet(Entity("entityName", "entityType1", Map(attr1 -> AttributeNumber(1), attr2 -> AttributeNumber(2))),
+                 wsid
+    )
+    insertAndGet(Entity("entityName", "entityType2", Map(attr2 -> AttributeNumber(2), attr3 -> AttributeNumber(3))),
+                 wsid
+    )
+    insertAndGet(Entity("entityName", "entityType1", Map(attr1 -> AttributeNumber(1), attr2 -> AttributeNumber(2))),
+                 wsid2
+    )
+    insertAndGet(Entity("entityName", "entityType2", Map(attr2 -> AttributeNumber(2), attr3 -> AttributeNumber(3))),
+                 wsid2
+    )
+
+    // check metadata before any renames
+    runAndWait(q.listEntityKeys(wsid)) should contain theSameElementsAs Seq(
+      EntityTypeAndAttributeKey("entityType1", attr1),
+      EntityTypeAndAttributeKey("entityType1", attr2),
+      EntityTypeAndAttributeKey("entityType2", attr2),
+      EntityTypeAndAttributeKey("entityType2", attr3)
+    )
+    runAndWait(q.listEntityKeys(wsid2)) should contain theSameElementsAs Seq(
+      EntityTypeAndAttributeKey("entityType1", attr1),
+      EntityTypeAndAttributeKey("entityType1", attr2),
+      EntityTypeAndAttributeKey("entityType2", attr2),
+      EntityTypeAndAttributeKey("entityType2", attr3)
+    )
+
+    // rename attr2 in entityType1 and wsid; should only affect entity1 and entity2 in wsid
+    val newAttr1 = AttributeName.withDefaultNS("new1")
+    runAndWait(q.renameAttribute(wsid, "entityType1", attr2, AttributeRename(newAttr1))) shouldBe 1
+    // check metadata
+    runAndWait(q.listEntityKeys(wsid)) should contain theSameElementsAs Seq(
+      EntityTypeAndAttributeKey("entityType1", attr1),
+      EntityTypeAndAttributeKey("entityType1", newAttr1),
+      EntityTypeAndAttributeKey("entityType2", attr2),
+      EntityTypeAndAttributeKey("entityType2", attr3)
+    )
+    runAndWait(q.listEntityKeys(wsid2)) should contain theSameElementsAs Seq(
+      EntityTypeAndAttributeKey("entityType1", attr1),
+      EntityTypeAndAttributeKey("entityType1", attr2),
+      EntityTypeAndAttributeKey("entityType2", attr2),
+      EntityTypeAndAttributeKey("entityType2", attr3)
+    )
+  }
 
   /**
    * Creates 1 entity with the first half of keys, 1 entity with the second half of keys, and 1 entity with no keys.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.entities.compact
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Sink, Source}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponentWithFlatSpecAndMatchers
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.exceptions.EntityNotFoundException
@@ -17,6 +17,8 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeEntityReference,
   AttributeEntityReferenceList,
   AttributeName,
+  AttributeNumber,
+  AttributeRename,
   AttributeString,
   Entity,
   EntityPointer,
@@ -518,6 +520,47 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
     )
 
     entities shouldBe empty
+  }
+
+  behavior of "renameAttribute"
+
+  it should "rename an attribute" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+
+    val oldAttr = AttributeName.withDefaultNS("foo")
+    val newAttr = AttributeName.withDefaultNS("aFancyNewName")
+
+    // Create entities with attributes
+    val updates = Seq(
+      EntityUpdateDefinition(
+        "name1",
+        "typeA",
+        Seq(AddUpdateAttribute(oldAttr, AttributeNumber(1)))
+      ),
+      EntityUpdateDefinition(
+        "name2",
+        "typeA",
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("bar"), AttributeNumber(2)))
+      ),
+      EntityUpdateDefinition(
+        "name3",
+        "typeB",
+        Seq(AddUpdateAttribute(oldAttr, AttributeNumber(3)))
+      )
+    )
+    Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+
+    val numRenamed =
+      Await.result(provider.renameAttribute("typeA", oldAttr, AttributeRename(newAttr), defaultRequestContext), atMost)
+    numRenamed shouldBe 1
+
+    val entitySource = provider.listEntities("typeA")
+    val actual = Await.result(entitySource.runWith(Sink.seq), atMost)
+    actual should contain theSameElementsAs Seq(
+      Entity("name1", "typeA", Map(newAttr -> AttributeNumber(1))),
+      Entity("name2", "typeA", Map(AttributeName.withDefaultNS("bar") -> AttributeNumber(2)))
+    )
+
   }
 
   // ====================================================================================================

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -9,11 +9,13 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.CountAndSource
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{EntityNotFoundException, EntityReferenceNotFoundException}
 import org.broadinstitute.dsde.rawls.entities.exceptions.{
+  AttributeException,
   DataEntityException,
   DeleteEntitiesConflictException,
-  DeleteEntitiesOfTypeConflictException
+  DeleteEntitiesOfTypeConflictException,
+  EntityNotFoundException,
+  EntityReferenceNotFoundException
 }
 import org.broadinstitute.dsde.rawls.model.{
   Attributable,
@@ -21,6 +23,7 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeEntityReferenceList,
   AttributeName,
   AttributeNumber,
+  AttributeRename,
   AttributeString,
   Entity,
   EntityPointer,
@@ -801,7 +804,159 @@ class CompactEntityProviderSpec extends TestDriverComponentWithFlatSpecAndMatche
 
   "queryEntities" should "have tests" is pending
   "queryEntitiesSource" should "have tests" is pending
-  "renameAttribute" should "have tests" is pending
+
+  behavior of "renameAttribute"
+
+  it should "throw error on an invalid new attribute name" in {
+    val entityType = "entityType"
+    val oldName = AttributeName.withDefaultNS("oldName")
+    val newName = AttributeName.withDefaultNS("no! @@bad@@")
+
+    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+
+    val provider = providerWithMocks(mockQueries)
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(provider.renameAttribute(entityType, oldName, AttributeRename(newName), testContext), atMost)
+    }
+
+    exception.errorReport.statusCode.get shouldBe StatusCodes.BadRequest
+
+    // execution should short-circuit before executing a rename
+    verify(mockQueries, never()).renameAttribute(any(), any(), any(), any())
+  }
+
+  it should "throw error on an invalid old attribute name" in {
+    val entityType = "entityType"
+    val oldName = AttributeName.withDefaultNS("no! @@bad@@")
+    val newName = AttributeName.withDefaultNS("newName")
+
+    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+
+    val provider = providerWithMocks(mockQueries)
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(provider.renameAttribute(entityType, oldName, AttributeRename(newName), testContext), atMost)
+    }
+
+    exception.errorReport.statusCode.get shouldBe StatusCodes.BadRequest
+
+    // execution should short-circuit before executing a rename
+    verify(mockQueries, never()).renameAttribute(any(), any(), any(), any())
+  }
+
+  it should "throw error on a reserved new attribute name" in {
+    val entityType = "entityType"
+    val oldName = AttributeName.withDefaultNS("oldName")
+    val newName = AttributeName.withDefaultNS(s"${entityType}_id")
+
+    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+
+    val provider = providerWithMocks(mockQueries)
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(provider.renameAttribute(entityType, oldName, AttributeRename(newName), testContext), atMost)
+    }
+
+    exception.errorReport.statusCode.get shouldBe StatusCodes.BadRequest
+
+    // execution should short-circuit before executing a rename
+    verify(mockQueries, never()).renameAttribute(any(), any(), any(), any())
+  }
+
+  it should "throw error on a reserved old attribute name" in {
+    val entityType = "entityType"
+    val oldName = AttributeName.withDefaultNS(s"${entityType}_id")
+    val newName = AttributeName.withDefaultNS("newName")
+
+    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+
+    val provider = providerWithMocks(mockQueries)
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(provider.renameAttribute(entityType, oldName, AttributeRename(newName), testContext), atMost)
+    }
+
+    exception.errorReport.statusCode.get shouldBe StatusCodes.BadRequest
+
+    // execution should short-circuit before executing a rename
+    verify(mockQueries, never()).renameAttribute(any(), any(), any(), any())
+  }
+
+  it should "throw error if new name already exists" in {
+    val entityType = "entityType"
+    val oldName = AttributeName.withDefaultNS("oldName")
+    val newName = AttributeName.withDefaultNS("newName")
+
+    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+
+    // mock: new name already exists
+    when(mockQueries.attributeExists(any[UUID], anyString(), mockitoEq(newName)))
+      .thenReturn(DBIO.successful(true))
+
+    val provider = providerWithMocks(mockQueries)
+
+    val exception = intercept[AttributeException] {
+      Await.result(provider.renameAttribute(entityType, oldName, AttributeRename(newName), testContext), atMost)
+    }
+
+    exception.code shouldBe StatusCodes.BadRequest
+
+    // execution should short-circuit before executing a rename
+    verify(mockQueries, never()).renameAttribute(any(), any(), any(), any())
+  }
+
+  it should "throw error if old name does not exist" in {
+    val entityType = "entityType"
+    val oldName = AttributeName.withDefaultNS("oldName")
+    val newName = AttributeName.withDefaultNS("newName")
+
+    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+
+    // mock: new name does not exist
+    when(mockQueries.attributeExists(any[UUID], anyString(), mockitoEq(newName)))
+      .thenReturn(DBIO.successful(false))
+    // mock: old name does not exist
+    when(mockQueries.attributeExists(any[UUID], anyString(), mockitoEq(oldName)))
+      .thenReturn(DBIO.successful(false))
+
+    val provider = providerWithMocks(mockQueries)
+
+    val exception = intercept[AttributeException] {
+      Await.result(provider.renameAttribute(entityType, oldName, AttributeRename(newName), testContext), atMost)
+    }
+
+    exception.code shouldBe StatusCodes.BadRequest
+
+    // execution should short-circuit before executing a rename
+    verify(mockQueries, never()).renameAttribute(any(), any(), any(), any())
+  }
+
+  it should "return the number of entities updated if successful" in {
+    val entityType = "entityType"
+    val oldName = AttributeName.withDefaultNS("oldName")
+    val newName = AttributeName.withDefaultNS("newName")
+
+    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+
+    // mock: new name does not exist
+    when(mockQueries.attributeExists(any[UUID], anyString(), mockitoEq(newName)))
+      .thenReturn(DBIO.successful(false))
+    // mock: old name does exist
+    when(mockQueries.attributeExists(any[UUID], anyString(), mockitoEq(oldName)))
+      .thenReturn(DBIO.successful(true))
+    // mock: rename touches 123 entities
+    when(mockQueries.renameAttribute(any[UUID], anyString(), mockitoEq(oldName), mockitoEq(AttributeRename(newName))))
+      .thenReturn(DBIO.successful(123))
+
+    val provider = providerWithMocks(mockQueries)
+
+    val actual =
+      Await.result(provider.renameAttribute(entityType, oldName, AttributeRename(newName), testContext), atMost)
+
+    actual shouldBe 123
+  }
+
   "renameEntity" should "have tests" is pending
 
   behavior of "renameEntityType"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -807,6 +807,25 @@ class CompactEntityProviderSpec extends TestDriverComponentWithFlatSpecAndMatche
 
   behavior of "renameAttribute"
 
+  it should "throw error if old and new names are the same" in {
+    val entityType = "entityType"
+    val oldName = AttributeName.withDefaultNS("same")
+    val newName = AttributeName.withDefaultNS("same")
+
+    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+
+    val provider = providerWithMocks(mockQueries)
+
+    val exception = intercept[AttributeException] {
+      Await.result(provider.renameAttribute(entityType, oldName, AttributeRename(newName), testContext), atMost)
+    }
+
+    exception.code shouldBe StatusCodes.BadRequest
+
+    // execution should short-circuit before executing a rename
+    verify(mockQueries, never()).renameAttribute(any(), any(), any(), any())
+  }
+
   it should "throw error on an invalid new attribute name" in {
     val entityType = "entityType"
     val oldName = AttributeName.withDefaultNS("oldName")

--- a/k6/quicksilver.js
+++ b/k6/quicksilver.js
@@ -8,6 +8,8 @@ import { generateBatchUpsert } from './batchOperations.js';
 
 export const options = {
   // define each test scenario to be run
+  // for info on the various executor options (VUs, duration, iterations, etc) see
+  // https://grafana.com/docs/k6/latest/using-k6/scenarios/executors/
   scenarios: {
     // entityQuery baseline and test run in parallel; each has three virtual users and makes as many requests as possible
     // within 20 seconds.


### PR DESCRIPTION
Ticket: CORE-469

Implement the `rename_entity_attributes` API, which renames a column in a data table.