### PR TITLE
[CORE-467] Copy compact entities

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -2,22 +2,12 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
+import org.broadinstitute.dsde.rawls.entities.compact.{CompactEntityProviderConfig, CompactEntitySerialization}
 
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 import org.broadinstitute.dsde.rawls.model.FilterOperators.FilterOperator
-import org.broadinstitute.dsde.rawls.model.{
-  Attributable,
-  AttributeName,
-  AttributeRename,
-  Entity,
-  EntityColumnFilter,
-  EntityPointer,
-  EntityQuery,
-  FilterOperators,
-  SortDirections
-}
+import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeName, AttributeRename, Entity, EntityColumnFilter, EntityPointer, EntityQuery, FilterOperators, SortDirections}
 import slick.dbio.Effect.Read
 import slick.jdbc.MySQLProfile.api._
 import slick.jdbc._
@@ -31,10 +21,11 @@ trait CompactEntityComponent extends LazyLogging {
   this: DriverComponent =>
 
   /** low-level raw SQL queries for ENTITY. */
-  object compactEntityQuery extends CompactEntityQuery(this)
+  def compactEntityQuery(config: CompactEntityProviderConfig): CompactEntityQuery =
+    new CompactEntityQuery(this, config)
 }
 
-class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery with CompactEntitySerialization {
+class CompactEntityQuery(driverComponent: DriverComponent, config: CompactEntityProviderConfig) extends RawSqlQuery with CompactEntitySerialization {
   override val driver = driverComponent.driver
   import driverComponent.uniqueResult
 
@@ -235,7 +226,7 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
         entityRefsCopiedCount <- copyEntityReferences(sourceWs, destWs, chunk)
       } yield (entitiesCopiedCount, entityRefsCopiedCount)
 
-    val chunks: Iterator[Set[EntityPointer]] = entityRefs.grouped(driverComponent.batchSize)
+    val chunks: Iterator[Set[EntityPointer]] = entityRefs.grouped(config.batchCopyBatchSize)
 
     val allCopies = DBIO.sequence(chunks map copyChunkOfEntitiesOrAllEntities)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -285,6 +285,12 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * - Uses recursive SQL queries to traverse the `ENTITY_REFS` table.
    * - Performs a union operation to include all downstream references.
    * - Groups the results by the originating entity and maps them to `RefMapping`.
+   *
+   * execution plan:
+   *  - main query does a full scan on a derived table (the CTE result)
+   *  - anchor query (first select statement) uses the index idx_to to look up rows in ENTITY_REFS
+   *  - union does a full scan of the intermediate result and joins the recursive result (er1) to ENTITY_REFS using the index idx_to
+   *  - Combining the anchor and recursive result uses a temporary table
    */
   def recursiveGetEntityReferences(workspaceId: UUID,
                                    entities: Set[EntityPointer],
@@ -295,7 +301,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     } else if (entities.size > batchSize) {
       val batches = entities.grouped(batchSize).toSeq
       DBIO
-        .sequence(batches.map(batch => recursiveGetEntityReferences(workspaceId, batch.toSet)))
+        .sequence(batches.map(batch => recursiveGetEntityReferences(workspaceId, batch)))
         .map(_.flatten.toSet)
     } else {
       val entityTypeNameClauses =
@@ -350,6 +356,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * - Generates SQL clauses for the entity type and name pairs in `refs`.
    * - Executes an `INSERT INTO ... SELECT` query to copy entities from the source workspace to the destination workspace.
    * - Excludes entities marked as deleted in the source workspace.
+   *
+   * `query execution plan (for select): index range scan on idx_entity_type_name.`
    */
   def copyEntities(sourceWorkspaceId: UUID, destWorkspaceId: UUID, refs: Set[EntityPointer]): ReadWriteAction[Int] =
     if (refs.isEmpty) {
@@ -380,6 +388,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * - If `refs` is empty, returns 0 without performing any database operations.
    * - Generates SQL clauses for the `from_entity_type` and `from_name` pairs in `refs`.
    * - Executes an `INSERT INTO ... SELECT` query to copy references from the source workspace to the destination workspace.
+   *
+   * `query execution plan (for select): Uses idx_to index. Extra: Using where; Using index; Using temporary`
    */
   def copyEntityReferences(sourceWorkspaceId: UUID,
                            destWorkspaceId: UUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -258,55 +258,47 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
 
   def recursiveGetEntityReferences(workspaceId: UUID,
                                    entities: Set[EntityPointer]
-  ): ReadAction[Map[EntityPointer, Set[EntityPointer]]] =
+                                  ): ReadAction[Map[EntityPointer, Set[EntityPointer]]] = {
     if (entities.isEmpty) {
       DBIO.successful(Map.empty)
     } else {
-      val entityTypeNameTuples = entities.map(ref => (ref.entityType, ref.entityName))
+      val entityTypeNameClauses = generateTypeNameSql(entities)
 
-      val query =
-        sql"""
-        with recursive EntityReferences as (
-          -- Base case: start with the initial set of entities
-          select
-            er.from_entity_type,
-            er.from_name,
-            er.to_entity_type,
-            er.to_name
-          from ENTITY_REFS er
-          where er.workspace_id = $workspaceId
-          and (er.from_entity_type, er.from_name) in (#${reduceSqlActionsWithDelim(entityTypeNameTuples.map {
-                                                                                     case (entityType, name) =>
-                                                                                       sql"($entityType, $name)"
-                                                                                   }.toSeq,
-                                                                                   sql","
-          )})
+      val baseSql = concatSqlActions(
+        sql"""with recursive EntityReferences as (
+              select er.from_entity_type, er.from_name, er.to_entity_type, er.to_name
+              from ENTITY_REFS er
+              where er.workspace_id = $workspaceId
+              and (""",
+        reduceSqlActionsWithDelim(entityTypeNameClauses.toSeq, sql" or "),
+        sql""")
+            """
+      )
 
-          union distinct
+      val recursiveSql = sql"""
+            union distinct
+            select er.from_entity_type, er.from_name, er.to_entity_type, er.to_name
+            from EntityReferences er1
+            join ENTITY_REFS er
+            on er1.to_entity_type = er.from_entity_type and er1.to_name = er.from_name
+            where er.workspace_id = $workspaceId
+          )
+        """
 
-          -- Recursive case: find references to other entities
-          select
-            er.from_entity_type,
-            er.from_name,
-            er.to_entity_type,
-            er.to_name
-          from EntityReferences er1
-          join ENTITY_REFS er
-          on er1.to_entity_type = er.from_entity_type and er1.to_name = er.from_name
-          where er.workspace_id = $workspaceId
-        )
+      val finalSql = sql"""
         select from_entity_type, from_name, to_entity_type, to_name
         from EntityReferences
-      """.as[(String, String, String, String)].map { rows =>
-          rows
-            .groupMap(row => EntityPointer(row._1, row._2))(row => EntityPointer(row._3, row._4))
-            .view
-            .mapValues(_.toSet)
-            .toMap
-        }
+      """
 
-      query
+      concatSqlActions(baseSql, recursiveSql, finalSql).as[(String, String, String, String)].map { rows =>
+        rows
+          .groupMap(row => EntityPointer(row._1, row._2))(row => EntityPointer(row._3, row._4))
+          .view
+          .mapValues(_.toSet)
+          .toMap
+      }
     }
+  }
 
   def copyEntities(sourceWorkspaceId: UUID, destWorkspaceId: UUID, refs: Set[EntityPointer]): ReadWriteAction[Int] =
     if (refs.isEmpty) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -235,6 +235,19 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
       query.as[CompactEntityRefRecord]
     }
 
+  /**
+   * Copies entities and their references from a source workspace to a destination workspace.
+   *
+   * This method performs the following operations:
+   * - Copies the specified entities from the source workspace to the destination workspace.
+   * - Copies the references associated with those entities to the destination workspace.
+   * - Handles the copying in batches to optimize performance and avoid memory issues.
+   *
+   * Execution Plan:
+   *         - Splits the entities into batches based on the `batchSize`.
+   *         - Copies each batch of entities and their references using `copyEntities` and `copyEntityReferences`.
+   *         - Aggregates the results from all batches to return the total counts.
+   */
   def copyEntitiesToNewWorkspace(sourceWs: UUID,
                                  destWs: UUID,
                                  entityRefs: Set[EntityPointer] = Set(),
@@ -256,16 +269,19 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
     }
   }
 
-  def getEntitySubtrees(workspaceId: UUID,
-                        entityType: String,
-                        entityNames: Set[String]
-  ): ReadAction[Set[RefMapping]] = {
-    val refs = entityNames.map(name => EntityPointer(entityType, name))
-    for {
-      allRefs <- recursiveGetEntityReferences(workspaceId, refs)
-    } yield allRefs
-  }
-
+  /**
+   * Recursively retrieves all entity references for a given set of entities in a workspace.
+   *
+   * This method performs a recursive query on the `ENTITY_REFS` table to find all downstream entities
+   * referenced by the input entities. It returns a `Set[RefMapping]`, where each `RefMapping` contains:
+   * - `from`: The originating entity.
+   * - `to`: A set of entities that the originating entity references, including all downstream references.
+   *
+   * Execution Plan:
+   * - Uses recursive SQL queries to traverse the `ENTITY_REFS` table.
+   * - Performs a union operation to include all downstream references.
+   * - Groups the results by the originating entity and maps them to `RefMapping`.
+   */
   def recursiveGetEntityReferences(workspaceId: UUID, entities: Set[EntityPointer]): ReadAction[Set[RefMapping]] =
     if (entities.isEmpty) {
       DBIO.successful(Set.empty[RefMapping])
@@ -311,6 +327,18 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
       }
     }
 
+  /**
+   * Copies entities from a source workspace to a destination workspace.
+   *
+   * This method inserts new rows into the `ENTITY` table for the destination workspace
+   * based on the entities in the source workspace. It excludes entities that are marked as deleted.
+   *
+   * Execution Plan:
+   * - If `refs` is empty, returns 0 without performing any database operations.
+   * - Generates SQL clauses for the entity type and name pairs in `refs`.
+   * - Executes an `INSERT INTO ... SELECT` query to copy entities from the source workspace to the destination workspace.
+   * - Excludes entities marked as deleted in the source workspace.
+   */
   def copyEntities(sourceWorkspaceId: UUID, destWorkspaceId: UUID, refs: Set[EntityPointer]): ReadWriteAction[Int] =
     if (refs.isEmpty) {
       DBIO.successful(0)
@@ -330,9 +358,16 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
     }
 
   /**
-   * Given a destWorkspaceId: UUID and refs: Set[EntityPointer]
-   * select rows from ENTITY_REFS table for the source workspace where the from_entity_type and from_name are in the refs set
-   * and insert new rows into ENTITY_REFS table for the destWorkspaceId with the same from_entity_type and from_name
+   * Copies entity references from a source workspace to a destination workspace.
+   *
+   * This method inserts rows into the `ENTITY_REFS` table for the destination workspace
+   * based on the references in the source workspace. It ensures that the `from_entity_type`
+   * and `from_name` match the provided set of `EntityPointer` objects.
+   *
+   * Execution Plan:
+   * - If `refs` is empty, returns 0 without performing any database operations.
+   * - Generates SQL clauses for the `from_entity_type` and `from_name` pairs in `refs`.
+   * - Executes an `INSERT INTO ... SELECT` query to copy references from the source workspace to the destination workspace.
    */
   def copyEntityReferences(sourceWorkspaceId: UUID,
                            destWorkspaceId: UUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -247,20 +247,16 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   def getEntitySubtrees(workspaceId: UUID,
                         entityType: String,
                         entityNames: Set[String]
-  ): ReadAction[Map[EntityPointer, Set[EntityPointer]]] = {
+  ): ReadAction[Set[RefMapping]] = {
     val refs = entityNames.map(name => EntityPointer(entityType, name))
     for {
-      startingEntityRecords <- getEntityRefs(workspaceId, refs)
-      entities = startingEntityRecords.map(record => record.toPointer)
-      allRefs <- recursiveGetEntityReferences(workspaceId, entities.toSet)
+      allRefs <- recursiveGetEntityReferences(workspaceId, refs)
     } yield allRefs
   }
 
-  def recursiveGetEntityReferences(workspaceId: UUID,
-                                   entities: Set[EntityPointer]
-                                  ): ReadAction[Map[EntityPointer, Set[EntityPointer]]] = {
+  def recursiveGetEntityReferences(workspaceId: UUID, entities: Set[EntityPointer]): ReadAction[Set[RefMapping]] =
     if (entities.isEmpty) {
-      DBIO.successful(Map.empty)
+      DBIO.successful(Set.empty[RefMapping])
     } else {
       val entityTypeNameClauses = generateTypeNameSql(entities)
 
@@ -296,9 +292,10 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
           .view
           .mapValues(_.toSet)
           .toMap
+          .map { case (key, value) => RefMapping(key, value) }
+          .toSet
       }
     }
-  }
 
   def copyEntities(sourceWorkspaceId: UUID, destWorkspaceId: UUID, refs: Set[EntityPointer]): ReadWriteAction[Int] =
     if (refs.isEmpty) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.entities.compact.{CompactEntityProviderConfig, CompactEntitySerialization}
+import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
 
 import java.sql.Timestamp
 import java.util.{Date, UUID}
@@ -31,13 +31,10 @@ trait CompactEntityComponent extends LazyLogging {
   this: DriverComponent =>
 
   /** low-level raw SQL queries for ENTITY. */
-  def compactEntityQuery(config: CompactEntityProviderConfig): CompactEntityQuery =
-    new CompactEntityQuery(this, config)
+  object compactEntityQuery extends CompactEntityQuery(this)
 }
 
-class CompactEntityQuery(driverComponent: DriverComponent, config: CompactEntityProviderConfig)
-    extends RawSqlQuery
-    with CompactEntitySerialization {
+class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery with CompactEntitySerialization {
   override val driver = driverComponent.driver
   import driverComponent.uniqueResult
 
@@ -249,7 +246,7 @@ class CompactEntityQuery(driverComponent: DriverComponent, config: CompactEntity
         entityRefsCopiedCount <- copyEntityReferences(sourceWs, destWs, chunk)
       } yield (entitiesCopiedCount, entityRefsCopiedCount)
 
-    val chunks: Iterator[Set[EntityPointer]] = entityRefs.grouped(config.batchCopyBatchSize)
+    val chunks: Iterator[Set[EntityPointer]] = entityRefs.grouped(driverComponent.batchSize)
 
     val allCopies = DBIO.sequence(chunks map copyChunkOfEntitiesOrAllEntities)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -7,7 +7,17 @@ import org.broadinstitute.dsde.rawls.entities.compact.{CompactEntityProviderConf
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 import org.broadinstitute.dsde.rawls.model.FilterOperators.FilterOperator
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeName, AttributeRename, Entity, EntityColumnFilter, EntityPointer, EntityQuery, FilterOperators, SortDirections}
+import org.broadinstitute.dsde.rawls.model.{
+  Attributable,
+  AttributeName,
+  AttributeRename,
+  Entity,
+  EntityColumnFilter,
+  EntityPointer,
+  EntityQuery,
+  FilterOperators,
+  SortDirections
+}
 import slick.dbio.Effect.Read
 import slick.jdbc.MySQLProfile.api._
 import slick.jdbc._
@@ -25,7 +35,9 @@ trait CompactEntityComponent extends LazyLogging {
     new CompactEntityQuery(this, config)
 }
 
-class CompactEntityQuery(driverComponent: DriverComponent, config: CompactEntityProviderConfig) extends RawSqlQuery with CompactEntitySerialization {
+class CompactEntityQuery(driverComponent: DriverComponent, config: CompactEntityProviderConfig)
+    extends RawSqlQuery
+    with CompactEntitySerialization {
   override val driver = driverComponent.driver
   import driverComponent.uniqueResult
 
@@ -67,6 +79,17 @@ class CompactEntityQuery(driverComponent: DriverComponent, config: CompactEntity
 
   implicit val getEntity: GetResult[Entity] =
     GetResult(r => Entity(r.<<, r.<<, fromSql(r.<<)))
+
+  implicit val getRefPointerRecord: GetResult[RefPointerRecord] =
+    GetResult(r =>
+      RefPointerRecord(
+        r.<<,
+        r.<<,
+        r.<<,
+        r.<<,
+        r.<<
+      )
+    )
 
   private val fromEntityWhereNotDeleted = "from ENTITY e where e.deleted = 0"
 
@@ -253,7 +276,7 @@ class CompactEntityQuery(driverComponent: DriverComponent, config: CompactEntity
 
       val baseSql = concatSqlActions(
         sql"""with recursive EntityReferences as (
-              select er.from_entity_type, er.from_name, er.to_entity_type, er.to_name
+              select er.workspace_id, er.from_entity_type, er.from_name, er.to_entity_type, er.to_name
               from ENTITY_REFS er
               where er.workspace_id = $workspaceId
               and (""",
@@ -264,7 +287,7 @@ class CompactEntityQuery(driverComponent: DriverComponent, config: CompactEntity
 
       val recursiveSql = sql"""
             union distinct
-            select er.from_entity_type, er.from_name, er.to_entity_type, er.to_name
+            select er.workspace_id, er.from_entity_type, er.from_name, er.to_entity_type, er.to_name
             from EntityReferences er1
             join ENTITY_REFS er
             on er1.to_entity_type = er.from_entity_type and er1.to_name = er.from_name
@@ -273,13 +296,15 @@ class CompactEntityQuery(driverComponent: DriverComponent, config: CompactEntity
         """
 
       val finalSql = sql"""
-        select from_entity_type, from_name, to_entity_type, to_name
+        select workspace_id, from_entity_type, from_name, to_entity_type, to_name
         from EntityReferences
       """
 
-      concatSqlActions(baseSql, recursiveSql, finalSql).as[(String, String, String, String)].map { rows =>
+      concatSqlActions(baseSql, recursiveSql, finalSql).as[RefPointerRecord].map { rows =>
         rows
-          .groupMap(row => EntityPointer(row._1, row._2))(row => EntityPointer(row._3, row._4))
+          .groupMap(row => EntityPointer(row.fromEntityType, row.fromName))(row =>
+            EntityPointer(row.toEntityType, row.toName)
+          )
           .view
           .mapValues(_.toSet)
           .toMap

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -7,7 +7,17 @@ import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 import org.broadinstitute.dsde.rawls.model.FilterOperators.FilterOperator
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeName, AttributeRename, Entity, EntityColumnFilter, EntityPointer, EntityQuery, FilterOperators, SortDirections}
+import org.broadinstitute.dsde.rawls.model.{
+  Attributable,
+  AttributeName,
+  AttributeRename,
+  Entity,
+  EntityColumnFilter,
+  EntityPointer,
+  EntityQuery,
+  FilterOperators,
+  SortDirections
+}
 import slick.dbio.Effect.Read
 import slick.jdbc.MySQLProfile.api._
 import slick.jdbc._
@@ -216,16 +226,16 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
 
   def copyEntitiesToNewWorkspace(sourceWs: UUID,
                                  destWs: UUID,
-                                 entityRefs: Set[AttributeEntityReference] = Set()
-  ): WriteAction[(Int, Int)] = {
+                                 entityRefs: Set[EntityPointer] = Set()
+  ): ReadWriteAction[(Int, Int)] = {
 
-    def copyChunkOfEntitiesOrAllEntities(chunk: Set[AttributeEntityReference] = Set()) =
+    def copyChunkOfEntitiesOrAllEntities(chunk: Set[EntityPointer] = Set()) =
       for {
         entitiesCopiedCount <- copyEntities(sourceWs, destWs, chunk)
         entityRefsCopiedCount <- copyEntityReferences(sourceWs, destWs, chunk)
       } yield (entitiesCopiedCount, entityRefsCopiedCount)
 
-    val chunks: Iterator[Set[AttributeEntityReference]] = entityRefs.grouped(driverComponent.batchSize)
+    val chunks: Iterator[Set[EntityPointer]] = entityRefs.grouped(driverComponent.batchSize)
 
     val allCopies = DBIO.sequence(chunks map copyChunkOfEntitiesOrAllEntities)
 
@@ -237,18 +247,18 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   def getEntitySubtrees(workspaceId: UUID,
                         entityType: String,
                         entityNames: Set[String]
-  ): ReadAction[Map[AttributeEntityReference, Set[AttributeEntityReference]]] = {
-    val refs = entityNames.map(name => AttributeEntityReference(entityType, name))
+  ): ReadAction[Map[EntityPointer, Set[EntityPointer]]] = {
+    val refs = entityNames.map(name => EntityPointer(entityType, name))
     for {
       startingEntityRecords <- getEntityRefs(workspaceId, refs)
-      entities = startingEntityRecords.map(record => record.toAttributeEntityReference)
+      entities = startingEntityRecords.map(record => record.toPointer)
       allRefs <- recursiveGetEntityReferences(workspaceId, entities.toSet)
     } yield allRefs
   }
 
   def recursiveGetEntityReferences(workspaceId: UUID,
-                                   entities: Set[AttributeEntityReference]
-  ): ReadAction[Map[AttributeEntityReference, Set[AttributeEntityReference]]] =
+                                   entities: Set[EntityPointer]
+  ): ReadAction[Map[EntityPointer, Set[EntityPointer]]] =
     if (entities.isEmpty) {
       DBIO.successful(Map.empty)
     } else {
@@ -289,7 +299,7 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
         from EntityReferences
       """.as[(String, String, String, String)].map { rows =>
           rows
-            .groupMap(row => AttributeEntityReference(row._1, row._2))(row => AttributeEntityReference(row._3, row._4))
+            .groupMap(row => EntityPointer(row._1, row._2))(row => EntityPointer(row._3, row._4))
             .view
             .mapValues(_.toSet)
             .toMap
@@ -298,37 +308,7 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
       query
     }
 
-//  def recursiveGetEntityReferences(workspaceId: UUID,
-//                                   entities: Set[AttributeEntityReference],
-//                                   accumulatedPathsWithLastId: Map[EntityPath, AttributeEntityReference]
-//                                  ): ReadAction[Seq[EntityPath]] = {
-//    val actions: Seq[ReadAction[Seq[(AttributeEntityReference, AttributeEntityReference)]]] = entities.toSeq.map { entity =>
-//      getReferencesTo(workspaceId, Seq(entity)).map { references =>
-//        references.map(ref => (entity, ref))
-//      }
-//    }
-//
-//    DBIO.sequence(actions).map(_.flatten.toSet).flatMap { priorEntityWithCurrentRec =>
-//      val currentPaths = priorEntityWithCurrentRec.flatMap { case (priorEntity, currentRec) =>
-//        val pathsThatEndWithPrior = accumulatedPathsWithLastId.filter { case (_, entity) => entity == priorEntity }
-//        pathsThatEndWithPrior.keys.map(_.path).map { path =>
-//          (EntityPath(path :+ currentRec), currentRec)
-//        }
-//      }.toMap
-//
-//      val untraversedIds = priorEntityWithCurrentRec.map(_._2) -- accumulatedPathsWithLastId.values.toSet
-//      if (untraversedIds.isEmpty) {
-//        DBIO.successful(accumulatedPathsWithLastId.keys.toSeq)
-//      } else {
-//        recursiveGetEntityReferences(workspaceId, untraversedIds, accumulatedPathsWithLastId ++ currentPaths)
-//      }
-//    }
-//  }
-
-  def copyEntities(sourceWorkspaceId: UUID,
-                   destWorkspaceId: UUID,
-                   refs: Set[AttributeEntityReference]
-  ): ReadWriteAction[Int] =
+  def copyEntities(sourceWorkspaceId: UUID, destWorkspaceId: UUID, refs: Set[EntityPointer]): ReadWriteAction[Int] =
     if (refs.isEmpty) {
       DBIO.successful(0)
     } else {
@@ -347,13 +327,13 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
     }
 
   /**
-   * Given a destWorkspaceId: UUID and refs: Set[AttributeEntityReference]
+   * Given a destWorkspaceId: UUID and refs: Set[EntityPointer]
    * select rows from ENTITY_REFS table for the source workspace where the from_entity_type and from_name are in the refs set
    * and insert new rows into ENTITY_REFS table for the destWorkspaceId with the same from_entity_type and from_name
    */
   def copyEntityReferences(sourceWorkspaceId: UUID,
                            destWorkspaceId: UUID,
-                           refs: Set[AttributeEntityReference]
+                           refs: Set[EntityPointer]
   ): ReadWriteAction[Int] =
     if (refs.isEmpty) {
       DBIO.successful(0)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -282,9 +282,13 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
    * - Performs a union operation to include all downstream references.
    * - Groups the results by the originating entity and maps them to `RefMapping`.
    */
-  def recursiveGetEntityReferences(workspaceId: UUID, entities: Set[EntityPointer]): ReadAction[Set[RefMapping]] =
+  def recursiveGetEntityReferences(workspaceId: UUID, entities: Set[EntityPointer], batchSize: Int = driverComponent.batchSize): ReadAction[Set[RefMapping]] =
     if (entities.isEmpty) {
       DBIO.successful(Set.empty[RefMapping])
+    } else if (entities.size > batchSize) {
+      val batches = entities.grouped(batchSize).toSeq
+      DBIO.sequence(batches.map(batch => recursiveGetEntityReferences(workspaceId, batch.toSet)))
+        .map(_.flatten.toSet)
     } else {
       val entityTypeNameClauses =
         generateTypeNameSql(entities, typeColumn = "from_entity_type", nameColumn = "from_name")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -286,7 +286,8 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
     if (entities.isEmpty) {
       DBIO.successful(Set.empty[RefMapping])
     } else {
-      val entityTypeNameClauses = generateTypeNameSql(entities)
+      val entityTypeNameClauses =
+        generateTypeNameSql(entities, typeColumn = "from_entity_type", nameColumn = "from_name")
 
       val baseSql = concatSqlActions(
         sql"""with recursive EntityReferences as (
@@ -296,9 +297,8 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
               and (""",
         reduceSqlActionsWithDelim(entityTypeNameClauses.toSeq, sql" or "),
         sql""")
-            """
+           """
       )
-
       val recursiveSql = sql"""
             union distinct
             select er.workspace_id, er.from_entity_type, er.from_name, er.to_entity_type, er.to_name
@@ -306,7 +306,7 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
             join ENTITY_REFS er
             on er1.to_entity_type = er.from_entity_type and er1.to_name = er.from_name
             where er.workspace_id = $workspaceId
-          )
+            )
         """
 
       val finalSql = sql"""
@@ -351,9 +351,9 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
              where e.workspace_id = $sourceWorkspaceId
              and deleted = 0
              and ( """,
-        reduceSqlActionsWithDelim(typeNameClauses.toSeq, sql" or ")
+        reduceSqlActionsWithDelim(typeNameClauses.toSeq, sql" or "),
+        sql""" );"""
       )
-      sql""" );"""
       sql.asUpdate
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -282,12 +282,16 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
    * - Performs a union operation to include all downstream references.
    * - Groups the results by the originating entity and maps them to `RefMapping`.
    */
-  def recursiveGetEntityReferences(workspaceId: UUID, entities: Set[EntityPointer], batchSize: Int = driverComponent.batchSize): ReadAction[Set[RefMapping]] =
+  def recursiveGetEntityReferences(workspaceId: UUID,
+                                   entities: Set[EntityPointer],
+                                   batchSize: Int = driverComponent.batchSize
+  ): ReadAction[Set[RefMapping]] =
     if (entities.isEmpty) {
       DBIO.successful(Set.empty[RefMapping])
     } else if (entities.size > batchSize) {
       val batches = entities.grouped(batchSize).toSeq
-      DBIO.sequence(batches.map(batch => recursiveGetEntityReferences(workspaceId, batch.toSet)))
+      DBIO
+        .sequence(batches.map(batch => recursiveGetEntityReferences(workspaceId, batch.toSet)))
         .map(_.flatten.toSet)
     } else {
       val entityTypeNameClauses =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -3,26 +3,19 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
+
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 import org.broadinstitute.dsde.rawls.model.FilterOperators.FilterOperator
-import org.broadinstitute.dsde.rawls.model.{
-  Attributable,
-  AttributeEntityReference,
-  AttributeName,
-  Entity,
-  EntityColumnFilter,
-  EntityQuery,
-  FilterOperators,
-  SortDirections
-}
+import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeName, Entity, EntityColumnFilter, EntityCopyResponse, EntityHardConflict, EntityPath, EntityQuery, EntitySoftConflict, FilterOperators, RawlsRequestContext, SortDirections, Workspace}
 import slick.dbio.Effect.Read
 import slick.jdbc.MySQLProfile.api._
 import slick.jdbc._
 import slick.sql.SqlStreamingAction
 import spray.json._
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
 
 trait CompactEntityComponent extends LazyLogging {
   this: DriverComponent =>
@@ -207,6 +200,87 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
       // execute
       query.as[CompactEntityRefRecord]
     }
+
+  def copyEntitiesToNewWorkspace(sourceWs: UUID,
+                                 destWs: UUID,
+                                 entityRefs: Set[AttributeEntityReference] = Set()
+                                ): WriteAction[Int] = {
+
+    def copyChunkOfEntitiesOrAllEntities(chunk: Set[AttributeEntityReference] = Set()) =
+      for {
+        entitiesCopiedCount <- copyEntities(sourceWs, destWs, chunk)
+      } yield entitiesCopiedCount
+
+      val chunks: Iterator[Set[AttributeEntityReference]] = if (entityRefs.size > driverComponent.batchSize) {
+        entityRefs.grouped(driverComponent.batchSize)
+      } else {
+        Iterator(entityRefs)
+      }
+
+    val allCopies = DBIO.sequence(chunks map copyChunkOfEntitiesOrAllEntities)
+
+    allCopies.map { copyActionResults: Iterator[Int] =>
+      copyActionResults.sum
+    }
+  }
+
+  def getEntitySubtrees(workspaceId: UUID,
+                        entityType: String,
+                        entityNames: Set[String]
+                       ): ReadAction[Seq[EntityPath]] = {
+    val refs = entityNames.map { name => AttributeEntityReference(entityType, name) }
+    for {
+      startingEntityRecords <- getEntityRefs(workspaceId, refs)
+      entities = startingEntityRecords.map { record => record.toAttributeEntityReference}
+      refsToId = startingEntityRecords.map(record => EntityPath(Seq(record.toAttributeEntityReference)) -> record.toAttributeEntityReference).toMap
+      allRefs <- recursiveGetEntityReferences(workspaceId, entities.toSet, refsToId)
+    } yield allRefs
+  }
+
+  def recursiveGetEntityReferences(workspaceId: UUID,
+                                   entities: Set[AttributeEntityReference],
+                                   accumulatedPathsWithLastId: Map[EntityPath, AttributeEntityReference]
+                                  ): ReadAction[Seq[EntityPath]] = {
+    val actions: Seq[ReadAction[Seq[(AttributeEntityReference, AttributeEntityReference)]]] = entities.toSeq.map { entity =>
+      getReferencesTo(workspaceId, Seq(entity)).map { references =>
+        references.map(ref => (entity, ref))
+      }
+    }
+
+    DBIO.sequence(actions).map(_.flatten.toSet).flatMap { priorEntityWithCurrentRec =>
+      val currentPaths = priorEntityWithCurrentRec.flatMap { case (priorEntity, currentRec) =>
+        val pathsThatEndWithPrior = accumulatedPathsWithLastId.filter { case (_, entity) => entity == priorEntity }
+        pathsThatEndWithPrior.keys.map(_.path).map { path =>
+          (EntityPath(path :+ currentRec), currentRec)
+        }
+      }.toMap
+
+      val untraversedIds = priorEntityWithCurrentRec.map(_._2) -- accumulatedPathsWithLastId.values.toSet
+      if (untraversedIds.isEmpty) {
+        DBIO.successful(accumulatedPathsWithLastId.keys.toSeq)
+      } else {
+        recursiveGetEntityReferences(workspaceId, untraversedIds, accumulatedPathsWithLastId ++ currentPaths)
+      }
+    }
+  }
+
+  def copyEntities(sourceWorkspaceId: UUID, destWorkspaceId: UUID, refs: Set[AttributeEntityReference]): ReadWriteAction[Int] =
+    if (refs.isEmpty) {
+      DBIO.successful(0)
+    } else {
+      val typeNameClauses = generateTypeNameSql(refs)
+      val sql = concatSqlActions(
+        sql"""insert into ENTITY(name, entity_type, workspace_id, record_version, deleted, attributes)
+             select name, entity_type, $destWorkspaceId, record_version, 0, attributes
+             from ENTITY e
+             where e.workspace_id = $sourceWorkspaceId
+             and deleted = 0
+             and ( """,
+        reduceSqlActionsWithDelim(typeNameClauses.toSeq, sql" or "))
+             sql""" );"""
+      sql.asUpdate
+  }
+
 
   /** Given a set of entity type/name pairs, return the count of those entities that exist.
     *

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -7,7 +7,22 @@ import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 import org.broadinstitute.dsde.rawls.model.FilterOperators.FilterOperator
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeName, Entity, EntityColumnFilter, EntityCopyResponse, EntityHardConflict, EntityPath, EntityQuery, EntitySoftConflict, FilterOperators, RawlsRequestContext, SortDirections, Workspace}
+import org.broadinstitute.dsde.rawls.model.{
+  Attributable,
+  AttributeEntityReference,
+  AttributeName,
+  Entity,
+  EntityColumnFilter,
+  EntityCopyResponse,
+  EntityHardConflict,
+  EntityPath,
+  EntityQuery,
+  EntitySoftConflict,
+  FilterOperators,
+  RawlsRequestContext,
+  SortDirections,
+  Workspace
+}
 import slick.dbio.Effect.Read
 import slick.jdbc.MySQLProfile.api._
 import slick.jdbc._
@@ -204,67 +219,118 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   def copyEntitiesToNewWorkspace(sourceWs: UUID,
                                  destWs: UUID,
                                  entityRefs: Set[AttributeEntityReference] = Set()
-                                ): WriteAction[Int] = {
+  ): WriteAction[(Int, Int)] = {
 
     def copyChunkOfEntitiesOrAllEntities(chunk: Set[AttributeEntityReference] = Set()) =
       for {
         entitiesCopiedCount <- copyEntities(sourceWs, destWs, chunk)
-      } yield entitiesCopiedCount
+        entityRefsCopiedCount <- copyEntityReferences(sourceWs, destWs, chunk)
+      } yield (entitiesCopiedCount, entityRefsCopiedCount)
 
-      val chunks: Iterator[Set[AttributeEntityReference]] = if (entityRefs.size > driverComponent.batchSize) {
-        entityRefs.grouped(driverComponent.batchSize)
-      } else {
-        Iterator(entityRefs)
-      }
+    val chunks: Iterator[Set[AttributeEntityReference]] = entityRefs.grouped(driverComponent.batchSize)
 
     val allCopies = DBIO.sequence(chunks map copyChunkOfEntitiesOrAllEntities)
 
-    allCopies.map { copyActionResults: Iterator[Int] =>
-      copyActionResults.sum
+    allCopies.map { copyActionResults: Iterator[(Int, Int)] =>
+      (copyActionResults.map(_._1).sum, copyActionResults.map(_._2).sum)
     }
   }
 
   def getEntitySubtrees(workspaceId: UUID,
                         entityType: String,
                         entityNames: Set[String]
-                       ): ReadAction[Seq[EntityPath]] = {
-    val refs = entityNames.map { name => AttributeEntityReference(entityType, name) }
+  ): ReadAction[Map[AttributeEntityReference, Set[AttributeEntityReference]]] = {
+    val refs = entityNames.map(name => AttributeEntityReference(entityType, name))
     for {
       startingEntityRecords <- getEntityRefs(workspaceId, refs)
-      entities = startingEntityRecords.map { record => record.toAttributeEntityReference}
-      refsToId = startingEntityRecords.map(record => EntityPath(Seq(record.toAttributeEntityReference)) -> record.toAttributeEntityReference).toMap
-      allRefs <- recursiveGetEntityReferences(workspaceId, entities.toSet, refsToId)
+      entities = startingEntityRecords.map(record => record.toAttributeEntityReference)
+      allRefs <- recursiveGetEntityReferences(workspaceId, entities.toSet)
     } yield allRefs
   }
 
   def recursiveGetEntityReferences(workspaceId: UUID,
-                                   entities: Set[AttributeEntityReference],
-                                   accumulatedPathsWithLastId: Map[EntityPath, AttributeEntityReference]
-                                  ): ReadAction[Seq[EntityPath]] = {
-    val actions: Seq[ReadAction[Seq[(AttributeEntityReference, AttributeEntityReference)]]] = entities.toSeq.map { entity =>
-      getReferencesTo(workspaceId, Seq(entity)).map { references =>
-        references.map(ref => (entity, ref))
-      }
-    }
+                                   entities: Set[AttributeEntityReference]
+  ): ReadAction[Map[AttributeEntityReference, Set[AttributeEntityReference]]] =
+    if (entities.isEmpty) {
+      DBIO.successful(Map.empty)
+    } else {
+      val entityTypeNameTuples = entities.map(ref => (ref.entityType, ref.entityName))
 
-    DBIO.sequence(actions).map(_.flatten.toSet).flatMap { priorEntityWithCurrentRec =>
-      val currentPaths = priorEntityWithCurrentRec.flatMap { case (priorEntity, currentRec) =>
-        val pathsThatEndWithPrior = accumulatedPathsWithLastId.filter { case (_, entity) => entity == priorEntity }
-        pathsThatEndWithPrior.keys.map(_.path).map { path =>
-          (EntityPath(path :+ currentRec), currentRec)
+      val query =
+        sql"""
+        with recursive EntityReferences as (
+          -- Base case: start with the initial set of entities
+          select
+            er.from_entity_type,
+            er.from_name,
+            er.to_entity_type,
+            er.to_name
+          from ENTITY_REFS er
+          where er.workspace_id = $workspaceId
+          and (er.from_entity_type, er.from_name) in (#${reduceSqlActionsWithDelim(entityTypeNameTuples.map {
+                                                                                     case (entityType, name) =>
+                                                                                       sql"($entityType, $name)"
+                                                                                   }.toSeq,
+                                                                                   sql","
+          )})
+
+          union distinct
+
+          -- Recursive case: find references to other entities
+          select
+            er.from_entity_type,
+            er.from_name,
+            er.to_entity_type,
+            er.to_name
+          from EntityReferences er1
+          join ENTITY_REFS er
+          on er1.to_entity_type = er.from_entity_type and er1.to_name = er.from_name
+          where er.workspace_id = $workspaceId
+        )
+        select from_entity_type, from_name, to_entity_type, to_name
+        from EntityReferences
+      """.as[(String, String, String, String)].map { rows =>
+          rows
+            .groupMap(row => AttributeEntityReference(row._1, row._2))(row => AttributeEntityReference(row._3, row._4))
+            .view
+            .mapValues(_.toSet)
+            .toMap
         }
-      }.toMap
 
-      val untraversedIds = priorEntityWithCurrentRec.map(_._2) -- accumulatedPathsWithLastId.values.toSet
-      if (untraversedIds.isEmpty) {
-        DBIO.successful(accumulatedPathsWithLastId.keys.toSeq)
-      } else {
-        recursiveGetEntityReferences(workspaceId, untraversedIds, accumulatedPathsWithLastId ++ currentPaths)
-      }
+      query
     }
-  }
 
-  def copyEntities(sourceWorkspaceId: UUID, destWorkspaceId: UUID, refs: Set[AttributeEntityReference]): ReadWriteAction[Int] =
+//  def recursiveGetEntityReferences(workspaceId: UUID,
+//                                   entities: Set[AttributeEntityReference],
+//                                   accumulatedPathsWithLastId: Map[EntityPath, AttributeEntityReference]
+//                                  ): ReadAction[Seq[EntityPath]] = {
+//    val actions: Seq[ReadAction[Seq[(AttributeEntityReference, AttributeEntityReference)]]] = entities.toSeq.map { entity =>
+//      getReferencesTo(workspaceId, Seq(entity)).map { references =>
+//        references.map(ref => (entity, ref))
+//      }
+//    }
+//
+//    DBIO.sequence(actions).map(_.flatten.toSet).flatMap { priorEntityWithCurrentRec =>
+//      val currentPaths = priorEntityWithCurrentRec.flatMap { case (priorEntity, currentRec) =>
+//        val pathsThatEndWithPrior = accumulatedPathsWithLastId.filter { case (_, entity) => entity == priorEntity }
+//        pathsThatEndWithPrior.keys.map(_.path).map { path =>
+//          (EntityPath(path :+ currentRec), currentRec)
+//        }
+//      }.toMap
+//
+//      val untraversedIds = priorEntityWithCurrentRec.map(_._2) -- accumulatedPathsWithLastId.values.toSet
+//      if (untraversedIds.isEmpty) {
+//        DBIO.successful(accumulatedPathsWithLastId.keys.toSeq)
+//      } else {
+//        recursiveGetEntityReferences(workspaceId, untraversedIds, accumulatedPathsWithLastId ++ currentPaths)
+//      }
+//    }
+//  }
+
+  def copyEntities(sourceWorkspaceId: UUID,
+                   destWorkspaceId: UUID,
+                   refs: Set[AttributeEntityReference]
+  ): ReadWriteAction[Int] =
     if (refs.isEmpty) {
       DBIO.successful(0)
     } else {
@@ -276,11 +342,40 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
              where e.workspace_id = $sourceWorkspaceId
              and deleted = 0
              and ( """,
-        reduceSqlActionsWithDelim(typeNameClauses.toSeq, sql" or "))
-             sql""" );"""
+        reduceSqlActionsWithDelim(typeNameClauses.toSeq, sql" or ")
+      )
+      sql""" );"""
       sql.asUpdate
-  }
+    }
 
+  /**
+   * Given a destWorkspaceId: UUID and refs: Set[AttributeEntityReference]
+   * select rows from ENTITY_REFS table for the source workspace where the from_entity_type and from_name are in the refs set
+   * and insert new rows into ENTITY_REFS table for the destWorkspaceId with the same from_entity_type and from_name
+   */
+  def copyEntityReferences(sourceWorkspaceId: UUID,
+                           destWorkspaceId: UUID,
+                           refs: Set[AttributeEntityReference]
+  ): ReadWriteAction[Int] =
+    if (refs.isEmpty) {
+      DBIO.successful(0)
+    } else {
+      val typeNameClauses = generateTypeNameSql(refs, typeColumn = "from_entity_type", nameColumn = "from_name")
+
+      // build the overall query
+      val query = concatSqlActions(
+        sql"""insert into ENTITY_REFS(workspace_id, from_entity_type, from_name, to_entity_type, to_name)
+               select $destWorkspaceId, from_entity_type, from_name, to_entity_type, to_name
+               from ENTITY_REFS
+               where workspace_id = $sourceWorkspaceId
+               and ( """,
+        reduceSqlActionsWithDelim(typeNameClauses.toSeq, sql" or "),
+        sql""" );"""
+      )
+
+      // execute
+      query.asUpdate
+    }
 
   /** Given a set of entity type/name pairs, return the count of those entities that exist.
     *

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -237,7 +237,8 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
 
   def copyEntitiesToNewWorkspace(sourceWs: UUID,
                                  destWs: UUID,
-                                 entityRefs: Set[EntityPointer] = Set()
+                                 entityRefs: Set[EntityPointer] = Set(),
+                                 batchSize: Int = driverComponent.batchSize
   ): ReadWriteAction[(Int, Int)] = {
 
     def copyChunkOfEntitiesOrAllEntities(chunk: Set[EntityPointer] = Set()) =
@@ -246,7 +247,7 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
         entityRefsCopiedCount <- copyEntityReferences(sourceWs, destWs, chunk)
       } yield (entitiesCopiedCount, entityRefsCopiedCount)
 
-    val chunks: Iterator[Set[EntityPointer]] = entityRefs.grouped(driverComponent.batchSize)
+    val chunks: Iterator[Set[EntityPointer]] = entityRefs.grouped(batchSize)
 
     val allCopies = DBIO.sequence(chunks map copyChunkOfEntitiesOrAllEntities)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
@@ -63,7 +63,12 @@ case class KeysRecord(id: Long, workspaceId: UUID, entityType: String, attribute
 /**
   * model class for rows in the ENTITY_REFS table
   */
-case class RefPointerRecord(fromId: Long, toId: Long)
+case class RefPointerRecord(workspaceId: UUID,
+                            fromEntityType: String,
+                            fromName: String,
+                            toEntityType: String,
+                            toName: String
+)
 
 /** all reference pointers from one entity to all its reference targets */
 case class RefMapping(from: EntityPointer, to: Set[EntityPointer])

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntitySlickComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntitySlickComponent.scala
@@ -31,11 +31,16 @@ trait CompactEntitySlickComponent {
 
   /** high-level Slick table for ENTITY_REFS */
   class CompactEntityRefTable(tag: Tag) extends Table[RefPointerRecord](tag, "ENTITY_REFS") {
-    def fromId = column[Long]("from_id")
-    def toId = column[Long]("to_id")
+    def workspaceId = column[UUID]("workspace_id")
+    def fromEntityType = column[String]("from_entity_type")
+    def fromName = column[String]("from_name")
+    def toEntityType = column[String]("to_entity_type")
+    def toName = column[String]("to_name")
 
     def * =
-      (fromId, toId) <> (RefPointerRecord.tupled, RefPointerRecord.unapply)
+      (workspaceId, fromEntityType, fromName, toEntityType, toName) <> (RefPointerRecord.tupled,
+                                                                        RefPointerRecord.unapply
+      )
   }
 
   /** high-level Slick table for ENTITY_KEYS */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -566,9 +566,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         }
       case None =>
         throw new RawlsExceptionWithErrorReport(
-          ErrorReport(StatusCodes.InternalServerError,
-                      "Workspace setting service not available"
-          )
+          ErrorReport(StatusCodes.InternalServerError, "Workspace setting service not available")
         )
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -17,6 +17,7 @@ import org.broadinstitute.dsde.rawls.entities.exceptions.{
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.CompactDataTablesConfig
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.CompactDataTables
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.util.TracingUtils.{setTraceSpanAttribute, traceFutureWithParent}
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
@@ -413,6 +414,18 @@ class EntityService(protected val ctx: RawlsRequestContext,
         entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
           entityManager.resolveProviderFuture(EntityRequestArguments(destWsCtx, s))
         }
+
+        sourceCompactEnabled <- isCompactDataTableSettingEnabled(entityCopyDef.sourceWorkspace)
+        destCompactEnabled <- isCompactDataTableSettingEnabled(entityCopyDef.destinationWorkspace)
+        _ = if (sourceCompactEnabled != destCompactEnabled) {
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(
+              StatusCodes.BadRequest,
+              "Only one workspace has the CompactDataTablesSetting enabled. This setting must match on the source and destination workspace in order to copy entities."
+            )
+          )
+        }
+
         entityCopyResponse <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
           entityProvider
             .copyEntities(sourceWsCtx,
@@ -542,6 +555,22 @@ class EntityService(protected val ctx: RawlsRequestContext,
         ErrorReport(StatusCodes.InternalServerError, s"Unexpected error: ${ex.getMessage}", ex)
       )
   }
+
+  private def isCompactDataTableSettingEnabled(workspaceName: WorkspaceName): Future[Boolean] =
+    workspaceSettingServiceConstructor match {
+      case Some(serviceConstructor) =>
+        val workspaceSettingService = serviceConstructor(ctx)
+        workspaceSettingService.getWorkspaceSettingOfType(workspaceName, CompactDataTables) map {
+          case Some(qs: CompactDataTablesSetting) => qs.config.enabled
+          case _                                  => false
+        }
+      case None =>
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.InternalServerError,
+                      "Workspace setting service not available"
+          )
+        )
+    }
 
   /**
     * Migrate all entity data in a given workspace from legacy (LocalEntityProvider) to compact (Quicksilver) format.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -9,7 +9,6 @@ import io.opentelemetry.api.common.AttributeKey
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.base.EntityProvider
-import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityProviderConfig
 import org.broadinstitute.dsde.rawls.entities.exceptions.{
   DataEntityException,
   DeleteEntitiesConflictException,
@@ -37,8 +36,7 @@ object EntityService {
                   entityManager: EntityManager,
                   pageSizeLimit: Int,
                   workspaceSettingServiceConstructor: Option[RawlsRequestContext => WorkspaceSettingService] =
-                    None, // only used for Quicksilver migration
-                  compactEntityProviderConfig: CompactEntityProviderConfig
+                    None // only used for Quicksilver migration
   )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext, system: ActorSystem): EntityService =
     new EntityService(ctx,
                       dataSource,
@@ -46,8 +44,7 @@ object EntityService {
                       entityManager,
                       workbenchMetricBaseName,
                       pageSizeLimit,
-                      workspaceSettingServiceConstructor,
-                      compactEntityProviderConfig
+                      workspaceSettingServiceConstructor
     )
 }
 
@@ -58,8 +55,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                     override val workbenchMetricBaseName: String,
                     pageSizeLimit: Int,
                     workspaceSettingServiceConstructor: Option[RawlsRequestContext => WorkspaceSettingService] =
-                      None, // only used for Quicksilver migration
-                    compactEntityProviderConfig: CompactEntityProviderConfig
+                      None // only used for Quicksilver migration
 )(implicit protected val executionContext: ExecutionContext, system: ActorSystem)
     extends WorkspaceSupport
     with EntitySupport
@@ -601,7 +597,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
 
               DBIO.sequence(batches.map { batch =>
                 // ... insert each batch into the temp table
-                dataAccess.compactEntityQuery(compactEntityProviderConfig).migrationInsertAttributesToTempTable(batch)
+                dataAccess.compactEntityQuery.migrationInsertAttributesToTempTable(batch)
               })
             }
 
@@ -610,32 +606,26 @@ class EntityService(protected val ctx: RawlsRequestContext,
 
         for {
           // create temp table
-          _ <- dataAccess.compactEntityQuery(compactEntityProviderConfig).migrationCreateTempTable
+          _ <- dataAccess.compactEntityQuery.migrationCreateTempTable
           // insert entity name, entity type, and attributes to the temp table
           _ = logger.info(s"Quicksilver migration: inserting to temp table ...")
           _ <- DBIO.sequence(allTypesResult)
           // update ENTITY from the contents of the temp table
           _ = logger.info(s"Quicksilver migration: updating ENTITY from temp table ...")
-          _ <- dataAccess
-            .compactEntityQuery(compactEntityProviderConfig)
-            .migrationUpdateFromTempTable(workspaceContext.workspaceIdAsUUID)
+          _ <- dataAccess.compactEntityQuery.migrationUpdateFromTempTable(workspaceContext.workspaceIdAsUUID)
           // populate the ENTITY_REFS table for this workspace
           _ = logger.info(s"Quicksilver migration: populating ENTITY_REFS ...")
-          _ <- dataAccess
-            .compactEntityQuery(compactEntityProviderConfig)
-            .migrationAddReferences(workspaceContext.workspaceIdAsUUID, shardId)
+          _ <- dataAccess.compactEntityQuery.migrationAddReferences(workspaceContext.workspaceIdAsUUID, shardId)
           // delete legacy attributes from the ENTITY_ATTRIBUTE_xx_xx table
           _ = logger.info(s"Quicksilver migration: deleting legacy attributes ...")
-          _ <- dataAccess
-            .compactEntityQuery(compactEntityProviderConfig)
-            .migrationDeleteLegacyReferences(workspaceContext.workspaceIdAsUUID, shardId)
+          _ <- dataAccess.compactEntityQuery.migrationDeleteLegacyReferences(workspaceContext.workspaceIdAsUUID,
+                                                                             shardId
+          )
           // delete the all_attribute_values column for this workspace
           _ = logger.info(s"Quicksilver migration: clearing all_attribute_values ...")
-          _ <- dataAccess
-            .compactEntityQuery(compactEntityProviderConfig)
-            .migrationClearAllAttributesString(workspaceContext.workspaceIdAsUUID)
+          _ <- dataAccess.compactEntityQuery.migrationClearAllAttributesString(workspaceContext.workspaceIdAsUUID)
 
-          _ <- dataAccess.compactEntityQuery(compactEntityProviderConfig).migrationDeleteTempTable
+          _ <- dataAccess.compactEntityQuery.migrationDeleteTempTable
           _ = logger.info(s"Quicksilver migration: done!")
         } yield ()
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -527,6 +527,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
       )
     } yield entityProvider
 
+  /**
+   * Determine if a workspace has the CompactDataTables setting enabled.
+   */
   private def isCompactDataTableSettingEnabled(workspaceName: WorkspaceName): Future[Boolean] =
     workspaceSettingServiceConstructor match {
       case Some(serviceConstructor) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.AttributeKey
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.base.EntityProvider
+import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityProviderConfig
 import org.broadinstitute.dsde.rawls.entities.exceptions.{
   DataEntityException,
   DeleteEntitiesConflictException,
@@ -36,7 +37,8 @@ object EntityService {
                   entityManager: EntityManager,
                   pageSizeLimit: Int,
                   workspaceSettingServiceConstructor: Option[RawlsRequestContext => WorkspaceSettingService] =
-                    None // only used for Quicksilver migration
+                    None, // only used for Quicksilver migration
+                  compactEntityProviderConfig: CompactEntityProviderConfig
   )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext, system: ActorSystem): EntityService =
     new EntityService(ctx,
                       dataSource,
@@ -44,7 +46,8 @@ object EntityService {
                       entityManager,
                       workbenchMetricBaseName,
                       pageSizeLimit,
-                      workspaceSettingServiceConstructor
+                      workspaceSettingServiceConstructor,
+                      compactEntityProviderConfig
     )
 }
 
@@ -55,7 +58,8 @@ class EntityService(protected val ctx: RawlsRequestContext,
                     override val workbenchMetricBaseName: String,
                     pageSizeLimit: Int,
                     workspaceSettingServiceConstructor: Option[RawlsRequestContext => WorkspaceSettingService] =
-                      None // only used for Quicksilver migration
+                      None, // only used for Quicksilver migration
+                    compactEntityProviderConfig: CompactEntityProviderConfig
 )(implicit protected val executionContext: ExecutionContext, system: ActorSystem)
     extends WorkspaceSupport
     with EntitySupport
@@ -516,14 +520,14 @@ class EntityService(protected val ctx: RawlsRequestContext,
    */
   private def getProviderWithTracing(workspaceContext: Workspace,
                                      localContext: RawlsRequestContext
-                                    ): Future[EntityProvider] =
+  ): Future[EntityProvider] =
     for {
       entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
         entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
       }
       _ = setTraceSpanAttribute(localContext,
-        AttributeKey.stringKey("providerType"),
-        entityProvider.getClass.getSimpleName
+                                AttributeKey.stringKey("providerType"),
+                                entityProvider.getClass.getSimpleName
       )
     } yield entityProvider
 
@@ -597,7 +601,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
 
               DBIO.sequence(batches.map { batch =>
                 // ... insert each batch into the temp table
-                dataAccess.compactEntityQuery.migrationInsertAttributesToTempTable(batch)
+                dataAccess.compactEntityQuery(compactEntityProviderConfig).migrationInsertAttributesToTempTable(batch)
               })
             }
 
@@ -606,26 +610,32 @@ class EntityService(protected val ctx: RawlsRequestContext,
 
         for {
           // create temp table
-          _ <- dataAccess.compactEntityQuery.migrationCreateTempTable
+          _ <- dataAccess.compactEntityQuery(compactEntityProviderConfig).migrationCreateTempTable
           // insert entity name, entity type, and attributes to the temp table
           _ = logger.info(s"Quicksilver migration: inserting to temp table ...")
           _ <- DBIO.sequence(allTypesResult)
           // update ENTITY from the contents of the temp table
           _ = logger.info(s"Quicksilver migration: updating ENTITY from temp table ...")
-          _ <- dataAccess.compactEntityQuery.migrationUpdateFromTempTable(workspaceContext.workspaceIdAsUUID)
+          _ <- dataAccess
+            .compactEntityQuery(compactEntityProviderConfig)
+            .migrationUpdateFromTempTable(workspaceContext.workspaceIdAsUUID)
           // populate the ENTITY_REFS table for this workspace
           _ = logger.info(s"Quicksilver migration: populating ENTITY_REFS ...")
-          _ <- dataAccess.compactEntityQuery.migrationAddReferences(workspaceContext.workspaceIdAsUUID, shardId)
+          _ <- dataAccess
+            .compactEntityQuery(compactEntityProviderConfig)
+            .migrationAddReferences(workspaceContext.workspaceIdAsUUID, shardId)
           // delete legacy attributes from the ENTITY_ATTRIBUTE_xx_xx table
           _ = logger.info(s"Quicksilver migration: deleting legacy attributes ...")
-          _ <- dataAccess.compactEntityQuery.migrationDeleteLegacyReferences(workspaceContext.workspaceIdAsUUID,
-                                                                             shardId
-          )
+          _ <- dataAccess
+            .compactEntityQuery(compactEntityProviderConfig)
+            .migrationDeleteLegacyReferences(workspaceContext.workspaceIdAsUUID, shardId)
           // delete the all_attribute_values column for this workspace
           _ = logger.info(s"Quicksilver migration: clearing all_attribute_values ...")
-          _ <- dataAccess.compactEntityQuery.migrationClearAllAttributesString(workspaceContext.workspaceIdAsUUID)
+          _ <- dataAccess
+            .compactEntityQuery(compactEntityProviderConfig)
+            .migrationClearAllAttributesString(workspaceContext.workspaceIdAsUUID)
 
-          _ <- dataAccess.compactEntityQuery.migrationDeleteTempTable
+          _ <- dataAccess.compactEntityQuery(compactEntityProviderConfig).migrationDeleteTempTable
           _ = logger.info(s"Quicksilver migration: done!")
         } yield ()
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -117,8 +117,6 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                             linkExistingEntities: Boolean,
                             parentContext: RawlsRequestContext
   ): Future[EntityCopyResponse] =
-    // retrieve the workspace settings for both workspaces and verify that both have CompactDataTables enabled
-//    val sourceSettings = sourceWorkspaceContext.workspaceSettings
     checkAndCopyEntities(
       sourceWorkspaceContext,
       destWorkspaceContext,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -11,40 +11,11 @@ import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.L
 import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, ExpressionEvaluationContext, ExpressionValidator}
 import org.broadinstitute.dsde.rawls.entities.compact.batch.BatchHandling
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.{CountAndSource, EntityQueryStrategy}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{
-  AttributeException,
-  DataEntityException,
-  DeleteEntitiesConflictException,
-  DeleteEntitiesOfTypeConflictException,
-  EntityNotFoundException,
-  EntityReferenceNotFoundException,
-  UnsupportedEntityOperationException
-}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{AttributeException, DataEntityException, DeleteEntitiesConflictException, DeleteEntitiesOfTypeConflictException, EntityNotFoundException, EntityReferenceNotFoundException, UnsupportedEntityOperationException}
 import org.broadinstitute.dsde.rawls.entities.{EntityRequestArguments, EntityUtils}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.model.{
-  Attributable,
-  AttributeEntityReference,
-  AttributeEntityReferenceList,
-  AttributeName,
-  AttributeRename,
-  AttributeValue,
-  Entity,
-  EntityCopyResponse,
-  EntityHardConflict,
-  EntityPointer,
-  EntityQuery,
-  EntityQueryResponse,
-  EntityQueryResultMetadata,
-  EntitySoftConflict,
-  EntityTypeMetadata,
-  EntityTypeRename,
-  ErrorReport,
-  RawlsRequestContext,
-  SubmissionValidationEntityInputs,
-  Workspace
-}
+import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeRename, AttributeValue, Entity, EntityCopyResponse, EntityHardConflict, EntityPointer, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntitySoftConflict, EntityTypeMetadata, EntityTypeRename, ErrorReport, RawlsRequestContext, SubmissionValidationEntityInputs, Workspace}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.{trace, traceDBIOWithParent}
 import slick.dbio.{DBIO, DBIOAction, Effect, NoStream}
 import slick.jdbc.ResultSetConcurrency.ReadOnly
@@ -118,47 +89,57 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                             linkExistingEntities: Boolean,
                             parentContext: RawlsRequestContext
   ): Future[EntityCopyResponse] = {
-
-    val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name)).toSet
-    val copyResult = repository.dataSource.inTransaction { _ =>
-      for {
-        hardConflicts <- repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs)
-        result <-
-          if (hardConflicts.nonEmpty) {
-            DBIO.successful(
-              EntityCopyResponse(
-                Seq.empty,
-                hardConflicts.map(c => EntityHardConflict(c.entityType, c.name)),
-                Seq.empty
+    val start = System.nanoTime()
+    val resultFuture = {
+      val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name)).toSet
+      val copyResult = repository.dataSource.inTransaction { _ =>
+        for {
+          hardConflicts <- repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs)
+          result <-
+            if (hardConflicts.nonEmpty) {
+              DBIO.successful(
+                EntityCopyResponse(
+                  Seq.empty,
+                  hardConflicts.map(c => EntityHardConflict(c.entityType, c.name)),
+                  Seq.empty
+                )
               )
-            )
-          } else {
-            repository.queries
-              .recursiveGetEntityReferences(sourceWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs)
-              .flatMap { entityReferenceMap =>
-                val entities = entityReferenceMap.map(_.from)
-                val entityReferences = entityReferenceMap.flatMap(_.to)
-                repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entityReferences).flatMap {
-                  conflicts =>
-                    val softConflicts = conflicts.toSeq.map(_.toPointer).toSet
-                    if (softConflicts.isEmpty || linkExistingEntities) {
-                      copyEntitiesExcludingAnySoftConflicts(
-                        entities,
-                        entityReferences,
-                        softConflicts,
-                        sourceWorkspaceContext.workspaceIdAsUUID,
-                        destWorkspaceContext.workspaceIdAsUUID
-                      )
-                    } else {
-                      unmergedSoftConflicts(entityReferenceMap, softConflicts)
-                    }
+            } else {
+              repository.queries
+                .recursiveGetEntityReferences(sourceWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs, config.batchCopyBatchSize)
+                .flatMap { entityReferenceMap =>
+                  val entities = entityReferenceMap.map(_.from)
+                  val entityReferences = entityReferenceMap.flatMap(_.to)
+                  logger.info(
+                    s"Copying ${entities.size} entities and ${entityReferences.size} references from workspace ${sourceWorkspaceContext.workspaceId} to workspace ${destWorkspaceContext.workspaceId}"
+                  )
+                  repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entityReferences).flatMap {
+                    conflicts =>
+                      val softConflicts = conflicts.toSeq.map(_.toPointer).toSet
+                      if (softConflicts.isEmpty || linkExistingEntities) {
+                        copyEntitiesExcludingAnySoftConflicts(
+                          entities,
+                          entityReferences,
+                          softConflicts,
+                          sourceWorkspaceContext.workspaceIdAsUUID,
+                          destWorkspaceContext.workspaceIdAsUUID
+                        )
+                      } else {
+                        unmergedSoftConflicts(entityReferenceMap, softConflicts)
+                      }
+                  }
                 }
-              }
-          }
-      } yield result
+            }
+        } yield result
+      }
+      withWorkspaceLastModified(copyResult)
+      copyResult
     }
-    withWorkspaceLastModified(copyResult)
-    copyResult
+    resultFuture.onComplete { _ =>
+      val durationMs = (System.nanoTime() - start) / 1000000
+      logger.info(s"copyEntities took ${durationMs}ms using batchSize ${config.batchCopyBatchSize}")
+    }(executionContext)
+    resultFuture
   }
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -164,7 +164,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
 
           pathsAndConflicts.flatMap { case (entityReferenceMap, entityReferences, softConflicts) =>
             if (softConflicts.isEmpty || linkExistingEntities) {
-              val allEntityRefs: Set[EntityPointer] = entityReferences
+              val allEntityRefs: Set[EntityPointer] = entityReferenceMap.keys.toSet concat entityReferences
               val allConflictRefs: Set[EntityPointer] = softConflicts
               val entitiesToCopy: Set[EntityPointer] = allEntityRefs diff allConflictRefs
               repository.dataSource.inTransaction { _ =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -118,49 +118,49 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                             linkExistingEntities: Boolean,
                             parentContext: RawlsRequestContext
   ): Future[EntityCopyResponse] = {
-      val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name)).toSet
-      val copyResult = repository.dataSource.inTransaction { _ =>
-        for {
-          hardConflicts <- repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs)
-          result <-
-            if (hardConflicts.nonEmpty) {
-              DBIO.successful(
-                EntityCopyResponse(
-                  Seq.empty,
-                  hardConflicts.map(c => EntityHardConflict(c.entityType, c.name)),
-                  Seq.empty
-                )
+    val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name)).toSet
+    val copyResult = repository.dataSource.inTransaction { _ =>
+      for {
+        hardConflicts <- repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs)
+        result <-
+          if (hardConflicts.nonEmpty) {
+            DBIO.successful(
+              EntityCopyResponse(
+                Seq.empty,
+                hardConflicts.map(c => EntityHardConflict(c.entityType, c.name)),
+                Seq.empty
               )
-            } else {
-              repository.queries
-                .recursiveGetEntityReferences(sourceWorkspaceContext.workspaceIdAsUUID,
-                                              entitiesToCopyRefs,
-                                              config.batchCopyBatchSize
-                )
-                .flatMap { entityReferenceMap =>
-                  val entities = entityReferenceMap.map(_.from)
-                  val entityReferences = entityReferenceMap.flatMap(_.to)
-                  repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entityReferences).flatMap {
-                    conflicts =>
-                      val softConflicts = conflicts.toSeq.map(_.toPointer).toSet
-                      if (softConflicts.isEmpty || linkExistingEntities) {
-                        copyEntitiesExcludingAnySoftConflicts(
-                          entities,
-                          entityReferences,
-                          softConflicts,
-                          sourceWorkspaceContext.workspaceIdAsUUID,
-                          destWorkspaceContext.workspaceIdAsUUID
-                        )
-                      } else {
-                        unmergedSoftConflicts(entityReferenceMap, softConflicts)
-                      }
-                  }
+            )
+          } else {
+            repository.queries
+              .recursiveGetEntityReferences(sourceWorkspaceContext.workspaceIdAsUUID,
+                                            entitiesToCopyRefs,
+                                            config.batchCopyBatchSize
+              )
+              .flatMap { entityReferenceMap =>
+                val entities = entityReferenceMap.map(_.from)
+                val entityReferences = entityReferenceMap.flatMap(_.to)
+                repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entityReferences).flatMap {
+                  conflicts =>
+                    val softConflicts = conflicts.toSeq.map(_.toPointer).toSet
+                    if (softConflicts.isEmpty || linkExistingEntities) {
+                      copyEntitiesExcludingAnySoftConflicts(
+                        entities,
+                        entityReferences,
+                        softConflicts,
+                        sourceWorkspaceContext.workspaceIdAsUUID,
+                        destWorkspaceContext.workspaceIdAsUUID
+                      )
+                    } else {
+                      unmergedSoftConflicts(entityReferenceMap, softConflicts)
+                    }
                 }
-            }
-        } yield result
-      }
-      withWorkspaceLastModified(copyResult)
-      copyResult
+              }
+          }
+      } yield result
+    }
+    withWorkspaceLastModified(copyResult)
+    copyResult
   }
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -174,7 +174,8 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
       .copyEntitiesToNewWorkspace(
         sourceWorkspaceId,
         destWorkspaceId,
-        entitiesToCopy
+        entitiesToCopy,
+        config.batchCopyBatchSize
       )
     EntityCopyResponse(
       entitiesToCopy.map(_.toAttributeEntityReference).toSeq,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -11,11 +11,39 @@ import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.L
 import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, ExpressionEvaluationContext, ExpressionValidator}
 import org.broadinstitute.dsde.rawls.entities.compact.batch.BatchHandling
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.{CountAndSource, EntityQueryStrategy}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, DeleteEntitiesConflictException, DeleteEntitiesOfTypeConflictException, EntityNotFoundException, EntityReferenceNotFoundException}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{
+  DataEntityException,
+  DeleteEntitiesConflictException,
+  DeleteEntitiesOfTypeConflictException,
+  EntityNotFoundException,
+  EntityReferenceNotFoundException
+}
 import org.broadinstitute.dsde.rawls.entities.{EntityRequestArguments, EntityUtils}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeRename, AttributeUpdateOperations, AttributeValue, Entity, EntityCopyResponse, EntityHardConflict, EntityPath, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntitySoftConflict, EntityTypeMetadata, EntityTypeRename, ErrorReport, RawlsRequestContext, SubmissionValidationEntityInputs, Workspace}
+import org.broadinstitute.dsde.rawls.model.{
+  Attributable,
+  AttributeEntityReference,
+  AttributeEntityReferenceList,
+  AttributeName,
+  AttributeRename,
+  AttributeUpdateOperations,
+  AttributeValue,
+  Entity,
+  EntityCopyResponse,
+  EntityHardConflict,
+  EntityPath,
+  EntityQuery,
+  EntityQueryResponse,
+  EntityQueryResultMetadata,
+  EntitySoftConflict,
+  EntityTypeMetadata,
+  EntityTypeRename,
+  ErrorReport,
+  RawlsRequestContext,
+  SubmissionValidationEntityInputs,
+  Workspace
+}
 import slick.dbio.DBIO
 import slick.jdbc.ResultSetConcurrency.ReadOnly
 import slick.jdbc.TransactionIsolation.ReadCommitted
@@ -86,16 +114,16 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                             entityNames: Seq[String],
                             linkExistingEntities: Boolean,
                             parentContext: RawlsRequestContext
-                           ): Future[EntityCopyResponse] =
+  ): Future[EntityCopyResponse] =
 
     checkAndCopyEntities(
-        sourceWorkspaceContext,
-        destWorkspaceContext,
-        entityType,
-        entityNames,
-        linkExistingEntities,
-        parentContext
-      )
+      sourceWorkspaceContext,
+      destWorkspaceContext,
+      entityType,
+      entityNames,
+      linkExistingEntities,
+      parentContext
+    )
 
   def checkAndCopyEntities(sourceWorkspaceContext: Workspace,
                            destWorkspaceContext: Workspace,
@@ -103,72 +131,70 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                            entityNames: Seq[String],
                            linkExistingEntities: Boolean,
                            parentContext: RawlsRequestContext
-                          ): Future[EntityCopyResponse] = {
+  ): Future[EntityCopyResponse] = {
 
-    def getSoftConflicts(paths: Seq[EntityPath]): Future[Seq[EntityPath]] =
-    // return the entities already present in the destination workspace
+    def getSoftConflicts(paths: Set[AttributeEntityReference]): Future[Set[AttributeEntityReference]] =
+      // return the entities already present in the destination workspace
       repository.dataSource.inTransaction { _ =>
-        repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, paths.map(_.path.last).toSet).map { conflicts =>
+        repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, paths).map { conflicts =>
           val conflictsAsRefs = conflicts.toSeq.map(_.toAttributeEntityReference)
-          paths.filter(p => conflictsAsRefs.contains(p.path.last))
+          paths.filter(p => conflictsAsRefs.contains(p))
         }
       }
 
-    // Same as LocalEntityProvider
-    def buildSoftConflictTree(pathsRemaining: EntityPath): Seq[EntitySoftConflict] =
-      if (pathsRemaining.path.isEmpty) Seq.empty
-      else
-        Seq(
-          EntitySoftConflict(pathsRemaining.path.head.entityType,
-            pathsRemaining.path.head.entityName,
-            buildSoftConflictTree(EntityPath(pathsRemaining.path.tail))
-          )
-        )
-
     val entitiesToCopyRefs = entityNames.map(name => AttributeEntityReference(entityType, name))
-    repository.dataSource.inTransaction { _ =>
-      repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs.toSet)
-    }.flatMap {
-      case Seq() =>
-        val pathsAndConflicts = for {
-          entityPaths <- repository.dataSource.inTransaction { _ =>
-            repository.queries.getEntitySubtrees(sourceWorkspaceContext.workspaceIdAsUUID, entityType, entityNames.toSet)
-          }
-            softConflicts <- getSoftConflicts(entityPaths)
-          } yield (entityPaths, softConflicts)
-
-        pathsAndConflicts.flatMap { case (entityPaths, softConflicts) =>
-          if (softConflicts.isEmpty || linkExistingEntities) {
-            val allEntityRefs: Seq[AttributeEntityReference] = entityPaths.flatMap(_.path)
-            val allConflictRefs: Seq[AttributeEntityReference] = softConflicts.flatMap(_.path)
-            val entitiesToCopy: Seq[AttributeEntityReference] = allEntityRefs diff allConflictRefs toSet
-            repository.dataSource.inTransaction { _ =>
-              for {
-                _ <- repository.queries.copyEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID, destWorkspaceContext.workspaceIdAsUUID, entitiesToCopy)
-                _ <- repository.updateLastModified(workspaceId)
-              } yield EntityCopyResponse(entitiesToCopy.toSeq, Seq.empty, Seq.empty)
+    repository.dataSource
+      .inTransaction { _ =>
+        repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs.toSet)
+      }
+      .flatMap {
+        case Seq() =>
+          val pathsAndConflicts = for {
+            entityReferenceMap <- repository.dataSource.inTransaction { _ =>
+              repository.queries.getEntitySubtrees(sourceWorkspaceContext.workspaceIdAsUUID,
+                                                   entityType,
+                                                   entityNames.toSet
+              )
             }
-          } else {
-            val unmergedSoftConflicts = softConflicts
-              .flatMap(buildSoftConflictTree)
-              .groupBy(c => (c.entityType, c.entityName))
-              .map { case ((conflictType, conflictName), conflicts) =>
-                EntitySoftConflict(conflictType, conflictName, conflicts.flatMap(_.conflicts))
-              }
-              .toSeq
-            Future.successful(EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts))
-          }
-        }
-      case hardConflicts =>
-        Future.successful(
-          EntityCopyResponse(Seq.empty,
-            hardConflicts.map(c => EntityHardConflict(c.entityType, c.name)),
-            Seq.empty
-          )
-        )
-    }
-  }
+            entityReferences = entityReferenceMap.values.flatten.toSet
+            softConflicts <- getSoftConflicts(entityReferences)
+          } yield (entityReferenceMap, entityReferences, softConflicts)
 
+          pathsAndConflicts.flatMap { case (entityReferenceMap, entityReferences, softConflicts) =>
+            if (softConflicts.isEmpty || linkExistingEntities) {
+              val allEntityRefs: Set[AttributeEntityReference] = entityReferences
+              val allConflictRefs: Set[AttributeEntityReference] = softConflicts
+              val entitiesToCopy: Set[AttributeEntityReference] = allEntityRefs diff allConflictRefs
+              repository.dataSource.inTransaction { _ =>
+                for {
+                  _ <- repository.queries.copyEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID,
+                                                                     destWorkspaceContext.workspaceIdAsUUID,
+                                                                     entitiesToCopy
+                  )
+                  _ <- repository.updateLastModified(workspaceId)
+                } yield EntityCopyResponse(entitiesToCopy.toSeq, Seq.empty, Seq.empty)
+              }
+            } else {
+              val unmergedSoftConflicts = entityReferenceMap.flatMap { case (key, value) =>
+                val conflicts = value
+                  .intersect(softConflicts)
+                  .map(conflict => EntitySoftConflict(conflict.entityType, conflict.entityName, Seq.empty))
+                  .toSeq
+                if (conflicts.nonEmpty) {
+                  Some(EntitySoftConflict(key.entityType, key.entityName, conflicts))
+                } else {
+                  None
+                }
+              }.toSeq
+              Future.successful(EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts))
+            }
+          }
+        case hardConflicts =>
+          Future.successful(
+            EntityCopyResponse(Seq.empty, hardConflicts.map(c => EntityHardConflict(c.entityType, c.name)), Seq.empty)
+          )
+      }
+  }
 
   override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] = {
     EntityUtils.validateEntity(entity)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -11,11 +11,40 @@ import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.L
 import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, ExpressionEvaluationContext, ExpressionValidator}
 import org.broadinstitute.dsde.rawls.entities.compact.batch.BatchHandling
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.{CountAndSource, EntityQueryStrategy}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{AttributeException, DataEntityException, DeleteEntitiesConflictException, DeleteEntitiesOfTypeConflictException, EntityNotFoundException, EntityReferenceNotFoundException, UnsupportedEntityOperationException}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{
+  AttributeException,
+  DataEntityException,
+  DeleteEntitiesConflictException,
+  DeleteEntitiesOfTypeConflictException,
+  EntityNotFoundException,
+  EntityReferenceNotFoundException,
+  UnsupportedEntityOperationException
+}
 import org.broadinstitute.dsde.rawls.entities.{EntityRequestArguments, EntityUtils}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeRename, AttributeValue, Entity, EntityCopyResponse, EntityHardConflict, EntityPointer, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntitySoftConflict, EntityTypeMetadata, EntityTypeRename, ErrorReport, RawlsRequestContext, SubmissionValidationEntityInputs, Workspace}
+import org.broadinstitute.dsde.rawls.model.{
+  Attributable,
+  AttributeEntityReference,
+  AttributeEntityReferenceList,
+  AttributeName,
+  AttributeRename,
+  AttributeValue,
+  Entity,
+  EntityCopyResponse,
+  EntityHardConflict,
+  EntityPointer,
+  EntityQuery,
+  EntityQueryResponse,
+  EntityQueryResultMetadata,
+  EntitySoftConflict,
+  EntityTypeMetadata,
+  EntityTypeRename,
+  ErrorReport,
+  RawlsRequestContext,
+  SubmissionValidationEntityInputs,
+  Workspace
+}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.{trace, traceDBIOWithParent}
 import slick.dbio.{DBIO, DBIOAction, Effect, NoStream}
 import slick.jdbc.ResultSetConcurrency.ReadOnly
@@ -89,8 +118,6 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                             linkExistingEntities: Boolean,
                             parentContext: RawlsRequestContext
   ): Future[EntityCopyResponse] = {
-    val start = System.nanoTime()
-    val resultFuture = {
       val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name)).toSet
       val copyResult = repository.dataSource.inTransaction { _ =>
         for {
@@ -106,13 +133,13 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
               )
             } else {
               repository.queries
-                .recursiveGetEntityReferences(sourceWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs, config.batchCopyBatchSize)
+                .recursiveGetEntityReferences(sourceWorkspaceContext.workspaceIdAsUUID,
+                                              entitiesToCopyRefs,
+                                              config.batchCopyBatchSize
+                )
                 .flatMap { entityReferenceMap =>
                   val entities = entityReferenceMap.map(_.from)
                   val entityReferences = entityReferenceMap.flatMap(_.to)
-                  logger.info(
-                    s"Copying ${entities.size} entities and ${entityReferences.size} references from workspace ${sourceWorkspaceContext.workspaceId} to workspace ${destWorkspaceContext.workspaceId}"
-                  )
                   repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entityReferences).flatMap {
                     conflicts =>
                       val softConflicts = conflicts.toSeq.map(_.toPointer).toSet
@@ -134,12 +161,6 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
       }
       withWorkspaceLastModified(copyResult)
       copyResult
-    }
-    resultFuture.onComplete { _ =>
-      val durationMs = (System.nanoTime() - start) / 1000000
-      logger.info(s"copyEntities took ${durationMs}ms using batchSize ${config.batchCopyBatchSize}")
-    }(executionContext)
-    resultFuture
   }
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -11,41 +11,18 @@ import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.L
 import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, ExpressionEvaluationContext, ExpressionValidator}
 import org.broadinstitute.dsde.rawls.entities.compact.batch.BatchHandling
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.{CountAndSource, EntityQueryStrategy}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{
-  DataEntityException,
-  DeleteEntitiesConflictException,
-  DeleteEntitiesOfTypeConflictException,
-  EntityNotFoundException,
-  EntityReferenceNotFoundException
-}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, DeleteEntitiesConflictException, DeleteEntitiesOfTypeConflictException, EntityNotFoundException, EntityReferenceNotFoundException}
 import org.broadinstitute.dsde.rawls.entities.{EntityRequestArguments, EntityUtils}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
-import org.broadinstitute.dsde.rawls.model.{
-  Attributable,
-  AttributeEntityReference,
-  AttributeEntityReferenceList,
-  AttributeName,
-  AttributeRename,
-  AttributeUpdateOperations,
-  AttributeValue,
-  Entity,
-  EntityCopyResponse,
-  EntityQuery,
-  EntityQueryResponse,
-  EntityQueryResultMetadata,
-  EntityTypeMetadata,
-  EntityTypeRename,
-  ErrorReport,
-  RawlsRequestContext,
-  SubmissionValidationEntityInputs,
-  Workspace
-}
+import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeRename, AttributeUpdateOperations, AttributeValue, Entity, EntityCopyResponse, EntityHardConflict, EntityPath, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntitySoftConflict, EntityTypeMetadata, EntityTypeRename, ErrorReport, RawlsRequestContext, SubmissionValidationEntityInputs, Workspace}
+import slick.dbio.DBIO
 import slick.jdbc.ResultSetConcurrency.ReadOnly
 import slick.jdbc.TransactionIsolation.ReadCommitted
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
 import scala.util.Try
 
 /**
@@ -109,7 +86,89 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                             entityNames: Seq[String],
                             linkExistingEntities: Boolean,
                             parentContext: RawlsRequestContext
-  ): Future[EntityCopyResponse] = ???
+                           ): Future[EntityCopyResponse] =
+
+    checkAndCopyEntities(
+        sourceWorkspaceContext,
+        destWorkspaceContext,
+        entityType,
+        entityNames,
+        linkExistingEntities,
+        parentContext
+      )
+
+  def checkAndCopyEntities(sourceWorkspaceContext: Workspace,
+                           destWorkspaceContext: Workspace,
+                           entityType: String,
+                           entityNames: Seq[String],
+                           linkExistingEntities: Boolean,
+                           parentContext: RawlsRequestContext
+                          ): Future[EntityCopyResponse] = {
+
+    def getSoftConflicts(paths: Seq[EntityPath]): Future[Seq[EntityPath]] =
+    // return the entities already present in the destination workspace
+      repository.dataSource.inTransaction { _ =>
+        repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, paths.map(_.path.last).toSet).map { conflicts =>
+          val conflictsAsRefs = conflicts.toSeq.map(_.toAttributeEntityReference)
+          paths.filter(p => conflictsAsRefs.contains(p.path.last))
+        }
+      }
+
+    // Same as LocalEntityProvider
+    def buildSoftConflictTree(pathsRemaining: EntityPath): Seq[EntitySoftConflict] =
+      if (pathsRemaining.path.isEmpty) Seq.empty
+      else
+        Seq(
+          EntitySoftConflict(pathsRemaining.path.head.entityType,
+            pathsRemaining.path.head.entityName,
+            buildSoftConflictTree(EntityPath(pathsRemaining.path.tail))
+          )
+        )
+
+    val entitiesToCopyRefs = entityNames.map(name => AttributeEntityReference(entityType, name))
+    repository.dataSource.inTransaction { _ =>
+      repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs.toSet)
+    }.flatMap {
+      case Seq() =>
+        val pathsAndConflicts = for {
+          entityPaths <- repository.dataSource.inTransaction { _ =>
+            repository.queries.getEntitySubtrees(sourceWorkspaceContext.workspaceIdAsUUID, entityType, entityNames.toSet)
+          }
+            softConflicts <- getSoftConflicts(entityPaths)
+          } yield (entityPaths, softConflicts)
+
+        pathsAndConflicts.flatMap { case (entityPaths, softConflicts) =>
+          if (softConflicts.isEmpty || linkExistingEntities) {
+            val allEntityRefs: Seq[AttributeEntityReference] = entityPaths.flatMap(_.path)
+            val allConflictRefs: Seq[AttributeEntityReference] = softConflicts.flatMap(_.path)
+            val entitiesToCopy: Seq[AttributeEntityReference] = allEntityRefs diff allConflictRefs toSet
+            repository.dataSource.inTransaction { _ =>
+              for {
+                _ <- repository.queries.copyEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID, destWorkspaceContext.workspaceIdAsUUID, entitiesToCopy)
+                _ <- repository.updateLastModified(workspaceId)
+              } yield EntityCopyResponse(entitiesToCopy.toSeq, Seq.empty, Seq.empty)
+            }
+          } else {
+            val unmergedSoftConflicts = softConflicts
+              .flatMap(buildSoftConflictTree)
+              .groupBy(c => (c.entityType, c.entityName))
+              .map { case ((conflictType, conflictName), conflicts) =>
+                EntitySoftConflict(conflictType, conflictName, conflicts.flatMap(_.conflicts))
+              }
+              .toSeq
+            Future.successful(EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts))
+          }
+        }
+      case hardConflicts =>
+        Future.successful(
+          EntityCopyResponse(Seq.empty,
+            hardConflicts.map(c => EntityHardConflict(c.entityType, c.name)),
+            Seq.empty
+          )
+        )
+    }
+  }
+
 
   override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] = {
     EntityUtils.validateEntity(entity)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -136,13 +136,14 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
             repository.queries
               .recursiveGetEntityReferences(sourceWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs)
               .flatMap { entityReferenceMap =>
+                val entities = entityReferenceMap.map(_.from)
                 val entityReferences = entityReferenceMap.flatMap(_.to)
                 repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entityReferences).flatMap {
                   conflicts =>
                     val softConflicts = conflicts.toSeq.map(_.toPointer).toSet
                     if (softConflicts.isEmpty || linkExistingEntities) {
                       copyEntitiesExcludingAnySoftConflicts(
-                        entitiesToCopyRefs,
+                        entities,
                         entityReferences,
                         softConflicts,
                         sourceWorkspaceContext.workspaceIdAsUUID,
@@ -165,13 +166,13 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
    * are in the set of soft conflicts. Return an EntityCopyResponse containing a Seq of entities
    * that were copied.
    */
-  private def copyEntitiesExcludingAnySoftConflicts(entitiesToCopyRefs: Set[EntityPointer],
+  private def copyEntitiesExcludingAnySoftConflicts(entities: Set[EntityPointer],
                                                     entityReferences: Set[EntityPointer],
                                                     softConflicts: Set[EntityPointer],
                                                     sourceWorkspaceId: UUID,
                                                     destWorkspaceId: UUID
   ) = {
-    val allEntityRefs: Set[EntityPointer] = entitiesToCopyRefs ++ entityReferences
+    val allEntityRefs: Set[EntityPointer] = entities ++ entityReferences
     val entitiesToCopy: Set[EntityPointer] = allEntityRefs diff softConflicts
     repository.queries
       .copyEntitiesToNewWorkspace(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -116,30 +116,13 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                             entityNames: Seq[String],
                             linkExistingEntities: Boolean,
                             parentContext: RawlsRequestContext
-  ): Future[EntityCopyResponse] =
-    checkAndCopyEntities(
-      sourceWorkspaceContext,
-      destWorkspaceContext,
-      entityType,
-      entityNames,
-      linkExistingEntities,
-      parentContext
-    )
-
-  def checkAndCopyEntities(sourceWorkspaceContext: Workspace,
-                           destWorkspaceContext: Workspace,
-                           entityType: String,
-                           entityNames: Seq[String],
-                           linkExistingEntities: Boolean,
-                           parentContext: RawlsRequestContext
   ): Future[EntityCopyResponse] = {
 
-    def getSoftConflicts(paths: Set[EntityPointer]): Future[Set[EntityPointer]] =
+    def getSoftConflicts(entities: Set[EntityPointer]): Future[Set[EntityPointer]] =
       // return the entities already present in the destination workspace
       repository.dataSource.inTransaction { _ =>
-        repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, paths).map { conflicts =>
-          val conflictsAsRefs = conflicts.toSeq.map(_.toPointer)
-          paths.filter(p => conflictsAsRefs.contains(p))
+        repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entities).map { conflicts =>
+          conflicts.toSeq.map(_.toPointer).toSet
         }
       }
 
@@ -157,15 +140,14 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                                                    entityNames.toSet
               )
             }
-            entityReferences = entityReferenceMap.values.flatten.toSet
+            entityReferences = entityReferenceMap.flatMap(_.to)
             softConflicts <- getSoftConflicts(entityReferences)
           } yield (entityReferenceMap, entityReferences, softConflicts)
 
           pathsAndConflicts.flatMap { case (entityReferenceMap, entityReferences, softConflicts) =>
             if (softConflicts.isEmpty || linkExistingEntities) {
-              val allEntityRefs: Set[EntityPointer] = entityReferenceMap.keys.toSet concat entityReferences
-              val allConflictRefs: Set[EntityPointer] = softConflicts
-              val entitiesToCopy: Set[EntityPointer] = allEntityRefs diff allConflictRefs
+              val allEntityRefs: Set[EntityPointer] = entityReferenceMap.map(_.from) concat entityReferences
+              val entitiesToCopy: Set[EntityPointer] = allEntityRefs diff softConflicts
               repository.dataSource.inTransaction { _ =>
                 for {
                   _ <- repository.queries.copyEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID,
@@ -179,13 +161,13 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                 )
               }
             } else {
-              val unmergedSoftConflicts = entityReferenceMap.flatMap { case (key, value) =>
-                val conflicts = value
+              val unmergedSoftConflicts = entityReferenceMap.flatMap { refMapping =>
+                val conflicts = refMapping.to
                   .intersect(softConflicts)
                   .map(conflict => EntitySoftConflict(conflict.entityType, conflict.entityName, Seq.empty))
                   .toSeq
                 if (conflicts.nonEmpty) {
-                  Some(EntitySoftConflict(key.entityType, key.entityName, conflicts))
+                  Some(EntitySoftConflict(refMapping.from.entityType, refMapping.from.entityName, conflicts))
                 } else {
                   None
                 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -117,7 +117,8 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                             linkExistingEntities: Boolean,
                             parentContext: RawlsRequestContext
   ): Future[EntityCopyResponse] =
-
+    // retrieve the workspace settings for both workspaces and verify that both have CompactDataTables enabled
+//    val sourceSettings = sourceWorkspaceContext.workspaceSettings
     checkAndCopyEntities(
       sourceWorkspaceContext,
       destWorkspaceContext,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -118,68 +118,63 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                             parentContext: RawlsRequestContext
   ): Future[EntityCopyResponse] = {
 
-    def getSoftConflicts(entities: Set[EntityPointer]): Future[Set[EntityPointer]] =
-      // return the entities already present in the destination workspace
-      repository.dataSource.inTransaction { _ =>
-        repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entities).map { conflicts =>
-          conflicts.toSeq.map(_.toPointer).toSet
-        }
-      }
-
     val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name))
-    repository.dataSource
-      .inTransaction { _ =>
-        repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs.toSet)
-      }
-      .flatMap {
-        case Seq() =>
-          val pathsAndConflicts = for {
-            entityReferenceMap <- repository.dataSource.inTransaction { _ =>
-              repository.queries.getEntitySubtrees(sourceWorkspaceContext.workspaceIdAsUUID,
-                                                   entityType,
-                                                   entityNames.toSet
-              )
-            }
-            entityReferences = entityReferenceMap.flatMap(_.to)
-            softConflicts <- getSoftConflicts(entityReferences)
-          } yield (entityReferenceMap, entityReferences, softConflicts)
-
-          pathsAndConflicts.flatMap { case (entityReferenceMap, entityReferences, softConflicts) =>
-            if (softConflicts.isEmpty || linkExistingEntities) {
-              val allEntityRefs: Set[EntityPointer] = entityReferenceMap.map(_.from) concat entityReferences
-              val entitiesToCopy: Set[EntityPointer] = allEntityRefs diff softConflicts
-              repository.dataSource.inTransaction { _ =>
-                for {
-                  _ <- repository.queries.copyEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID,
-                                                                     destWorkspaceContext.workspaceIdAsUUID,
-                                                                     entitiesToCopy
-                  )
-                  _ <- repository.updateLastModified(workspaceId)
-                } yield EntityCopyResponse(entitiesToCopy.map(e => e.toAttributeEntityReference).toSeq,
-                                           Seq.empty,
-                                           Seq.empty
-                )
-              }
-            } else {
-              val unmergedSoftConflicts = entityReferenceMap.flatMap { refMapping =>
-                val conflicts = refMapping.to
-                  .intersect(softConflicts)
-                  .map(conflict => EntitySoftConflict(conflict.entityType, conflict.entityName, Seq.empty))
-                  .toSeq
-                if (conflicts.nonEmpty) {
-                  Some(EntitySoftConflict(refMapping.from.entityType, refMapping.from.entityName, conflicts))
-                } else {
-                  None
+    val copyResult = repository.dataSource.inTransaction { _ =>
+      for {
+        // Get hard conflicts
+        hardConflicts <- repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID,
+          entitiesToCopyRefs.toSet
+        )
+        result: EntityCopyResponse =
+          if (hardConflicts.nonEmpty) {
+              EntityCopyResponse(
+                Seq.empty,
+                hardConflicts.map(c => EntityHardConflict(c.entityType, c.name)),
+                Seq.empty
+            )
+          } else {
+            repository.queries
+              .getEntitySubtrees(sourceWorkspaceContext.workspaceIdAsUUID, entityType, entityNames.toSet)
+              .flatMap { entityReferenceMap =>
+                val entityReferences = entityReferenceMap.flatMap(_.to)
+                repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entityReferences).map {
+                  conflicts =>
+                    val softConflicts = conflicts.toSeq.map(_.toPointer).toSet
+                    if (softConflicts.isEmpty || linkExistingEntities) {
+                      val allEntityRefs: Set[EntityPointer] = entityReferenceMap.map(_.from) ++ entityReferences
+                      val entitiesToCopy: Set[EntityPointer] = allEntityRefs diff softConflicts
+                      repository.queries
+                        .copyEntitiesToNewWorkspace(
+                          sourceWorkspaceContext.workspaceIdAsUUID,
+                          destWorkspaceContext.workspaceIdAsUUID,
+                          entitiesToCopy
+                        )
+                      EntityCopyResponse(
+                        entitiesToCopy.map(_.toAttributeEntityReference).toSeq,
+                        Seq.empty,
+                        Seq.empty
+                      )
+                    } else {
+                      val unmergedSoftConflicts = entityReferenceMap.flatMap { refMapping =>
+                        val conflicts = refMapping.to
+                          .intersect(softConflicts)
+                          .map(conflict => EntitySoftConflict(conflict.entityType, conflict.entityName, Seq.empty))
+                          .toSeq
+                        if (conflicts.nonEmpty) {
+                          Some(EntitySoftConflict(refMapping.from.entityType, refMapping.from.entityName, conflicts))
+                        } else {
+                          None
+                        }
+                      }.toSeq
+                      EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts)
+                    }
                 }
-              }.toSeq
-              Future.successful(EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts))
-            }
+              }
           }
-        case hardConflicts =>
-          Future.successful(
-            EntityCopyResponse(Seq.empty, hardConflicts.map(c => EntityHardConflict(c.entityType, c.name)), Seq.empty)
-          )
-      }
+      } yield result
+    }
+    withWorkspaceLastModified(copyResult)
+    copyResult
   }
 
   override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -142,7 +142,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                     val softConflicts = conflicts.toSeq.map(_.toPointer).toSet
                     if (softConflicts.isEmpty || linkExistingEntities) {
                       copyEntitiesExcludingAnySoftConflicts(
-                        entityReferenceMap,
+                        entitiesToCopyRefs,
                         entityReferences,
                         softConflicts,
                         sourceWorkspaceContext.workspaceIdAsUUID,
@@ -165,13 +165,13 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
    * are in the set of soft conflicts. Return an EntityCopyResponse containing a Seq of entities
    * that were copied.
    */
-  private def copyEntitiesExcludingAnySoftConflicts(entityReferenceMap: Set[RefMapping],
+  private def copyEntitiesExcludingAnySoftConflicts(entitiesToCopyRefs: Set[EntityPointer],
                                                     entityReferences: Set[EntityPointer],
                                                     softConflicts: Set[EntityPointer],
                                                     sourceWorkspaceId: UUID,
                                                     destWorkspaceId: UUID
   ) = {
-    val allEntityRefs: Set[EntityPointer] = entityReferenceMap.map(_.from) ++ entityReferences
+    val allEntityRefs: Set[EntityPointer] = entitiesToCopyRefs ++ entityReferences
     val entitiesToCopy: Set[EntityPointer] = allEntityRefs diff softConflicts
     repository.queries
       .copyEntitiesToNewWorkspace(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -126,13 +126,13 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         hardConflicts <- repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID,
           entitiesToCopyRefs.toSet
         )
-        result: EntityCopyResponse =
+        result <-
           if (hardConflicts.nonEmpty) {
-              EntityCopyResponse(
+              DBIO.successful(EntityCopyResponse(
                 Seq.empty,
                 hardConflicts.map(c => EntityHardConflict(c.entityType, c.name)),
                 Seq.empty
-            )
+            ))
           } else {
             repository.queries
               .getEntitySubtrees(sourceWorkspaceContext.workspaceIdAsUUID, entityType, entityNames.toSet)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -46,7 +46,7 @@ import org.broadinstitute.dsde.rawls.model.{
   Workspace
 }
 import org.broadinstitute.dsde.rawls.util.TracingUtils.{trace, traceDBIOWithParent}
-import slick.dbio.DBIO
+import slick.dbio.{DBIO, DBIOAction, Effect, NoStream}
 import slick.jdbc.ResultSetConcurrency.ReadOnly
 import slick.jdbc.{ResultSetConcurrency, ResultSetType}
 import slick.jdbc.TransactionIsolation.ReadCommitted
@@ -122,7 +122,6 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
     val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name))
     val copyResult = repository.dataSource.inTransaction { _ =>
       for {
-        // Get hard conflicts
         hardConflicts <- repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID,
                                                           entitiesToCopyRefs.toSet
         )
@@ -140,15 +139,16 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
               .getEntitySubtrees(sourceWorkspaceContext.workspaceIdAsUUID, entityType, entityNames.toSet)
               .flatMap { entityReferenceMap =>
                 val entityReferences = entityReferenceMap.flatMap(_.to)
-                repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entityReferences).map {
+                repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entityReferences).flatMap {
                   conflicts =>
                     val softConflicts = conflicts.toSeq.map(_.toPointer).toSet
                     if (softConflicts.isEmpty || linkExistingEntities) {
-                      copyEntitiesExcludingAnySoftConflicts(entityReferenceMap,
-                                                            entityReferences,
-                                                            softConflicts,
-                                                            sourceWorkspaceContext.workspaceIdAsUUID,
-                                                            destWorkspaceContext.workspaceIdAsUUID
+                      copyEntitiesExcludingAnySoftConflicts(
+                        entityReferenceMap,
+                        entityReferences,
+                        softConflicts,
+                        sourceWorkspaceContext.workspaceIdAsUUID,
+                        destWorkspaceContext.workspaceIdAsUUID
                       )
                     } else {
                       unmergedSoftConflicts(entityReferenceMap, softConflicts)
@@ -177,16 +177,18 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         entitiesToCopy,
         config.batchCopyBatchSize
       )
-    EntityCopyResponse(
-      entitiesToCopy.map(_.toAttributeEntityReference).toSeq,
-      Seq.empty,
-      Seq.empty
-    )
+      .map { _ =>
+        EntityCopyResponse(
+          entitiesToCopy.map(_.toAttributeEntityReference).toSeq,
+          Seq.empty,
+          Seq.empty
+        )
+      }
   }
 
   def unmergedSoftConflicts(entityReferenceMap: Set[RefMapping],
                             softConflicts: Set[EntityPointer]
-  ): EntityCopyResponse = {
+  ): DBIOAction[EntityCopyResponse, NoStream, Effect] = {
     val unmergedSoftConflicts = entityReferenceMap.flatMap { refMapping =>
       val conflicts = refMapping.to
         .intersect(softConflicts)
@@ -198,7 +200,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         None
       }
     }.toSeq
-    EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts)
+    DBIO.successful(EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts))
   }
 
   override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -142,7 +142,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                 val entityReferences = entityReferenceMap.flatMap(_.to)
                 repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entityReferences).flatMap {
                   conflicts =>
-                    val softConflicts = conflicts.toSeq.map(_.toPointer).toSet
+                    val softConflicts = conflicts.map(_.toPointer).toSet
                     if (softConflicts.isEmpty || linkExistingEntities) {
                       copyEntitiesExcludingAnySoftConflicts(
                         entities,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -119,12 +119,10 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                             parentContext: RawlsRequestContext
   ): Future[EntityCopyResponse] = {
 
-    val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name))
+    val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name)).toSet
     val copyResult = repository.dataSource.inTransaction { _ =>
       for {
-        hardConflicts <- repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID,
-                                                          entitiesToCopyRefs.toSet
-        )
+        hardConflicts <- repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs)
         result <-
           if (hardConflicts.nonEmpty) {
             DBIO.successful(
@@ -136,7 +134,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
             )
           } else {
             repository.queries
-              .getEntitySubtrees(sourceWorkspaceContext.workspaceIdAsUUID, entityType, entityNames.toSet)
+              .recursiveGetEntityReferences(sourceWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs)
               .flatMap { entityReferenceMap =>
                 val entityReferences = entityReferenceMap.flatMap(_.to)
                 repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entityReferences).flatMap {
@@ -162,6 +160,11 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
     copyResult
   }
 
+  /**
+   * Copy all entities from sourceWorkspaceId to destWorkspaceId, excluding any entities that
+   * are in the set of soft conflicts. Return an EntityCopyResponse containing a Seq of entities
+   * that were copied.
+   */
   private def copyEntitiesExcludingAnySoftConflicts(entityReferenceMap: Set[RefMapping],
                                                     entityReferences: Set[EntityPointer],
                                                     softConflicts: Set[EntityPointer],
@@ -186,6 +189,10 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
       }
   }
 
+  /**
+   * For each entity in the entityReferenceMap, check any of the entites that it references
+   * are in the set of soft conflicts. If so, create an EntitySoftConflict for that entity
+   */
   def unmergedSoftConflicts(entityReferenceMap: Set[RefMapping],
                             softConflicts: Set[EntityPointer]
   ): DBIOAction[EntityCopyResponse, NoStream, Effect] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -124,15 +124,17 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
       for {
         // Get hard conflicts
         hardConflicts <- repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID,
-          entitiesToCopyRefs.toSet
+                                                          entitiesToCopyRefs.toSet
         )
         result <-
           if (hardConflicts.nonEmpty) {
-              DBIO.successful(EntityCopyResponse(
+            DBIO.successful(
+              EntityCopyResponse(
                 Seq.empty,
                 hardConflicts.map(c => EntityHardConflict(c.entityType, c.name)),
                 Seq.empty
-            ))
+              )
+            )
           } else {
             repository.queries
               .getEntitySubtrees(sourceWorkspaceContext.workspaceIdAsUUID, entityType, entityNames.toSet)
@@ -142,32 +144,14 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                   conflicts =>
                     val softConflicts = conflicts.toSeq.map(_.toPointer).toSet
                     if (softConflicts.isEmpty || linkExistingEntities) {
-                      val allEntityRefs: Set[EntityPointer] = entityReferenceMap.map(_.from) ++ entityReferences
-                      val entitiesToCopy: Set[EntityPointer] = allEntityRefs diff softConflicts
-                      repository.queries
-                        .copyEntitiesToNewWorkspace(
-                          sourceWorkspaceContext.workspaceIdAsUUID,
-                          destWorkspaceContext.workspaceIdAsUUID,
-                          entitiesToCopy
-                        )
-                      EntityCopyResponse(
-                        entitiesToCopy.map(_.toAttributeEntityReference).toSeq,
-                        Seq.empty,
-                        Seq.empty
+                      copyEntitiesExcludingAnySoftConflicts(entityReferenceMap,
+                                                            entityReferences,
+                                                            softConflicts,
+                                                            sourceWorkspaceContext.workspaceIdAsUUID,
+                                                            destWorkspaceContext.workspaceIdAsUUID
                       )
                     } else {
-                      val unmergedSoftConflicts = entityReferenceMap.flatMap { refMapping =>
-                        val conflicts = refMapping.to
-                          .intersect(softConflicts)
-                          .map(conflict => EntitySoftConflict(conflict.entityType, conflict.entityName, Seq.empty))
-                          .toSeq
-                        if (conflicts.nonEmpty) {
-                          Some(EntitySoftConflict(refMapping.from.entityType, refMapping.from.entityName, conflicts))
-                        } else {
-                          None
-                        }
-                      }.toSeq
-                      EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts)
+                      unmergedSoftConflicts(entityReferenceMap, softConflicts)
                     }
                 }
               }
@@ -176,6 +160,44 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
     }
     withWorkspaceLastModified(copyResult)
     copyResult
+  }
+
+  private def copyEntitiesExcludingAnySoftConflicts(entityReferenceMap: Set[RefMapping],
+                                                    entityReferences: Set[EntityPointer],
+                                                    softConflicts: Set[EntityPointer],
+                                                    sourceWorkspaceId: UUID,
+                                                    destWorkspaceId: UUID
+  ) = {
+    val allEntityRefs: Set[EntityPointer] = entityReferenceMap.map(_.from) ++ entityReferences
+    val entitiesToCopy: Set[EntityPointer] = allEntityRefs diff softConflicts
+    repository.queries
+      .copyEntitiesToNewWorkspace(
+        sourceWorkspaceId,
+        destWorkspaceId,
+        entitiesToCopy
+      )
+    EntityCopyResponse(
+      entitiesToCopy.map(_.toAttributeEntityReference).toSeq,
+      Seq.empty,
+      Seq.empty
+    )
+  }
+
+  def unmergedSoftConflicts(entityReferenceMap: Set[RefMapping],
+                            softConflicts: Set[EntityPointer]
+  ): EntityCopyResponse = {
+    val unmergedSoftConflicts = entityReferenceMap.flatMap { refMapping =>
+      val conflicts = refMapping.to
+        .intersect(softConflicts)
+        .map(conflict => EntitySoftConflict(conflict.entityType, conflict.entityName, Seq.empty))
+        .toSeq
+      if (conflicts.nonEmpty) {
+        Some(EntitySoftConflict(refMapping.from.entityType, refMapping.from.entityName, conflicts))
+      } else {
+        None
+      }
+    }.toSeq
+    EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts)
   }
 
   override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -32,8 +32,8 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeValue,
   Entity,
   EntityCopyResponse,
-  EntityPointer,
   EntityHardConflict,
+  EntityPointer,
   EntityQuery,
   EntityQueryResponse,
   EntityQueryResultMetadata,
@@ -135,16 +135,16 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                            parentContext: RawlsRequestContext
   ): Future[EntityCopyResponse] = {
 
-    def getSoftConflicts(paths: Set[AttributeEntityReference]): Future[Set[AttributeEntityReference]] =
+    def getSoftConflicts(paths: Set[EntityPointer]): Future[Set[EntityPointer]] =
       // return the entities already present in the destination workspace
       repository.dataSource.inTransaction { _ =>
         repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, paths).map { conflicts =>
-          val conflictsAsRefs = conflicts.toSeq.map(_.toAttributeEntityReference)
+          val conflictsAsRefs = conflicts.toSeq.map(_.toPointer)
           paths.filter(p => conflictsAsRefs.contains(p))
         }
       }
 
-    val entitiesToCopyRefs = entityNames.map(name => AttributeEntityReference(entityType, name))
+    val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name))
     repository.dataSource
       .inTransaction { _ =>
         repository.queries.getEntityRefs(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs.toSet)
@@ -164,9 +164,9 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
 
           pathsAndConflicts.flatMap { case (entityReferenceMap, entityReferences, softConflicts) =>
             if (softConflicts.isEmpty || linkExistingEntities) {
-              val allEntityRefs: Set[AttributeEntityReference] = entityReferences
-              val allConflictRefs: Set[AttributeEntityReference] = softConflicts
-              val entitiesToCopy: Set[AttributeEntityReference] = allEntityRefs diff allConflictRefs
+              val allEntityRefs: Set[EntityPointer] = entityReferences
+              val allConflictRefs: Set[EntityPointer] = softConflicts
+              val entitiesToCopy: Set[EntityPointer] = allEntityRefs diff allConflictRefs
               repository.dataSource.inTransaction { _ =>
                 for {
                   _ <- repository.queries.copyEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID,
@@ -174,7 +174,10 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                                                                      entitiesToCopy
                   )
                   _ <- repository.updateLastModified(workspaceId)
-                } yield EntityCopyResponse(entitiesToCopy.toSeq, Seq.empty, Seq.empty)
+                } yield EntityCopyResponse(entitiesToCopy.map(e => e.toAttributeEntityReference).toSeq,
+                                           Seq.empty,
+                                           Seq.empty
+                )
               }
             } else {
               val unmergedSoftConflicts = entityReferenceMap.flatMap { case (key, value) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderConfig.scala
@@ -3,5 +3,5 @@ package org.broadinstitute.dsde.rawls.entities.compact
 case class CompactEntityProviderConfig(
   // number of entities to handle in a single SQL statement when processing batchUpsert/batchUpdate
   batchUpsertBatchSize: Int = 2500,
-  batchCopyBatchSize: Int = 4000
+  batchCopyBatchSize: Int = 2500
 )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderConfig.scala
@@ -2,5 +2,6 @@ package org.broadinstitute.dsde.rawls.entities.compact
 
 case class CompactEntityProviderConfig(
   // number of entities to handle in a single SQL statement when processing batchUpsert/batchUpdate
-  batchUpsertBatchSize: Int = 2500
+  batchUpsertBatchSize: Int = 250,
+  batchCopyBatchSize: Int = 4000
 )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderConfig.scala
@@ -2,6 +2,5 @@ package org.broadinstitute.dsde.rawls.entities.compact
 
 case class CompactEntityProviderConfig(
   // number of entities to handle in a single SQL statement when processing batchUpsert/batchUpdate
-  batchUpsertBatchSize: Int = 250,
-  batchCopyBatchSize: Int = 4000
+  batchUpsertBatchSize: Int = 250
 )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderConfig.scala
@@ -2,6 +2,6 @@ package org.broadinstitute.dsde.rawls.entities.compact
 
 case class CompactEntityProviderConfig(
   // number of entities to handle in a single SQL statement when processing batchUpsert/batchUpdate
-  batchUpsertBatchSize: Int = 250,
+  batchUpsertBatchSize: Int = 2500,
   batchCopyBatchSize: Int = 4000
 )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderConfig.scala
@@ -2,5 +2,6 @@ package org.broadinstitute.dsde.rawls.entities.compact
 
 case class CompactEntityProviderConfig(
   // number of entities to handle in a single SQL statement when processing batchUpsert/batchUpdate
-  batchUpsertBatchSize: Int = 250
+  batchUpsertBatchSize: Int = 250,
+  batchCopyBatchSize: Int = 4000
 )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderConfig.scala
@@ -3,5 +3,5 @@ package org.broadinstitute.dsde.rawls.entities.compact
 case class CompactEntityProviderConfig(
   // number of entities to handle in a single SQL statement when processing batchUpsert/batchUpdate
   batchUpsertBatchSize: Int = 2500,
-  batchCopyBatchSize: Int = 2500
+  batchCopyBatchSize: Int = 5000
 )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -61,6 +61,13 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
       )
     }
 
+  def getWorkspaceSettingOfType(workspaceName: WorkspaceName,
+                                settingType: WorkspaceSettingType
+  ): Future[Option[WorkspaceSetting]] =
+    getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.readSettings).flatMap { workspace =>
+      workspaceSettingRepository.getWorkspaceSettingOfType(workspace.workspaceIdAsUUID, settingType)
+    }
+
   // Returns applied settings on a workspace.
   def getWorkspaceSettings(workspaceName: WorkspaceName): Future[List[WorkspaceSetting]] =
     getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.readSettings).flatMap { workspace =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -2055,6 +2055,93 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     updatedRefs should contain theSameElementsAs Seq(newTargetEntity.toPointer)
   }
 
+  behavior of "copyEntities"
+
+  it should "copy entities and references from source workspace to destination workspace" in withMinimalTestDatabase {
+    _ =>
+      val sourceWorkspaceId = minimalTestData.workspace.workspaceIdAsUUID
+      val destinationWorkspaceId = minimalTestData.workspace2.workspaceIdAsUUID
+
+      val entity1 =
+        Entity("entityName1", "entityType1", Map(AttributeName.withDefaultNS("attr1") -> AttributeString("value1")))
+      val entity2 =
+        Entity("entityName2", "entityType1", Map(AttributeName.withDefaultNS("attr2") -> AttributeNumber(42)))
+      val entity3 =
+        Entity("entityName3", "entityType2", Map(AttributeName.withDefaultNS("attr3") -> AttributeString("value3")))
+      insertAndGetAll(Seq(entity1, entity2, entity3), sourceWorkspaceId)
+
+      val copiedEntitiesResult = runAndWait(
+        q.copyEntities(sourceWorkspaceId,
+                       destinationWorkspaceId,
+                       Set(entity1.toPointer, entity2.toPointer, entity3.toPointer)
+        )
+      )
+
+      copiedEntitiesResult shouldBe 3
+
+      val copiedEntities = runAndWait(q.listEntities(destinationWorkspaceId, "entityType1")) ++ runAndWait(
+        q.listEntities(destinationWorkspaceId, "entityType2")
+      )
+      copiedEntities.map(_.toEntity) should contain theSameElementsAs Seq(entity1, entity2, entity3)
+
+  }
+
+  it should "copy entityRefs from source workspace to destination workspace" in withMinimalTestDatabase { _ =>
+    // Define source and destination workspaces
+    val sourceWorkspaceId = minimalTestData.workspace.workspaceIdAsUUID
+    val destinationWorkspaceId = minimalTestData.workspace2.workspaceIdAsUUID
+
+    // Create entities in the source workspace
+    val entity1 =
+      Entity("entityName1", "entityType1", Map(AttributeName.withDefaultNS("attr1") -> AttributeString("value1")))
+    val entity2 = Entity("entityName2", "entityType1", Map(AttributeName.withDefaultNS("attr2") -> AttributeNumber(42)))
+    val entity3 =
+      Entity("entityName3", "entityType2", Map(AttributeName.withDefaultNS("attr3") -> AttributeString("value3")))
+
+    // Insert entity references between entities
+    val refMapping = RefMapping(entity1.toPointer, Set(entity2.toPointer, entity3.toPointer))
+    runAndWait(q.insertReferences(sourceWorkspaceId, Set(refMapping)))
+
+    // Perform the copy operation
+    val copiedEntityRefsResult =
+      runAndWait(q.copyEntityReferences(sourceWorkspaceId, destinationWorkspaceId, Set(entity1.toPointer)))
+
+    // Verify the result
+    copiedEntityRefsResult shouldBe 2
+
+    // Verify references in the destination workspace
+    val copiedReferences = runAndWait(q.getReferencesFrom(destinationWorkspaceId, entity1.toPointer))
+    copiedReferences should contain theSameElementsAs Seq(entity2.toPointer, entity3.toPointer)
+  }
+
+  it should "get recursive entity references" in withMinimalTestDatabase { _ =>
+    // Define workspace
+    val workspaceId = minimalTestData.workspace.workspaceIdAsUUID
+
+    // Create entities
+    val entity1 = EntityPointer("entityType1", "entityName1")
+    val entity2 = EntityPointer("entityType1", "entityName2")
+    val entity3 = EntityPointer("entityType1", "entityName3")
+    val entity4 = EntityPointer("entityType1", "entityName4")
+
+    // Insert references to form a recursive structure
+    val refMapping1 = RefMapping(entity1, Set(entity2, entity3))
+    val refMapping2 = RefMapping(entity2, Set(entity4))
+    val refMapping3 = RefMapping(entity3, Set(entity4))
+
+    runAndWait(q.insertReferences(workspaceId, Set(refMapping1, refMapping2, refMapping3)))
+
+    // Perform the recursive query
+    val recursiveReferences = runAndWait(q.recursiveGetEntityReferences(workspaceId, Set(entity1)))
+
+    // Verify the result
+    recursiveReferences should contain theSameElementsAs Set(
+      RefMapping(entity1, Set(entity2, entity3)),
+      RefMapping(entity2, Set(entity4)),
+      RefMapping(entity3, Set(entity4))
+    )
+  }
+
   // ====================================================================================================
   //  helpers for tests
   // ====================================================================================================

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -2057,7 +2057,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
   behavior of "copyEntities"
 
-  it should "copy entities and references from source workspace to destination workspace" in withMinimalTestDatabase {
+  it should "copy entities from source workspace to destination workspace" in withMinimalTestDatabase {
     _ =>
       val sourceWorkspaceId = minimalTestData.workspace.workspaceIdAsUUID
       val destinationWorkspaceId = minimalTestData.workspace2.workspaceIdAsUUID
@@ -2139,6 +2139,30 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       RefMapping(entity1, Set(entity2, entity3)),
       RefMapping(entity2, Set(entity4)),
       RefMapping(entity3, Set(entity4))
+    )
+  }
+
+  it should "get recursive entity references with cycles" in withMinimalTestDatabase { _ =>
+    // Define workspace
+    val workspaceId = minimalTestData.workspace.workspaceIdAsUUID
+
+    // Create entities
+    val entity1 = EntityPointer("entityType1", "entityName1")
+    val entity2 = EntityPointer("entityType1", "entityName2")
+
+    // Insert references to form a recursive structure
+    val refMapping1 = RefMapping(entity1, Set(entity2))
+    val refMapping2 = RefMapping(entity2, Set(entity1))
+
+    runAndWait(q.insertReferences(workspaceId, Set(refMapping1, refMapping2)))
+
+    // Perform the recursive query
+    val recursiveReferences = runAndWait(q.recursiveGetEntityReferences(workspaceId, Set(entity1)))
+
+    // Verify the result
+    recursiveReferences should contain theSameElementsAs Set(
+      RefMapping(entity1, Set(entity2)),
+      RefMapping(entity2, Set(entity1))
     )
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -2124,32 +2124,31 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
   behavior of "copyEntities"
 
-  it should "copy entities from source workspace to destination workspace" in withMinimalTestDatabase {
-    _ =>
-      val sourceWorkspaceId = minimalTestData.workspace.workspaceIdAsUUID
-      val destinationWorkspaceId = minimalTestData.workspace2.workspaceIdAsUUID
+  it should "copy entities from source workspace to destination workspace" in withMinimalTestDatabase { _ =>
+    val sourceWorkspaceId = minimalTestData.workspace.workspaceIdAsUUID
+    val destinationWorkspaceId = minimalTestData.workspace2.workspaceIdAsUUID
 
-      val entity1 =
-        Entity("entityName1", "entityType1", Map(AttributeName.withDefaultNS("attr1") -> AttributeString("value1")))
-      val entity2 =
-        Entity("entityName2", "entityType1", Map(AttributeName.withDefaultNS("attr2") -> AttributeNumber(42)))
-      val entity3 =
-        Entity("entityName3", "entityType2", Map(AttributeName.withDefaultNS("attr3") -> AttributeString("value3")))
-      insertAndGetAll(Seq(entity1, entity2, entity3), sourceWorkspaceId)
+    val entity1 =
+      Entity("entityName1", "entityType1", Map(AttributeName.withDefaultNS("attr1") -> AttributeString("value1")))
+    val entity2 =
+      Entity("entityName2", "entityType1", Map(AttributeName.withDefaultNS("attr2") -> AttributeNumber(42)))
+    val entity3 =
+      Entity("entityName3", "entityType2", Map(AttributeName.withDefaultNS("attr3") -> AttributeString("value3")))
+    insertAndGetAll(Seq(entity1, entity2, entity3), sourceWorkspaceId)
 
-      val copiedEntitiesResult = runAndWait(
-        q.copyEntities(sourceWorkspaceId,
-                       destinationWorkspaceId,
-                       Set(entity1.toPointer, entity2.toPointer, entity3.toPointer)
-        )
+    val copiedEntitiesResult = runAndWait(
+      q.copyEntities(sourceWorkspaceId,
+                     destinationWorkspaceId,
+                     Set(entity1.toPointer, entity2.toPointer, entity3.toPointer)
       )
+    )
 
-      copiedEntitiesResult shouldBe 3
+    copiedEntitiesResult shouldBe 3
 
-      val copiedEntities = runAndWait(q.listEntities(destinationWorkspaceId, "entityType1")) ++ runAndWait(
-        q.listEntities(destinationWorkspaceId, "entityType2")
-      )
-      copiedEntities.map(_.toEntity) should contain theSameElementsAs Seq(entity1, entity2, entity3)
+    val copiedEntities = runAndWait(q.listEntities(destinationWorkspaceId, "entityType1")) ++ runAndWait(
+      q.listEntities(destinationWorkspaceId, "entityType2")
+    )
+    copiedEntities.map(_.toEntity) should contain theSameElementsAs Seq(entity1, entity2, entity3)
 
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -717,6 +717,39 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
 
   }
 
+  behavior of "copyEntities"
+
+  it should "copyEntities from sourceWorkspace to destinationWorkspace" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+    val entityType = "typeA"
+    // Create entities in source workspace
+    val updates = Seq(
+      EntityUpdateDefinition("name1", entityType, Seq()),
+      EntityUpdateDefinition("name2", entityType, Seq())
+    )
+    Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+
+    // Copy entities to destination workspace
+    val copiedEntities = Await.result(
+      provider.copyEntities(minimalTestData.workspace,
+                            minimalTestData.workspace2,
+                            entityType,
+                            updates.map(_.name),
+                            linkExistingEntities = false,
+                            defaultRequestContext
+      ),
+      atMost
+    )
+
+    copiedEntities.entitiesCopied should contain theSameElementsAs Seq(
+      AttributeEntityReference(entityType, "name1"),
+      AttributeEntityReference(entityType, "name2")
+    )
+    copiedEntities.hardConflicts shouldBe empty
+    copiedEntities.softConflicts shouldBe empty
+
+  }
+
   // ====================================================================================================
   //  helper methods
   // ====================================================================================================

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -719,35 +719,72 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
 
   behavior of "copyEntities"
 
-  it should "copyEntities from sourceWorkspace to destinationWorkspace" in withMinimalTestDatabase { _ =>
+  it should "copy entities and entity references from source to destination workspace" in withMinimalTestDatabase { _ =>
     val provider = defaultProvider()
-    val entityType = "typeA"
-    // Create entities in source workspace
-    val updates = Seq(
-      EntityUpdateDefinition("name1", entityType, Seq()),
-      EntityUpdateDefinition("name2", entityType, Seq())
-    )
-    Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
 
-    // Copy entities to destination workspace
+    val updates: Seq[EntityUpdateDefinition] = Seq(
+      EntityUpdateDefinition("name1", "typeA", Seq()),
+      EntityUpdateDefinition(
+        "name2",
+        "typeA",
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("ref"), AttributeEntityReference("typeA", "name1")))
+      ),
+      EntityUpdateDefinition(
+        "name3",
+        "typeB",
+        Seq(
+          AddUpdateAttribute(
+            AttributeName.withDefaultNS("refs"),
+            AttributeEntityReferenceList(
+              Seq(
+                AttributeEntityReference("typeA", "name1"),
+                AttributeEntityReference("typeA", "name2")
+              )
+            )
+          )
+        )
+      )
+    )
+
+    val numUpdated = Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+    numUpdated shouldBe 3
+
     val copiedEntities = Await.result(
       provider.copyEntities(minimalTestData.workspace,
                             minimalTestData.workspace2,
-                            entityType,
-                            updates.map(_.name),
+                            "typeB",
+                            Seq("name3"),
                             linkExistingEntities = false,
                             defaultRequestContext
       ),
       atMost
     )
-
     copiedEntities.entitiesCopied should contain theSameElementsAs Seq(
-      AttributeEntityReference(entityType, "name1"),
-      AttributeEntityReference(entityType, "name2")
+      AttributeEntityReference("typeA", "name1"),
+      AttributeEntityReference("typeA", "name2"),
+      AttributeEntityReference("typeB", "name3")
     )
     copiedEntities.hardConflicts shouldBe empty
     copiedEntities.softConflicts shouldBe empty
 
+  }
+
+  it should "not copy entity that does not exist in source workspace" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+    val copiedEntities = Await.result(
+      provider.copyEntities(
+        minimalTestData.workspace,
+        minimalTestData.workspace2,
+        "typeA",
+        Seq("nonExistentEntity"),
+        linkExistingEntities = false,
+        defaultRequestContext
+      ),
+      atMost
+    )
+    copiedEntities.entitiesCopied shouldBe empty
+    copiedEntities.hardConflicts shouldBe empty
+    copiedEntities.softConflicts shouldBe empty
   }
 
   // ====================================================================================================

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -1544,10 +1544,12 @@ class CompactEntityProviderSpec
           )
         )
       )
-    when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]]))
+    when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]], any[Int]))
       .thenReturn(DBIO.successful((3, 0)))
 
-    val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
+    val config = CompactEntityProviderConfig()
+    val provider =
+      providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext), config)
     val result = Await.result(provider.copyEntities(sourceWorkspace,
                                                     destWorkspace,
                                                     entityType,
@@ -1565,7 +1567,8 @@ class CompactEntityProviderSpec
     verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
     verify(mockQuery, times(1)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID,
                                                            destWorkspace.workspaceIdAsUUID,
-                                                           mockEntityRefs.toSet
+                                                           mockEntityRefs.toSet,
+                                                           config.batchCopyBatchSize
     )
   }
 
@@ -1738,10 +1741,12 @@ class CompactEntityProviderSpec
           Set(RefMapping(EntityPointer(entityType, "entity1"), Set(EntityPointer(entityType, "entity2"))))
         )
       )
-    when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]]))
+    when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]], any[Int]))
       .thenReturn(DBIO.successful((1, 0)))
 
-    val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
+    val config = CompactEntityProviderConfig()
+    val provider =
+      providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext), config)
     val result = Await.result(provider.copyEntities(sourceWorkspace,
                                                     destWorkspace,
                                                     entityType,
@@ -1759,7 +1764,8 @@ class CompactEntityProviderSpec
     verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
     verify(mockQuery, times(1)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID,
                                                            destWorkspace.workspaceIdAsUUID,
-                                                           mockEntityRefs.toSet
+                                                           mockEntityRefs.toSet,
+                                                           config.batchCopyBatchSize
     )
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -1468,7 +1468,7 @@ class CompactEntityProviderSpec
 
   behavior of "copyEntities"
 
-  it should "copy entities from source workspace to destination workspace" in {
+  it should "copy entities from source workspace to destination workspace when no conflicts are present" in {
     val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
@@ -1649,6 +1649,72 @@ class CompactEntityProviderSpec
 
     verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
     verify(mockQuery, times(0)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID,
+                                                           destWorkspace.workspaceIdAsUUID,
+                                                           mockEntityRefs.toSet
+    )
+  }
+
+  it should "exclude copying soft conflicts when soft conflicts are present and linkExistingEntities is true" in {
+    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockRepository = mock[CompactEntityRepository]
+    when(mockRepository.queries).thenReturn(mockQuery)
+    when(mockRepository.dataSource).thenReturn(slickDataSource)
+    when[ReadWriteAction[Int]](mockRepository.updateLastModified(any[UUID]()))
+      .thenReturn(DBIO.successful(1))
+
+    val sourceWorkspace = Workspace("namespace",
+                                    "sourceWorkspace",
+                                    UUID.randomUUID.toString,
+                                    "source-bucket",
+                                    None,
+                                    new DateTime(),
+                                    new DateTime(),
+                                    "creator",
+                                    Map.empty
+    )
+    val destWorkspace = Workspace("namespace",
+                                  "destWorkspace",
+                                  UUID.randomUUID.toString,
+                                  "dest-bucket",
+                                  None,
+                                  new DateTime(),
+                                  new DateTime(),
+                                  "creator",
+                                  Map.empty
+    )
+
+    val entityType = "sampleType"
+    val entityNames = Seq("entity1")
+
+    val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
+    when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity1"))))
+      .thenReturn(DBIO.successful(Seq()))
+    when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity2"))))
+      .thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(2, "entity2", entityType))))
+    when(mockQuery.getEntitySubtrees(sourceWorkspace.workspaceIdAsUUID, entityType, entityNames.toSet))
+      .thenReturn(
+        DBIO.successful(Map.from(mockEntityRefs.map(ref => ref -> Set(EntityPointer(entityType, "entity2")))))
+      )
+    when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]]))
+      .thenReturn(DBIO.successful((1, 0)))
+
+    val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
+    val result = Await.result(provider.copyEntities(sourceWorkspace,
+                                                    destWorkspace,
+                                                    entityType,
+                                                    entityNames,
+                                                    linkExistingEntities = true,
+                                                    defaultRequestContext
+                              ),
+                              atMost
+    )
+
+    result.entitiesCopied.length shouldBe 1
+    result.hardConflicts shouldBe empty
+    result.softConflicts shouldBe empty
+
+    verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
+    verify(mockQuery, times(1)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID,
                                                            destWorkspace.workspaceIdAsUUID,
                                                            mockEntityRefs.toSet
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -10,14 +10,40 @@ import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.CountAndSource
 import org.broadinstitute.dsde.rawls.entities.exceptions._
 import org.broadinstitute.dsde.rawls.model.AgoraEntityType.EntityType
-import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, AttributeUpdateOperation, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeNumber, AttributeRename, AttributeString, Entity, EntityHardConflict, EntityPointer, EntityQuery, EntityQueryResultMetadata, EntitySoftConflict, EntityTypeMetadata, EntityTypeRename, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, SortDirections, UserInfo, Workspace}
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
+  AddUpdateAttribute,
+  AttributeUpdateOperation,
+  EntityUpdateDefinition
+}
+import org.broadinstitute.dsde.rawls.model.{
+  Attributable,
+  AttributeEntityReference,
+  AttributeEntityReferenceList,
+  AttributeName,
+  AttributeNumber,
+  AttributeRename,
+  AttributeString,
+  Entity,
+  EntityHardConflict,
+  EntityPointer,
+  EntityQuery,
+  EntityQueryResultMetadata,
+  EntitySoftConflict,
+  EntityTypeMetadata,
+  EntityTypeRename,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  SortDirections,
+  UserInfo,
+  Workspace
+}
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, MockitoTestUtils}
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, anyString, eq => mockitoEq}
-import org.mockito.Mockito.{never, times, verify, when, timeout => mockitotimeout}
+import org.mockito.Mockito.{never, timeout => mockitotimeout, times, verify, when}
 import org.mockito.{ArgumentMatchers, Mockito}
-import org.scalatest.concurrent.Futures.{PatienceConfig, scaled}
+import org.scalatest.concurrent.Futures.{scaled, PatienceConfig}
 import org.scalatest.time.{Millis, Seconds, Span}
 import slick.dbio.DBIO
 
@@ -1440,7 +1466,6 @@ class CompactEntityProviderSpec
     )
   }
 
-
   behavior of "copyEntities"
 
   it should "copy entities from source workspace to destination workspace" in {
@@ -1452,8 +1477,26 @@ class CompactEntityProviderSpec
       .thenReturn(DBIO.successful(1))
 
     val sourceWorkspaceId = UUID.randomUUID
-    val sourceWorkspace = Workspace("namespace", "sourceWorkspace", sourceWorkspaceId.toString, "source-bucket", None, new DateTime(), new DateTime(), "creator", Map.empty)
-    val destWorkspace = Workspace("namespace", "destWorkspace", UUID.randomUUID.toString, "dest-bucket", None, new DateTime(), new DateTime(), "creator", Map.empty)
+    val sourceWorkspace = Workspace("namespace",
+                                    "sourceWorkspace",
+                                    sourceWorkspaceId.toString,
+                                    "source-bucket",
+                                    None,
+                                    new DateTime(),
+                                    new DateTime(),
+                                    "creator",
+                                    Map.empty
+    )
+    val destWorkspace = Workspace("namespace",
+                                  "destWorkspace",
+                                  UUID.randomUUID.toString,
+                                  "dest-bucket",
+                                  None,
+                                  new DateTime(),
+                                  new DateTime(),
+                                  "creator",
+                                  Map.empty
+    )
 
     val entityType = "sampleType"
     val entityNames = Seq("entity1", "entity2", "entity3")
@@ -1462,17 +1505,29 @@ class CompactEntityProviderSpec
     when(mockQuery.getEntityRefs(any[UUID], any[Set[EntityPointer]])).thenReturn(DBIO.successful(Seq.empty))
     when(mockQuery.getEntitySubtrees(sourceWorkspaceId, entityType, entityNames.toSet))
       .thenReturn(DBIO.successful(Map.from(mockEntityRefs.map(ref => ref -> Set.empty))))
-    when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]])).thenReturn(DBIO.successful((3, 0)))
+    when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]]))
+      .thenReturn(DBIO.successful((3, 0)))
 
     val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
-    val result = Await.result(provider.copyEntities(sourceWorkspace, destWorkspace, entityType, entityNames, linkExistingEntities = false, defaultRequestContext), atMost)
+    val result = Await.result(provider.copyEntities(sourceWorkspace,
+                                                    destWorkspace,
+                                                    entityType,
+                                                    entityNames,
+                                                    linkExistingEntities = false,
+                                                    defaultRequestContext
+                              ),
+                              atMost
+    )
 
     result.entitiesCopied.length shouldBe 3
     result.hardConflicts shouldBe empty
     result.softConflicts shouldBe empty
 
     verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
-    verify(mockQuery, times(1)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID, destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
+    verify(mockQuery, times(1)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID,
+                                                           destWorkspace.workspaceIdAsUUID,
+                                                           mockEntityRefs.toSet
+    )
   }
 
   it should "not copy entities when a hard conflict is present" in {
@@ -1483,23 +1538,53 @@ class CompactEntityProviderSpec
     when[ReadWriteAction[Int]](mockRepository.updateLastModified(any[UUID]()))
       .thenReturn(DBIO.successful(1))
 
-    val sourceWorkspace = Workspace("namespace", "sourceWorkspace", UUID.randomUUID.toString, "source-bucket", None, new DateTime(), new DateTime(), "creator", Map.empty)
-    val destWorkspace = Workspace("namespace", "destWorkspace", UUID.randomUUID.toString, "dest-bucket", None, new DateTime(), new DateTime(), "creator", Map.empty)
+    val sourceWorkspace = Workspace("namespace",
+                                    "sourceWorkspace",
+                                    UUID.randomUUID.toString,
+                                    "source-bucket",
+                                    None,
+                                    new DateTime(),
+                                    new DateTime(),
+                                    "creator",
+                                    Map.empty
+    )
+    val destWorkspace = Workspace("namespace",
+                                  "destWorkspace",
+                                  UUID.randomUUID.toString,
+                                  "dest-bucket",
+                                  None,
+                                  new DateTime(),
+                                  new DateTime(),
+                                  "creator",
+                                  Map.empty
+    )
 
     val entityType = "sampleType"
     val entityNames = Seq("entity1")
 
     val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
-    when(mockQuery.getEntityRefs(any[UUID], any[Set[EntityPointer]])).thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(1, "entity1", entityType))))
+    when(mockQuery.getEntityRefs(any[UUID], any[Set[EntityPointer]]))
+      .thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(1, "entity1", entityType))))
     val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
 
-    val result = Await.result(provider.copyEntities(sourceWorkspace, destWorkspace, entityType, entityNames, linkExistingEntities = false, defaultRequestContext), atMost)
+    val result = Await.result(provider.copyEntities(sourceWorkspace,
+                                                    destWorkspace,
+                                                    entityType,
+                                                    entityNames,
+                                                    linkExistingEntities = false,
+                                                    defaultRequestContext
+                              ),
+                              atMost
+    )
     result.entitiesCopied shouldBe empty
     result.hardConflicts shouldBe Seq(EntityHardConflict(entityType, "entity1"))
     result.softConflicts shouldBe empty
 
     verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
-    verify(mockQuery, times(0)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID, destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
+    verify(mockQuery, times(0)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID,
+                                                           destWorkspace.workspaceIdAsUUID,
+                                                           mockEntityRefs.toSet
+    )
 
   }
 
@@ -1511,27 +1596,62 @@ class CompactEntityProviderSpec
     when[ReadWriteAction[Int]](mockRepository.updateLastModified(any[UUID]()))
       .thenReturn(DBIO.successful(1))
 
-    val sourceWorkspace = Workspace("namespace", "sourceWorkspace", UUID.randomUUID.toString, "source-bucket", None, new DateTime(), new DateTime(), "creator", Map.empty)
-    val destWorkspace = Workspace("namespace", "destWorkspace", UUID.randomUUID.toString, "dest-bucket", None, new DateTime(), new DateTime(), "creator", Map.empty)
+    val sourceWorkspace = Workspace("namespace",
+                                    "sourceWorkspace",
+                                    UUID.randomUUID.toString,
+                                    "source-bucket",
+                                    None,
+                                    new DateTime(),
+                                    new DateTime(),
+                                    "creator",
+                                    Map.empty
+    )
+    val destWorkspace = Workspace("namespace",
+                                  "destWorkspace",
+                                  UUID.randomUUID.toString,
+                                  "dest-bucket",
+                                  None,
+                                  new DateTime(),
+                                  new DateTime(),
+                                  "creator",
+                                  Map.empty
+    )
 
     val entityType = "sampleType"
     val entityNames = Seq("entity1")
 
     val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
-    when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity1")))).thenReturn(DBIO.successful(Seq()))
-    when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity2")))).thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(2, "entity2", entityType))))
+    when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity1"))))
+      .thenReturn(DBIO.successful(Seq()))
+    when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity2"))))
+      .thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(2, "entity2", entityType))))
     when(mockQuery.getEntitySubtrees(sourceWorkspace.workspaceIdAsUUID, entityType, entityNames.toSet))
-      .thenReturn(DBIO.successful(Map.from(mockEntityRefs.map(ref => ref -> Set(EntityPointer(entityType, "entity2"))))))
+      .thenReturn(
+        DBIO.successful(Map.from(mockEntityRefs.map(ref => ref -> Set(EntityPointer(entityType, "entity2")))))
+      )
 
     val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
-    val result = Await.result(provider.copyEntities(sourceWorkspace, destWorkspace, entityType, entityNames, linkExistingEntities = false, defaultRequestContext), atMost)
+    val result = Await.result(provider.copyEntities(sourceWorkspace,
+                                                    destWorkspace,
+                                                    entityType,
+                                                    entityNames,
+                                                    linkExistingEntities = false,
+                                                    defaultRequestContext
+                              ),
+                              atMost
+    )
 
     result.entitiesCopied shouldBe empty
     result.hardConflicts shouldBe empty
-    result.softConflicts shouldBe Seq(EntitySoftConflict(entityType, "entity1", Seq(EntitySoftConflict(entityType, "entity2", Seq.empty))))
+    result.softConflicts shouldBe Seq(
+      EntitySoftConflict(entityType, "entity1", Seq(EntitySoftConflict(entityType, "entity2", Seq.empty)))
+    )
 
     verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
-    verify(mockQuery, times(0)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID, destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
+    verify(mockQuery, times(0)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID,
+                                                           destWorkspace.workspaceIdAsUUID,
+                                                           mockEntityRefs.toSet
+    )
   }
 
   // ====================================================================================================

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.CountAndSource
 import org.broadinstitute.dsde.rawls.entities.exceptions._
 import org.broadinstitute.dsde.rawls.model.AgoraEntityType.EntityType
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, AttributeUpdateOperation, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeNumber, AttributeRename, AttributeString, Entity, EntityPointer, EntityQuery, EntityQueryResultMetadata, EntityTypeMetadata, EntityTypeRename, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, SortDirections, UserInfo, Workspace}
+import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeNumber, AttributeRename, AttributeString, Entity, EntityHardConflict, EntityPointer, EntityQuery, EntityQueryResultMetadata, EntityTypeMetadata, EntityTypeRename, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, SortDirections, UserInfo, Workspace}
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, MockitoTestUtils}
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, anyString, eq => mockitoEq}
@@ -1475,6 +1475,33 @@ class CompactEntityProviderSpec
     verify(mockQuery, times(1)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID, destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
   }
 
+  it should "not copy entities when a hard conflict is present" in {
+    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockRepository = mock[CompactEntityRepository]
+    when(mockRepository.queries).thenReturn(mockQuery)
+    when(mockRepository.dataSource).thenReturn(slickDataSource)
+    when[ReadWriteAction[Int]](mockRepository.updateLastModified(any[UUID]()))
+      .thenReturn(DBIO.successful(1))
+
+    val sourceWorkspace = Workspace("namespace", "sourceWorkspace", UUID.randomUUID.toString, "source-bucket", None, new DateTime(), new DateTime(), "creator", Map.empty)
+    val destWorkspace = Workspace("namespace", "destWorkspace", UUID.randomUUID.toString, "dest-bucket", None, new DateTime(), new DateTime(), "creator", Map.empty)
+
+    val entityType = "sampleType"
+    val entityNames = Seq("entity1")
+
+    val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
+    when(mockQuery.getEntityRefs(any[UUID], any[Set[EntityPointer]])).thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(1, "entity1", entityType))))
+    val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
+
+    val result = Await.result(provider.copyEntities(sourceWorkspace, destWorkspace, entityType, entityNames, linkExistingEntities = false, defaultRequestContext), atMost)
+    result.entitiesCopied shouldBe empty
+    result.hardConflicts shouldBe Seq(EntityHardConflict(entityType, "entity1"))
+    result.softConflicts shouldBe empty
+
+    verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
+    verify(mockQuery, times(0)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID, destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
+
+  }
 
   // ====================================================================================================
   //  helper methods

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -9,38 +9,15 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.CountAndSource
 import org.broadinstitute.dsde.rawls.entities.exceptions._
-import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
-  AddUpdateAttribute,
-  AttributeUpdateOperation,
-  EntityUpdateDefinition
-}
-import org.broadinstitute.dsde.rawls.model.{
-  Attributable,
-  AttributeEntityReference,
-  AttributeEntityReferenceList,
-  AttributeName,
-  AttributeNumber,
-  AttributeRename,
-  AttributeString,
-  Entity,
-  EntityPointer,
-  EntityQuery,
-  EntityQueryResultMetadata,
-  EntityTypeMetadata,
-  EntityTypeRename,
-  RawlsRequestContext,
-  RawlsUserEmail,
-  RawlsUserSubjectId,
-  SortDirections,
-  UserInfo,
-  Workspace
-}
+import org.broadinstitute.dsde.rawls.model.AgoraEntityType.EntityType
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, AttributeUpdateOperation, EntityUpdateDefinition}
+import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeNumber, AttributeRename, AttributeString, Entity, EntityPointer, EntityQuery, EntityQueryResultMetadata, EntityTypeMetadata, EntityTypeRename, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, SortDirections, UserInfo, Workspace}
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, MockitoTestUtils}
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, anyString, eq => mockitoEq}
-import org.mockito.Mockito.{never, timeout => mockitotimeout, times, verify, when}
+import org.mockito.Mockito.{never, times, verify, when, timeout => mockitotimeout}
 import org.mockito.{ArgumentMatchers, Mockito}
-import org.scalatest.concurrent.Futures.{scaled, PatienceConfig}
+import org.scalatest.concurrent.Futures.{PatienceConfig, scaled}
 import org.scalatest.time.{Millis, Seconds, Span}
 import slick.dbio.DBIO
 
@@ -1462,6 +1439,42 @@ class CompactEntityProviderSpec
       )
     )
   }
+
+
+  behavior of "copyEntities"
+
+  it should "copy entities from source workspace to destination workspace" in {
+    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockRepository = mock[CompactEntityRepository]
+    when(mockRepository.queries).thenReturn(mockQuery)
+    when(mockRepository.dataSource).thenReturn(slickDataSource)
+    when[ReadWriteAction[Int]](mockRepository.updateLastModified(any[UUID]()))
+      .thenReturn(DBIO.successful(1))
+
+    val sourceWorkspaceId = UUID.randomUUID
+    val sourceWorkspace = Workspace("namespace", "sourceWorkspace", sourceWorkspaceId.toString, "source-bucket", None, new DateTime(), new DateTime(), "creator", Map.empty)
+    val destWorkspace = Workspace("namespace", "destWorkspace", UUID.randomUUID.toString, "dest-bucket", None, new DateTime(), new DateTime(), "creator", Map.empty)
+
+    val entityType = "sampleType"
+    val entityNames = Seq("entity1", "entity2", "entity3")
+
+    val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
+    when(mockQuery.getEntityRefs(any[UUID], any[Set[EntityPointer]])).thenReturn(DBIO.successful(Seq.empty))
+    when(mockQuery.getEntitySubtrees(sourceWorkspaceId, entityType, entityNames.toSet))
+      .thenReturn(DBIO.successful(Map.from(mockEntityRefs.map(ref => ref -> Set.empty))))
+    when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]])).thenReturn(DBIO.successful((3, 0)))
+
+    val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
+    val result = Await.result(provider.copyEntities(sourceWorkspace, destWorkspace, entityType, entityNames, linkExistingEntities = false, defaultRequestContext), atMost)
+
+    result.entitiesCopied.length shouldBe 3
+    result.hardConflicts shouldBe empty
+    result.softConflicts shouldBe empty
+
+    verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
+    verify(mockQuery, times(1)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID, destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
+  }
+
 
   // ====================================================================================================
   //  helper methods

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -1531,10 +1531,11 @@ class CompactEntityProviderSpec
 
     val entityType = "sampleType"
     val entityNames = Seq("entity1", "entity2", "entity3")
+    val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name)).toSet
 
     val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
     when(mockQuery.getEntityRefs(any[UUID], any[Set[EntityPointer]])).thenReturn(DBIO.successful(Seq.empty))
-    when(mockQuery.getEntitySubtrees(sourceWorkspaceId, entityType, entityNames.toSet))
+    when(mockQuery.recursiveGetEntityReferences(sourceWorkspaceId, entitiesToCopyRefs))
       .thenReturn(
         DBIO.successful(
           Set(
@@ -1661,13 +1662,14 @@ class CompactEntityProviderSpec
 
     val entityType = "sampleType"
     val entityNames = Seq("entity1")
+    val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name)).toSet
 
     val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
     when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity1"))))
       .thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity2"))))
       .thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(2, "entity2", entityType))))
-    when(mockQuery.getEntitySubtrees(sourceWorkspace.workspaceIdAsUUID, entityType, entityNames.toSet))
+    when(mockQuery.recursiveGetEntityReferences(sourceWorkspace.workspaceIdAsUUID, entitiesToCopyRefs))
       .thenReturn(
         DBIO.successful(
           Set(RefMapping(EntityPointer(entityType, "entity1"), Set(EntityPointer(entityType, "entity2"))))
@@ -1729,13 +1731,14 @@ class CompactEntityProviderSpec
 
     val entityType = "sampleType"
     val entityNames = Seq("entity1")
+    val entitiesToCopyRefs = entityNames.map(name => EntityPointer(entityType, name)).toSet
 
     val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
     when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity1"))))
       .thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity2"))))
       .thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(2, "entity2", entityType))))
-    when(mockQuery.getEntitySubtrees(sourceWorkspace.workspaceIdAsUUID, entityType, entityNames.toSet))
+    when(mockQuery.recursiveGetEntityReferences(sourceWorkspace.workspaceIdAsUUID, entitiesToCopyRefs))
       .thenReturn(
         DBIO.successful(
           Set(RefMapping(EntityPointer(entityType, "entity1"), Set(EntityPointer(entityType, "entity2"))))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -1535,7 +1535,7 @@ class CompactEntityProviderSpec
     val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
     when(mockQuery.getEntityRefs(any[UUID], any[Set[EntityPointer]])).thenReturn(DBIO.successful(Seq.empty))
     when(mockQuery.getEntitySubtrees(sourceWorkspaceId, entityType, entityNames.toSet))
-      .thenReturn(DBIO.successful(Map.from(mockEntityRefs.map(ref => ref -> Set.empty))))
+      .thenReturn(DBIO.successful(Set(RefMapping(EntityPointer(entityType, "entity1"), Set.empty))))
     when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]]))
       .thenReturn(DBIO.successful((3, 0)))
 
@@ -1658,7 +1658,9 @@ class CompactEntityProviderSpec
       .thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(2, "entity2", entityType))))
     when(mockQuery.getEntitySubtrees(sourceWorkspace.workspaceIdAsUUID, entityType, entityNames.toSet))
       .thenReturn(
-        DBIO.successful(Map.from(mockEntityRefs.map(ref => ref -> Set(EntityPointer(entityType, "entity2")))))
+        DBIO.successful(
+          Set(RefMapping(EntityPointer(entityType, "entity1"), Set(EntityPointer(entityType, "entity2"))))
+        )
       )
 
     val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
@@ -1724,7 +1726,9 @@ class CompactEntityProviderSpec
       .thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(2, "entity2", entityType))))
     when(mockQuery.getEntitySubtrees(sourceWorkspace.workspaceIdAsUUID, entityType, entityNames.toSet))
       .thenReturn(
-        DBIO.successful(Map.from(mockEntityRefs.map(ref => ref -> Set(EntityPointer(entityType, "entity2")))))
+        DBIO.successful(
+          Set(RefMapping(EntityPointer(entityType, "entity1"), Set(EntityPointer(entityType, "entity2"))))
+        )
       )
     when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]]))
       .thenReturn(DBIO.successful((1, 0)))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -9,7 +9,6 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.CountAndSource
 import org.broadinstitute.dsde.rawls.entities.exceptions._
-import org.broadinstitute.dsde.rawls.model.AgoraEntityType.EntityType
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
   AddUpdateAttribute,
   AttributeUpdateOperation,
@@ -93,7 +92,7 @@ class CompactEntityProviderSpec
   behavior of "batchUpsertEntities and batchUpdateEntities"
 
   it should "issue one insert statement for multiple entities" in {
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.batchCreateEntities(any(), any(), any())).thenReturn(DBIO.successful(0))
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.getEntities(any(), any())).thenReturn(DBIO.successful(Seq()))
@@ -119,7 +118,7 @@ class CompactEntityProviderSpec
   }
 
   it should "issue multiple insert statements when given large batches" in {
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.batchCreateEntities(any(), any(), any())).thenReturn(DBIO.successful(0))
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.getEntities(any(), any())).thenReturn(DBIO.successful(Seq()))
@@ -155,7 +154,7 @@ class CompactEntityProviderSpec
   }
 
   it should "ask to insert references" in {
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.batchCreateEntities(any(), any(), any())).thenReturn(DBIO.successful(-1))
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.getEntities(any(), any())).thenReturn(DBIO.successful(Seq()))
@@ -223,7 +222,7 @@ class CompactEntityProviderSpec
       )
 
     // mocks
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.createEntity(any(), any())).thenReturn(DBIO.successful(1))
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
@@ -266,7 +265,7 @@ class CompactEntityProviderSpec
                           Some("""{"baz":123,"foo":"bar"}""")
       )
 
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.createEntity(any(), any())).thenReturn(DBIO.successful(1))
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
@@ -320,7 +319,7 @@ class CompactEntityProviderSpec
         )
       )
 
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.createEntity(any(), any())).thenReturn(DBIO.successful(1))
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
@@ -384,7 +383,7 @@ class CompactEntityProviderSpec
       )
     )
 
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(None)) // first request finds nothing
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(false)) // reference targets are missing
@@ -427,7 +426,7 @@ class CompactEntityProviderSpec
                           Some("{}")
       )
 
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(Some(createdEntityRec)))
 
@@ -465,7 +464,7 @@ class CompactEntityProviderSpec
   illegalEntities foreach { case (hint, entityToCreate) =>
     it should s"throw RawlsExceptionWithErrorReport when presented with a(n) $hint" in {
       // provider using mocks
-      val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+      val mockQuery = mock[CompactEntityQuery]
       val provider = providerWithMocks(mockQuery)
 
       val actual = intercept[RawlsExceptionWithErrorReport] {
@@ -519,7 +518,7 @@ class CompactEntityProviderSpec
                           Some("""{"baz":456,"foo":"boo"}""")
       )
 
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.getReferencesTo(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.deleteAllReferencesFrom(any(), any())).thenReturn(DBIO.successful(1))
     when(mockQuery.deleteEntities(any(), any())).thenReturn(DBIO.successful(0))
@@ -596,7 +595,7 @@ class CompactEntityProviderSpec
              )
       )
 
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.getReferencesTo(any(), any())).thenReturn(DBIO.successful(Seq(referencingEntity.toPointer)))
     when(mockQuery.deleteAllReferencesFrom(any(), any())).thenReturn(DBIO.successful(1))
     when(
@@ -634,7 +633,7 @@ class CompactEntityProviderSpec
   it should "delete all entities of type" in {
     val entityType = "type"
 
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.getReferencesToType(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.deleteAllReferencesFromType(any(), any())).thenReturn(DBIO.successful(1))
     when(mockQuery.deleteEntitiesOfType(any(), any())).thenReturn(DBIO.successful(0))
@@ -667,7 +666,7 @@ class CompactEntityProviderSpec
              )
       )
 
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.getReferencesToType(any(), any())).thenReturn(DBIO.successful(Seq(referencingEntity.toPointer)))
     when(mockQuery.deleteAllReferencesFromType(any(), any())).thenReturn(DBIO.successful(1))
     when(mockQuery.batchHideType(any(), any())).thenReturn(DBIO.successful(1))
@@ -691,7 +690,7 @@ class CompactEntityProviderSpec
   behavior of "entityTypeMetadata"
 
   it should "return empty map when no entities exist" in {
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.listEntityKeys(any[UUID]))
       .thenReturn(DBIO.successful(Seq.empty))
     when(mockQuery.countEntitiesGroupedByType(any[UUID]))
@@ -706,7 +705,7 @@ class CompactEntityProviderSpec
   }
 
   it should "return map with entity type and count when entities exist" in {
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     // type1 and type2 have keys, type3 has no keys
     when(mockQuery.listEntityKeys(any[UUID]))
       .thenReturn(
@@ -748,7 +747,7 @@ class CompactEntityProviderSpec
       CompactEntityRecord(1, "name", "type", UUID.randomUUID(), -1, deleted = false, Some("{}"))
 
     // mocks
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(Some(rec)))
 
@@ -767,7 +766,7 @@ class CompactEntityProviderSpec
       CompactEntityRecord(1, "name", "type", UUID.randomUUID(), -1, deleted = false, Some(attrString))
 
     // mocks
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(Some(rec)))
 
@@ -789,7 +788,7 @@ class CompactEntityProviderSpec
 
   it should "throw EntityNotFoundException if row not found in db" in {
     // mocks
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(None))
     // provider using mocks
@@ -811,7 +810,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("same")
     val newName = AttributeName.withDefaultNS("same")
 
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
 
     val provider = providerWithMocks(mockQueries)
 
@@ -830,7 +829,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("oldName")
     val newName = AttributeName.withDefaultNS("no! @@bad@@")
 
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
 
     val provider = providerWithMocks(mockQueries)
 
@@ -849,7 +848,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("no! @@bad@@")
     val newName = AttributeName.withDefaultNS("newName")
 
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
 
     val provider = providerWithMocks(mockQueries)
 
@@ -868,7 +867,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("oldName")
     val newName = AttributeName.withDefaultNS(s"${entityType}_id")
 
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
 
     val provider = providerWithMocks(mockQueries)
 
@@ -887,7 +886,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS(s"${entityType}_id")
     val newName = AttributeName.withDefaultNS("newName")
 
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
 
     val provider = providerWithMocks(mockQueries)
 
@@ -906,7 +905,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("oldName")
     val newName = AttributeName.withDefaultNS("newName")
 
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
 
     // mock: new name already exists
     when(mockQueries.attributeExists(any[UUID], anyString(), mockitoEq(newName)))
@@ -929,7 +928,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("oldName")
     val newName = AttributeName.withDefaultNS("newName")
 
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
 
     // mock: new name does not exist
     when(mockQueries.attributeExists(any[UUID], anyString(), mockitoEq(newName)))
@@ -955,7 +954,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("oldName")
     val newName = AttributeName.withDefaultNS("newName")
 
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
 
     // mock: new name does not exist
     when(mockQueries.attributeExists(any[UUID], anyString(), mockitoEq(newName)))
@@ -980,7 +979,7 @@ class CompactEntityProviderSpec
   behavior of "renameEntityType"
 
   it should "throw NotFound if the entity type doesn't exist" in {
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
 
     // Mock the count for a non-existent entity type to return 0
     when(mockQueries.countEntities(any[UUID], anyString())).thenReturn(DBIO.successful(0))
@@ -1001,7 +1000,7 @@ class CompactEntityProviderSpec
   }
 
   it should "throw Conflict if the new entity type already exists" in {
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
 
     // The old type exists
     when(mockQueries.countEntities(any[UUID], mockitoEq("existingType"))).thenReturn(DBIO.successful(2))
@@ -1027,7 +1026,7 @@ class CompactEntityProviderSpec
     val oldType = "oldType"
     val newType = "newType"
 
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
 
     // The old type exists
     when(mockQueries.countEntities(any[UUID], mockitoEq(oldType))).thenReturn(DBIO.successful(5))
@@ -1050,7 +1049,7 @@ class CompactEntityProviderSpec
     val entityName = "entityName"
     val operations = Seq.empty[AttributeUpdateOperation]
 
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
     val provider = providerWithMocks(mockQueries)
 
     val actual = intercept[UnsupportedEntityOperationException] {
@@ -1070,7 +1069,7 @@ class CompactEntityProviderSpec
       )
     )
 
-    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQueries = mock[CompactEntityQuery]
     // mock: batchUpdate does not find the pre-existing entity
     when(mockQueries.getEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any()))
       .thenAnswer(_ => throw new EntityNotFoundException())
@@ -1095,7 +1094,7 @@ class CompactEntityProviderSpec
       AttributeName.withDefaultNS("baz") -> AttributeNumber(42)
     )
     val entity = Entity("name", "type", attributes)
-    val provider = providerWithMocks(mock[slickDataSource.dataAccess.compactEntityQuery.type])
+    val provider = providerWithMocks(mock[CompactEntityQuery])
 
     val actual = provider.findAllReferences(entity)
 
@@ -1115,7 +1114,7 @@ class CompactEntityProviderSpec
       )
     )
     val entity = Entity("name", "type", attributes)
-    val provider = providerWithMocks(mock[slickDataSource.dataAccess.compactEntityQuery.type])
+    val provider = providerWithMocks(mock[CompactEntityQuery])
 
     val actual = provider.findAllReferences(entity)
 
@@ -1138,7 +1137,7 @@ class CompactEntityProviderSpec
   it should "return an empty Map when fed an empty Seq" in {
     val input = Seq()
 
-    val provider = providerWithMocks(mock[slickDataSource.dataAccess.compactEntityQuery.type])
+    val provider = providerWithMocks(mock[CompactEntityQuery])
 
     val actual = provider.findAllReferences(input)
 
@@ -1152,7 +1151,7 @@ class CompactEntityProviderSpec
     )
     val entity1 = Entity("name1", "type", attributes)
     val entity2 = Entity("name2", "type", attributes)
-    val provider = providerWithMocks(mock[slickDataSource.dataAccess.compactEntityQuery.type])
+    val provider = providerWithMocks(mock[CompactEntityQuery])
 
     val actual =
       provider.findAllReferences(Seq(entity1, entity2))
@@ -1196,7 +1195,7 @@ class CompactEntityProviderSpec
       )
     )
 
-    val provider = providerWithMocks(mock[slickDataSource.dataAccess.compactEntityQuery.type])
+    val provider = providerWithMocks(mock[CompactEntityQuery])
 
     val actual =
       provider.findAllReferences(Seq(entity1, entity2, entity3))
@@ -1240,7 +1239,7 @@ class CompactEntityProviderSpec
       )
     )
 
-    val provider = providerWithMocks(mock[slickDataSource.dataAccess.compactEntityQuery.type])
+    val provider = providerWithMocks(mock[CompactEntityQuery])
 
     val actual =
       provider.findAllReferences(Seq(entity1, entity2, entity3))
@@ -1260,7 +1259,7 @@ class CompactEntityProviderSpec
   behavior of "withWorkspaceLastModified"
 
   it should "trigger a last-modified update on success of the original future" in {
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1280,7 +1279,7 @@ class CompactEntityProviderSpec
   }
 
   it should "not trigger a last-modified update on failure of the original future" in {
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1305,7 +1304,7 @@ class CompactEntityProviderSpec
   }
 
   it should "not fail if the last-modified update fails" in {
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1501,7 +1500,7 @@ class CompactEntityProviderSpec
   behavior of "copyEntities"
 
   it should "copy entities from source workspace to destination workspace when no conflicts are present" in {
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1510,24 +1509,24 @@ class CompactEntityProviderSpec
 
     val sourceWorkspaceId = UUID.randomUUID
     val sourceWorkspace = Workspace("namespace",
-      "sourceWorkspace",
-      sourceWorkspaceId.toString,
-      "source-bucket",
-      None,
-      new DateTime(),
-      new DateTime(),
-      "creator",
-      Map.empty
+                                    "sourceWorkspace",
+                                    sourceWorkspaceId.toString,
+                                    "source-bucket",
+                                    None,
+                                    new DateTime(),
+                                    new DateTime(),
+                                    "creator",
+                                    Map.empty
     )
     val destWorkspace = Workspace("namespace",
-      "destWorkspace",
-      UUID.randomUUID.toString,
-      "dest-bucket",
-      None,
-      new DateTime(),
-      new DateTime(),
-      "creator",
-      Map.empty
+                                  "destWorkspace",
+                                  UUID.randomUUID.toString,
+                                  "dest-bucket",
+                                  None,
+                                  new DateTime(),
+                                  new DateTime(),
+                                  "creator",
+                                  Map.empty
     )
 
     val entityType = "sampleType"
@@ -1542,13 +1541,13 @@ class CompactEntityProviderSpec
 
     val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
     val result = Await.result(provider.copyEntities(sourceWorkspace,
-      destWorkspace,
-      entityType,
-      entityNames,
-      linkExistingEntities = false,
-      defaultRequestContext
-    ),
-      atMost
+                                                    destWorkspace,
+                                                    entityType,
+                                                    entityNames,
+                                                    linkExistingEntities = false,
+                                                    defaultRequestContext
+                              ),
+                              atMost
     )
 
     result.entitiesCopied.length shouldBe 3
@@ -1557,13 +1556,13 @@ class CompactEntityProviderSpec
 
     verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
     verify(mockQuery, times(1)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID,
-      destWorkspace.workspaceIdAsUUID,
-      mockEntityRefs.toSet
+                                                           destWorkspace.workspaceIdAsUUID,
+                                                           mockEntityRefs.toSet
     )
   }
 
   it should "not copy entities when a hard conflict is present" in {
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1571,24 +1570,24 @@ class CompactEntityProviderSpec
       .thenReturn(DBIO.successful(1))
 
     val sourceWorkspace = Workspace("namespace",
-      "sourceWorkspace",
-      UUID.randomUUID.toString,
-      "source-bucket",
-      None,
-      new DateTime(),
-      new DateTime(),
-      "creator",
-      Map.empty
+                                    "sourceWorkspace",
+                                    UUID.randomUUID.toString,
+                                    "source-bucket",
+                                    None,
+                                    new DateTime(),
+                                    new DateTime(),
+                                    "creator",
+                                    Map.empty
     )
     val destWorkspace = Workspace("namespace",
-      "destWorkspace",
-      UUID.randomUUID.toString,
-      "dest-bucket",
-      None,
-      new DateTime(),
-      new DateTime(),
-      "creator",
-      Map.empty
+                                  "destWorkspace",
+                                  UUID.randomUUID.toString,
+                                  "dest-bucket",
+                                  None,
+                                  new DateTime(),
+                                  new DateTime(),
+                                  "creator",
+                                  Map.empty
     )
 
     val entityType = "sampleType"
@@ -1600,13 +1599,13 @@ class CompactEntityProviderSpec
     val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
 
     val result = Await.result(provider.copyEntities(sourceWorkspace,
-      destWorkspace,
-      entityType,
-      entityNames,
-      linkExistingEntities = false,
-      defaultRequestContext
-    ),
-      atMost
+                                                    destWorkspace,
+                                                    entityType,
+                                                    entityNames,
+                                                    linkExistingEntities = false,
+                                                    defaultRequestContext
+                              ),
+                              atMost
     )
     result.entitiesCopied shouldBe empty
     result.hardConflicts shouldBe Seq(EntityHardConflict(entityType, "entity1"))
@@ -1614,14 +1613,14 @@ class CompactEntityProviderSpec
 
     verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
     verify(mockQuery, times(0)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID,
-      destWorkspace.workspaceIdAsUUID,
-      mockEntityRefs.toSet
+                                                           destWorkspace.workspaceIdAsUUID,
+                                                           mockEntityRefs.toSet
     )
 
   }
 
   it should "not copy entities when soft conflicts are present and linkExistingEntities is false" in {
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1629,24 +1628,24 @@ class CompactEntityProviderSpec
       .thenReturn(DBIO.successful(1))
 
     val sourceWorkspace = Workspace("namespace",
-      "sourceWorkspace",
-      UUID.randomUUID.toString,
-      "source-bucket",
-      None,
-      new DateTime(),
-      new DateTime(),
-      "creator",
-      Map.empty
+                                    "sourceWorkspace",
+                                    UUID.randomUUID.toString,
+                                    "source-bucket",
+                                    None,
+                                    new DateTime(),
+                                    new DateTime(),
+                                    "creator",
+                                    Map.empty
     )
     val destWorkspace = Workspace("namespace",
-      "destWorkspace",
-      UUID.randomUUID.toString,
-      "dest-bucket",
-      None,
-      new DateTime(),
-      new DateTime(),
-      "creator",
-      Map.empty
+                                  "destWorkspace",
+                                  UUID.randomUUID.toString,
+                                  "dest-bucket",
+                                  None,
+                                  new DateTime(),
+                                  new DateTime(),
+                                  "creator",
+                                  Map.empty
     )
 
     val entityType = "sampleType"
@@ -1664,13 +1663,13 @@ class CompactEntityProviderSpec
 
     val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
     val result = Await.result(provider.copyEntities(sourceWorkspace,
-      destWorkspace,
-      entityType,
-      entityNames,
-      linkExistingEntities = false,
-      defaultRequestContext
-    ),
-      atMost
+                                                    destWorkspace,
+                                                    entityType,
+                                                    entityNames,
+                                                    linkExistingEntities = false,
+                                                    defaultRequestContext
+                              ),
+                              atMost
     )
 
     result.entitiesCopied shouldBe empty
@@ -1681,13 +1680,13 @@ class CompactEntityProviderSpec
 
     verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
     verify(mockQuery, times(0)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID,
-      destWorkspace.workspaceIdAsUUID,
-      mockEntityRefs.toSet
+                                                           destWorkspace.workspaceIdAsUUID,
+                                                           mockEntityRefs.toSet
     )
   }
 
   it should "exclude copying soft conflicts when soft conflicts are present and linkExistingEntities is true" in {
-    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockQuery = mock[CompactEntityQuery]
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1695,24 +1694,24 @@ class CompactEntityProviderSpec
       .thenReturn(DBIO.successful(1))
 
     val sourceWorkspace = Workspace("namespace",
-      "sourceWorkspace",
-      UUID.randomUUID.toString,
-      "source-bucket",
-      None,
-      new DateTime(),
-      new DateTime(),
-      "creator",
-      Map.empty
+                                    "sourceWorkspace",
+                                    UUID.randomUUID.toString,
+                                    "source-bucket",
+                                    None,
+                                    new DateTime(),
+                                    new DateTime(),
+                                    "creator",
+                                    Map.empty
     )
     val destWorkspace = Workspace("namespace",
-      "destWorkspace",
-      UUID.randomUUID.toString,
-      "dest-bucket",
-      None,
-      new DateTime(),
-      new DateTime(),
-      "creator",
-      Map.empty
+                                  "destWorkspace",
+                                  UUID.randomUUID.toString,
+                                  "dest-bucket",
+                                  None,
+                                  new DateTime(),
+                                  new DateTime(),
+                                  "creator",
+                                  Map.empty
     )
 
     val entityType = "sampleType"
@@ -1732,13 +1731,13 @@ class CompactEntityProviderSpec
 
     val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
     val result = Await.result(provider.copyEntities(sourceWorkspace,
-      destWorkspace,
-      entityType,
-      entityNames,
-      linkExistingEntities = true,
-      defaultRequestContext
-    ),
-      atMost
+                                                    destWorkspace,
+                                                    entityType,
+                                                    entityNames,
+                                                    linkExistingEntities = true,
+                                                    defaultRequestContext
+                              ),
+                              atMost
     )
 
     result.entitiesCopied.length shouldBe 1
@@ -1747,8 +1746,8 @@ class CompactEntityProviderSpec
 
     verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
     verify(mockQuery, times(1)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID,
-      destWorkspace.workspaceIdAsUUID,
-      mockEntityRefs.toSet
+                                                           destWorkspace.workspaceIdAsUUID,
+                                                           mockEntityRefs.toSet
     )
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.CountAndSource
 import org.broadinstitute.dsde.rawls.entities.exceptions._
 import org.broadinstitute.dsde.rawls.model.AgoraEntityType.EntityType
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, AttributeUpdateOperation, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeNumber, AttributeRename, AttributeString, Entity, EntityHardConflict, EntityPointer, EntityQuery, EntityQueryResultMetadata, EntityTypeMetadata, EntityTypeRename, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, SortDirections, UserInfo, Workspace}
+import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeNumber, AttributeRename, AttributeString, Entity, EntityHardConflict, EntityPointer, EntityQuery, EntityQueryResultMetadata, EntitySoftConflict, EntityTypeMetadata, EntityTypeRename, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, SortDirections, UserInfo, Workspace}
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, MockitoTestUtils}
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, anyString, eq => mockitoEq}
@@ -1501,6 +1501,37 @@ class CompactEntityProviderSpec
     verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
     verify(mockQuery, times(0)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID, destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
 
+  }
+
+  it should "not copy entities when soft conflicts are present and linkExistingEntities is false" in {
+    val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val mockRepository = mock[CompactEntityRepository]
+    when(mockRepository.queries).thenReturn(mockQuery)
+    when(mockRepository.dataSource).thenReturn(slickDataSource)
+    when[ReadWriteAction[Int]](mockRepository.updateLastModified(any[UUID]()))
+      .thenReturn(DBIO.successful(1))
+
+    val sourceWorkspace = Workspace("namespace", "sourceWorkspace", UUID.randomUUID.toString, "source-bucket", None, new DateTime(), new DateTime(), "creator", Map.empty)
+    val destWorkspace = Workspace("namespace", "destWorkspace", UUID.randomUUID.toString, "dest-bucket", None, new DateTime(), new DateTime(), "creator", Map.empty)
+
+    val entityType = "sampleType"
+    val entityNames = Seq("entity1")
+
+    val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
+    when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity1")))).thenReturn(DBIO.successful(Seq()))
+    when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity2")))).thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(2, "entity2", entityType))))
+    when(mockQuery.getEntitySubtrees(sourceWorkspace.workspaceIdAsUUID, entityType, entityNames.toSet))
+      .thenReturn(DBIO.successful(Map.from(mockEntityRefs.map(ref => ref -> Set(EntityPointer(entityType, "entity2"))))))
+
+    val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
+    val result = Await.result(provider.copyEntities(sourceWorkspace, destWorkspace, entityType, entityNames, linkExistingEntities = false, defaultRequestContext), atMost)
+
+    result.entitiesCopied shouldBe empty
+    result.hardConflicts shouldBe empty
+    result.softConflicts shouldBe Seq(EntitySoftConflict(entityType, "entity1", Seq(EntitySoftConflict(entityType, "entity2", Seq.empty))))
+
+    verify(mockQuery, times(1)).getEntityRefs(destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
+    verify(mockQuery, times(0)).copyEntitiesToNewWorkspace(sourceWorkspace.workspaceIdAsUUID, destWorkspace.workspaceIdAsUUID, mockEntityRefs.toSet)
   }
 
   // ====================================================================================================

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -1500,6 +1500,7 @@ class CompactEntityProviderSpec
   behavior of "copyEntities"
 
   it should "copy entities from source workspace to destination workspace when no conflicts are present" in {
+    val config = CompactEntityProviderConfig()
     val mockQuery = mock[CompactEntityQuery]
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
@@ -1535,7 +1536,7 @@ class CompactEntityProviderSpec
 
     val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
     when(mockQuery.getEntityRefs(any[UUID], any[Set[EntityPointer]])).thenReturn(DBIO.successful(Seq.empty))
-    when(mockQuery.recursiveGetEntityReferences(sourceWorkspaceId, entitiesToCopyRefs))
+    when(mockQuery.recursiveGetEntityReferences(sourceWorkspaceId, entitiesToCopyRefs, config.batchCopyBatchSize))
       .thenReturn(
         DBIO.successful(
           Set(
@@ -1548,7 +1549,6 @@ class CompactEntityProviderSpec
     when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]], any[Int]))
       .thenReturn(DBIO.successful((3, 0)))
 
-    val config = CompactEntityProviderConfig()
     val provider =
       providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext), config)
     val result = Await.result(provider.copyEntities(sourceWorkspace,
@@ -1632,6 +1632,7 @@ class CompactEntityProviderSpec
   }
 
   it should "not copy entities when soft conflicts are present and linkExistingEntities is false" in {
+    val config = CompactEntityProviderConfig()
     val mockQuery = mock[CompactEntityQuery]
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
@@ -1669,7 +1670,12 @@ class CompactEntityProviderSpec
       .thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity2"))))
       .thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(2, "entity2", entityType))))
-    when(mockQuery.recursiveGetEntityReferences(sourceWorkspace.workspaceIdAsUUID, entitiesToCopyRefs))
+    when(
+      mockQuery.recursiveGetEntityReferences(sourceWorkspace.workspaceIdAsUUID,
+                                             entitiesToCopyRefs,
+                                             config.batchCopyBatchSize
+      )
+    )
       .thenReturn(
         DBIO.successful(
           Set(RefMapping(EntityPointer(entityType, "entity1"), Set(EntityPointer(entityType, "entity2"))))
@@ -1701,6 +1707,7 @@ class CompactEntityProviderSpec
   }
 
   it should "exclude copying soft conflicts when soft conflicts are present and linkExistingEntities is true" in {
+    val config = CompactEntityProviderConfig()
     val mockQuery = mock[CompactEntityQuery]
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
@@ -1738,7 +1745,12 @@ class CompactEntityProviderSpec
       .thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityRefs(destWorkspace.workspaceIdAsUUID, Set(EntityPointer(entityType, "entity2"))))
       .thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(2, "entity2", entityType))))
-    when(mockQuery.recursiveGetEntityReferences(sourceWorkspace.workspaceIdAsUUID, entitiesToCopyRefs))
+    when(
+      mockQuery.recursiveGetEntityReferences(sourceWorkspace.workspaceIdAsUUID,
+                                             entitiesToCopyRefs,
+                                             config.batchCopyBatchSize
+      )
+    )
       .thenReturn(
         DBIO.successful(
           Set(RefMapping(EntityPointer(entityType, "entity1"), Set(EntityPointer(entityType, "entity2"))))
@@ -1747,7 +1759,6 @@ class CompactEntityProviderSpec
     when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]], any[Int]))
       .thenReturn(DBIO.successful((1, 0)))
 
-    val config = CompactEntityProviderConfig()
     val provider =
       providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext), config)
     val result = Await.result(provider.copyEntities(sourceWorkspace,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.scaladsl.Source
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
-import org.broadinstitute.dsde.rawls.dataaccess.slick._
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{RefMapping, _}
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.CountAndSource
 import org.broadinstitute.dsde.rawls.entities.exceptions._
@@ -1535,7 +1535,15 @@ class CompactEntityProviderSpec
     val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
     when(mockQuery.getEntityRefs(any[UUID], any[Set[EntityPointer]])).thenReturn(DBIO.successful(Seq.empty))
     when(mockQuery.getEntitySubtrees(sourceWorkspaceId, entityType, entityNames.toSet))
-      .thenReturn(DBIO.successful(Set(RefMapping(EntityPointer(entityType, "entity1"), Set.empty))))
+      .thenReturn(
+        DBIO.successful(
+          Set(
+            RefMapping(EntityPointer(entityType, "entity1"), Set.empty),
+            RefMapping(EntityPointer(entityType, "entity2"), Set.empty),
+            RefMapping(EntityPointer(entityType, "entity3"), Set.empty)
+          )
+        )
+      )
     when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]]))
       .thenReturn(DBIO.successful((3, 0)))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -301,6 +301,15 @@ trait ApiServiceSpec
     val requesterPaysSetupService =
       new RequesterPaysSetupServiceImpl(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
 
+    override val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService =
+      new WorkspaceSettingService(_,
+                                  new WorkspaceSettingRepository(slickDataSource),
+                                  new WorkspaceRepository(slickDataSource),
+                                  gcsDAO,
+                                  samDAO,
+                                  mock[GoogleStorageService[IO]]
+      )
+
     val entityManager = EntityManager.defaultEntityManager(
       dataSource,
       new WorkspaceSettingRepository(dataSource),
@@ -310,7 +319,13 @@ trait ApiServiceSpec
     )
 
     val entityServiceConstructor =
-      EntityService.constructor(slickDataSource, samDAO, workbenchMetricBaseName = "test", entityManager, 1000) _
+      EntityService.constructor(slickDataSource,
+                                samDAO,
+                                workbenchMetricBaseName = "test",
+                                entityManager,
+                                1000,
+                                Some(workspaceSettingServiceConstructor)
+      ) _
 
     val resourceBufferDAO: ResourceBufferDAO = new MockResourceBufferDAO
     val resourceBufferConfig = ResourceBufferConfig(testConf.getConfig("resourceBuffer"))
@@ -378,15 +393,6 @@ trait ApiServiceSpec
       leonardoDAO,
       workbenchMetricBaseName
     )
-
-    override val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService =
-      new WorkspaceSettingService(_,
-                                  new WorkspaceSettingRepository(slickDataSource),
-                                  new WorkspaceRepository(slickDataSource),
-                                  gcsDAO,
-                                  samDAO,
-                                  mock[GoogleStorageService[IO]]
-      )
 
     val spendReportingBigQueryService = bigQueryServiceFactory.getServiceFromJson("json", GoogleProject("test-project"))
     val spendReportingServiceConfig =


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-467

Changes:
- In `entityService.copyEntities`, check that both the source and destination workspace have the same setting for CompactDataTablesSetting. If it is only enabled for one, throw an exception
- Implement copyEntities in CompactEntityProvider:
  - If the destination workspace already contains a record for any of the entities being copied, the request fails (these are hard conflicts)
  - Otherwise, check if the destination workspace contains a record for any of the downstream references of the entities being copied (soft conflicts). If there are no soft conflicts or `linkExistingEntities` is true, copy the entities and exclude any soft conflicts. If `linkExistingEntities` is false, do not copy anything and return the soft conflicts.

The legacy copyEntities code has different behavior for checking soft conflicts. It recursively builds a path of references for each entity being copied. If the destination workspace contains the last entity in the path it is considered a soft conflict. With the new implementation, if ANY of the references of the entity exist for the destination workspace, it is considered a soft conflict. Because we do not need to know the entity path, this also changes the response when the request fails due to soft conflicts (and linkExistingEntities is false). Instead of EntitySoftConflict including the conflicts recursively, it will be flattened: `EntitySoftConflict(entityToCopy.entityType, entityToCopy.entityName, Seq(EntitySoftConflict(entityRef.entityType, entityRef.entityName, Seq()), EntitySoftConflict(entityRef2.entityType, entityRef2.entityName, Seq())...))`

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
