### PR TITLE
CORE-472: Quicksilver updateEntity

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -95,6 +95,8 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
       sql"""(${entity.name}, ${entity.entityType}, $workspaceId, 0, 0, $attributesJson)"""
     }
 
+    // when called with insertOnly=true, the SQL statement is a simple `insert into ...`.
+    // when called with insertOnly=false, the SQL statement is `insert into ... on duplicate key update`.
     val upsertSql = if (insertOnly) {
       sql""
     } else {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -84,7 +84,7 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
     *
     * `execution plan: multiple-row insert`
     */
-  def batchCreateEntities(workspaceId: UUID, entities: Seq[Entity], allowUpsert: Boolean): ReadWriteAction[Int] = {
+  def batchCreateEntities(workspaceId: UUID, entities: Seq[Entity], insertOnly: Boolean): ReadWriteAction[Int] = {
     val baseSql =
       sql"""insert into ENTITY(name, entity_type, workspace_id, record_version, deleted, attributes) values """
 
@@ -94,10 +94,10 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
       sql"""(${entity.name}, ${entity.entityType}, $workspaceId, 0, 0, $attributesJson)"""
     }
 
-    val upsertSql = if (allowUpsert) {
-      sql""" on duplicate key update record_version = record_version+1, attributes = VALUES(attributes);"""
-    } else {
+    val upsertSql = if (insertOnly) {
       sql""
+    } else {
+      sql""" on duplicate key update record_version = record_version+1, attributes = VALUES(attributes);"""
     }
 
     concatSqlActions(baseSql, reduceSqlActionsWithDelim(values, sql","), upsertSql).asUpdate
@@ -111,7 +111,7 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
     * `execution plan: single-row insert`
     */
   def createEntity(workspaceId: UUID, entity: Entity): ReadWriteAction[Int] =
-    batchCreateEntities(workspaceId, Seq(entity), allowUpsert = false)
+    batchCreateEntities(workspaceId, Seq(entity), insertOnly = true)
 
   /**
     * Read a single entity from the db
@@ -474,10 +474,10 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   def renameEntityType(workspaceId: UUID, oldType: String, newType: String): ReadWriteAction[Int] = {
     // Update the entity type in the ENTITY table
     // explain plan: index range scan on idx_entity_type_name
-    val updateEntityTypeSql = 
+    val updateEntityTypeSql =
       sql"""update ENTITY set entity_type = $newType, record_version = record_version + 1
             where workspace_id = $workspaceId and entity_type = $oldType and deleted = 0"""
-    
+
     // Update entity references in the attributes JSON column
     // This requires a custom function that can do complex JSON updates which MySQL doesn't provide natively
     // The best approach would be to add a custom MySQL function for JSON path replacement
@@ -490,7 +490,7 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
             set from_entity_type = $newType
             where workspace_id = $workspaceId
             and from_entity_type = $oldType"""
-            
+
     // Update to_entity_type in ENTITY_REFS table
     // explain plan: index range scan on unq_from_to
     val updateToReferencesSql =
@@ -539,24 +539,25 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
         reduceSqlActionsWithDelim(replaceParamsSqls.toSeq, sql","),
         sql""") where er.workspace_id = $workspaceId and er.to_entity_type = $oldType"""
       )
-  }
-    
+    }
+
     // Execute all updates in same transaction
     for {
       paths <- getReferencePathsInAttributesSql.as[String]
-      _ <- if(paths.isEmpty) {
-        DBIO.successful(0)
-      } else {
-        DBIO.seq(
-          updateReferencesInAttributesSql(paths).asUpdate,
-          updateToReferencesSql.asUpdate
-        )
-      }
+      _ <-
+        if (paths.isEmpty) {
+          DBIO.successful(0)
+        } else {
+          DBIO.seq(
+            updateReferencesInAttributesSql(paths).asUpdate,
+            updateToReferencesSql.asUpdate
+          )
+        }
       _ <- updateFromReferencesSql.asUpdate
       entityRowsUpdated <- updateEntityTypeSql.asUpdate
     } yield entityRowsUpdated
   }
-  
+
   // ====================================================================================================
   //  entity query helpers
   //      methods in this section are used for building entity query functions

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -76,7 +76,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
     parentContext: RawlsRequestContext
   ): Future[Int] = {
     // perform the updates
-    val dbResults: Future[Int] = handleUpdates(entityUpdates, allowUpsert = false, config, parentContext)
+    val dbResults: Future[Int] = handleUpdates(entityUpdates, allowInsert = false, config, parentContext)
     // Fire-and-forget an update to the workspace's last-modified date; no need to wait for it to complete
     withWorkspaceLastModified(dbResults)
     // and return
@@ -88,7 +88,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
     parentContext: RawlsRequestContext
   ): Future[Int] = {
     // perform the upserts
-    val dbResults: Future[Int] = handleUpdates(entityUpdates, allowUpsert = true, config, parentContext)
+    val dbResults: Future[Int] = handleUpdates(entityUpdates, allowInsert = true, config, parentContext)
     // Fire-and-forget an update to the workspace's last-modified date; no need to wait for it to complete
     withWorkspaceLastModified(dbResults)
     // and return

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -16,18 +16,18 @@ import org.broadinstitute.dsde.rawls.entities.exceptions.{
   DeleteEntitiesConflictException,
   DeleteEntitiesOfTypeConflictException,
   EntityNotFoundException,
-  EntityReferenceNotFoundException
+  EntityReferenceNotFoundException,
+  UnsupportedEntityOperationException
 }
 import org.broadinstitute.dsde.rawls.entities.{EntityRequestArguments, EntityUtils}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
-import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model.{
   Attributable,
   AttributeEntityReference,
   AttributeEntityReferenceList,
   AttributeName,
   AttributeRename,
-  AttributeUpdateOperations,
   AttributeValue,
   Entity,
   EntityCopyResponse,
@@ -363,9 +363,28 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
 
   override def updateEntity(entityType: String,
                             entityName: String,
-                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation],
+                            operations: Seq[AttributeUpdateOperation],
                             parentContext: RawlsRequestContext
-  ): Future[Entity] = ???
+  ): Future[Entity] =
+    // validate
+    if (operations.isEmpty) {
+      Future.failed(
+        new UnsupportedEntityOperationException(message = "No operations provided", code = StatusCodes.BadRequest)
+      )
+    } else {
+      // translate the input arguments to the batchUpdate arguments
+      val updateDefinition = Source.single(EntityUpdateDefinition(entityName, entityType, operations))
+      // perform a batchUpdate for just this one entity. batchUpdate will throw an error if the entity does not exist.
+      batchUpdateEntities(updateDefinition, parentContext) flatMap { _ =>
+        repository.dataSource.inTransaction { _ =>
+          // on batchUpsert completion, re-retrieve the entity and return it
+          repository.queries.getEntity(workspaceId, entityType, entityName) map {
+            case Some(entityRec) => entityRec.toEntity
+            case None            => throw new EntityNotFoundException()
+          }
+        }
+      }
+    }
 
   // ====================================================================================================
   //  helper methods

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -112,7 +112,7 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
         updatedEntities = applyAll(updates, existingEntitiesByIdentifier)
 
         // Persist the updated entities to the database
-        writeCount <- insertBatch(updatedEntities, allowUpsert)
+        writeCount <- insertOrUpdateBatch(updatedEntities)
 
         // Re-retrieve the entities we just wrote. This gets the actual record_version values.
         finalRecordVersions <- repository.queries.getEntityVersions(workspaceId, updateIdentifiers.toSet)
@@ -170,25 +170,33 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
   }
 
   /** write this batch of Entity to the database */
-  private def insertBatch(batch: Seq[Entity], allowUpsert: Boolean): ReadWriteAction[Int] =
+  private def insertOrUpdateBatch(batch: Seq[Entity]): ReadWriteAction[Int] =
 
     for {
       // Batch insert to ENTITY table. Save the whole batch first to handle cases where an entity in this batch
       // has a reference to another entity in the same batch.
-      entitiesCreated <- repository.queries.batchCreateEntities(workspaceId, batch, allowUpsert = allowUpsert)
+      entitiesCreated <- repository.queries.batchCreateEntities(workspaceId, batch, insertOnly = false)
 
       // Find all requested references within this batch
       allReferences: Set[RefMapping] = findAllReferences(batch)
 
       // verify all requested references exist
-      allExist <- repository.queries.existsAll(workspaceId, allReferences.flatMap(_.to))
+      allExist <-
+        if (allReferences.nonEmpty)
+          repository.queries.existsAll(workspaceId, allReferences.flatMap(_.to))
+        else
+          DBIO.successful(true)
 
       // did we find all the reference sources and targets?
       _ = if (!allExist)
         throw new EntityReferenceNotFoundException("Some entity references do not exist")
 
       _ <- repository.queries.deleteAllReferencesFrom(workspaceId, batch.map(_.toPointer).toSet)
-      _ <- repository.queries.insertReferences(workspaceId, allReferences)
+      _ <-
+        if (allReferences.nonEmpty)
+          repository.queries.insertReferences(workspaceId, allReferences)
+        else
+          DBIO.successful(0)
     } yield entitiesCreated
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -36,9 +36,14 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
 
   /**
     * process the incoming EntityUpdateDefinitions and persist to the database
+    *
+    * @param entityUpdates the entity operations to process
+    * @param allowInsert are both inserts and updates allowed? When false, only updates are allowed.
+    * @param config options for processing the operations
+    * @param parentContext parent tracing span and userinfo
     */
   def handleUpdates(entityUpdates: Source[EntityUpdateDefinition, _],
-                    allowUpsert: Boolean,
+                    allowInsert: Boolean,
                     config: CompactEntityProviderConfig,
                     parentContext: RawlsRequestContext
   ): Future[Int] = {
@@ -49,7 +54,7 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
     // Apply the incoming operations to a pre-existing entity (for updates) or a blank entity (for inserts)
     // and create the DBIO actions to persist the results.
     val batchActionsSource: Source[ReadWriteAction[Int], _] =
-      batchedUpdates.via(flowOperationsToEntities(allowUpsert))
+      batchedUpdates.via(flowOperationsToEntities(allowInsert))
 
     // Materialize the batch actions into a sequence and convert to a single DBIO action
     val batchActionsF: Future[ReadWriteAction[Int]] = batchActionsSource
@@ -70,9 +75,12 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
   }
 
   /** Stream component to accept a seq of batch updates, look for any pre-existing entities targeted by those updates,
-    * apply the updates to those entities, then persist those entities. Emits the count of rows written as a DBIO. */
+    * apply the updates to those entities, then persist those entities. Emits the count of rows written as a DBIO.
+    *
+    * @param allowInsert are both inserts and updates allowed? When false, only updates are allowed.
+    */
   private def flowOperationsToEntities(
-    allowUpsert: Boolean
+    allowInsert: Boolean
   ): Flow[Seq[EntityUpdateDefinition], ReadWriteAction[Int], _] =
     Flow[Seq[EntityUpdateDefinition]].map { updates =>
       // Extract the entity type and name from each update
@@ -82,8 +90,8 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
       for {
         // Query the database for any pre-existing entities being updated
         existingEntities <- repository.queries.getEntities(workspaceId, uniqueUpdateIdentifiers)
-        // If this invocation does NOT allow upserts, validate that we found all entities being updated
-        _ = if (!allowUpsert) {
+        // If this invocation does NOT allow inserts, validate that we found all entities being updated
+        _ = if (!allowInsert) {
           val actualPointers = existingEntities.map(_.toPointer).toSet
           if (
             existingEntities.size != uniqueUpdateIdentifiers.size || (uniqueUpdateIdentifiers diff actualPointers).nonEmpty

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -77,13 +77,20 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
     Flow[Seq[EntityUpdateDefinition]].map { updates =>
       // Extract the entity type and name from each update
       val updateIdentifiers = updates.map(update => EntityPointer(update.entityType, update.name))
+      val uniqueUpdateIdentifiers = updateIdentifiers.toSet
 
       for {
         // Query the database for any pre-existing entities being updated
-        existingEntities <- repository.queries.getEntities(workspaceId, updateIdentifiers.toSet)
+        existingEntities <- repository.queries.getEntities(workspaceId, uniqueUpdateIdentifiers)
         // If this invocation does NOT allow upserts, validate that we found all entities being updated
-        _ = if (!allowUpsert && existingEntities.size != updateIdentifiers.size) {
-          throw new EntityNotFoundException()
+        _ = if (!allowUpsert) {
+          val actualPointers = existingEntities.map(_.toPointer).toSet
+          if (
+            existingEntities.size != uniqueUpdateIdentifiers.size || (uniqueUpdateIdentifiers diff actualPointers).nonEmpty
+          )
+            throw new EntityNotFoundException(
+              s"expected ${uniqueUpdateIdentifiers.size} entities to be updated, but found ${existingEntities.size}"
+            )
         }
 
         // Massage the existing entities so they're easier to look up later

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/UnsupportedEntityOperationException.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/UnsupportedEntityOperationException.scala
@@ -1,6 +1,10 @@
 package org.broadinstitute.dsde.rawls.entities.exceptions
 
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+
 /** Exception related to working with data entities.
  */
-class UnsupportedEntityOperationException(message: String = null, cause: Throwable = null)
-    extends DataEntityException(message, cause)
+class UnsupportedEntityOperationException(message: String = null,
+                                          cause: Throwable = null,
+                                          override val code: StatusCode = StatusCodes.InternalServerError
+) extends DataEntityException(message, cause, code)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -1514,8 +1514,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     )
 
     // insert the entities
-    runAndWait(q.batchCreateEntities(wsid, ws1Entities, insertOnly = false)) shouldBe ws1Entities.size
-    runAndWait(q.batchCreateEntities(ws2id, ws2Entities, insertOnly = false)) shouldBe ws2Entities.size
+    runAndWait(q.batchCreateEntities(wsid, ws1Entities, insertOnly = true)) shouldBe ws1Entities.size
+    runAndWait(q.batchCreateEntities(ws2id, ws2Entities, insertOnly = true)) shouldBe ws2Entities.size
 
     // validate listed entities of entityType "testEntityType" in the first workspace
     runAndWait(q.listEntities(wsid, testEntityType)).map(_.toEntity) should contain theSameElementsAs Seq(entity1,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -75,7 +75,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     // should throw a primary key violation error
     intercept[SQLIntegrityConstraintViolationException](
-      runAndWait(q.batchCreateEntities(wsid, entities, allowUpsert = false))
+      runAndWait(q.batchCreateEntities(wsid, entities, insertOnly = true))
     )
 
     // entity 2 should still exist
@@ -1341,8 +1341,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     )
 
     // insert the entities
-    runAndWait(q.batchCreateEntities(wsid, ws1Entities, allowUpsert = false)) shouldBe ws1Entities.size
-    runAndWait(q.batchCreateEntities(ws2id, ws2Entities, allowUpsert = false)) shouldBe ws2Entities.size
+    runAndWait(q.batchCreateEntities(wsid, ws1Entities, insertOnly = false)) shouldBe ws1Entities.size
+    runAndWait(q.batchCreateEntities(ws2id, ws2Entities, insertOnly = false)) shouldBe ws2Entities.size
 
     // validate listed entities of entityType "testEntityType" in the first workspace
     runAndWait(q.listEntities(wsid, testEntityType)).map(_.toEntity) should contain theSameElementsAs Seq(entity1,
@@ -1674,7 +1674,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     }
 
     // insert the entities
-    runAndWait(q.batchCreateEntities(workspaceId, entities, allowUpsert = false)) shouldBe entities.size
+    runAndWait(q.batchCreateEntities(workspaceId, entities, insertOnly = true)) shouldBe entities.size
     // retrieve the entities; retrieved value includes its id
     entities.map { entity =>
       val actual = runAndWait(q.getEntity(workspaceId, entity.entityType, entity.name))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -460,6 +460,85 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
     }
   }
 
+  behavior of "batchUpdateEntities"
+
+  it should "update entities with references" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+
+    val metadataBefore = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
+    metadataBefore shouldBe empty
+
+    // create target entities
+    Await.result(provider.createEntity(Entity("targetName1", "targetType", Map()), defaultRequestContext), atMost)
+    Await.result(provider.createEntity(Entity("targetName2", "targetType", Map()), defaultRequestContext), atMost)
+    Await.result(provider.createEntity(Entity("targetName3", "targetType", Map()), defaultRequestContext), atMost)
+    Await.result(provider.createEntity(Entity("targetName4", "targetType", Map()), defaultRequestContext), atMost)
+
+    // create the entity we'll be updating; give it two references
+    Await.result(
+      provider.createEntity(
+        Entity(
+          "sourceName",
+          "sourceType",
+          Map(
+            AttributeName.withDefaultNS("ref1") -> AttributeEntityReference("targetType", "targetName1"),
+            AttributeName.withDefaultNS("ref2") -> AttributeEntityReference("targetType", "targetName2")
+          )
+        ),
+        defaultRequestContext
+      ),
+      atMost
+    )
+
+    // validate the starting references before our batchUpsert
+    val initialReferences =
+      runAndWait(
+        provider.repository.queries.getReferencesFrom(wsid, EntityPointer("sourceType", "sourceName"))
+      )
+
+    initialReferences shouldBe Seq(EntityPointer("targetType", "targetName1"),
+                                   EntityPointer("targetType", "targetName2")
+    )
+
+    // perform the batchUpsert - delete one existing reference, add two more
+    val updates = Source(
+      Seq(
+        EntityUpdateDefinition(
+          "sourceName",
+          "sourceType",
+          Seq(
+            CreateAttributeEntityReferenceList(AttributeName.withDefaultNS("refList")),
+            AddListMember(AttributeName.withDefaultNS("refList"),
+                          AttributeEntityReference("targetType", "targetName3")
+            ),
+            AddListMember(AttributeName.withDefaultNS("refList"), AttributeEntityReference("targetType", "targetName4"))
+          )
+        ),
+        EntityUpdateDefinition("sourceName",
+                               "sourceType",
+                               Seq(
+                                 RemoveAttribute(AttributeName.withDefaultNS("ref2"))
+                               )
+        )
+      )
+    )
+
+    Await.result(provider.batchUpdateEntities(updates, defaultRequestContext), atMost)
+
+    // validate the references after our batchUpsert
+    val finalReferences =
+      runAndWait(
+        provider.repository.queries.getReferencesFrom(wsid, EntityPointer("sourceType", "sourceName"))
+      )
+
+    finalReferences.toSet shouldBe Set(
+      EntityPointer("targetType", "targetName1"),
+      EntityPointer("targetType", "targetName3"),
+      EntityPointer("targetType", "targetName4")
+    )
+
+  }
+
   behavior of "listEntities"
 
   it should "list entities" in withMinimalTestDatabase { _ =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.rawls.entities.exceptions.EntityNotFoundException
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
   AddListMember,
   AddUpdateAttribute,
+  AttributeUpdateOperation,
   CreateAttributeEntityReferenceList,
   EntityUpdateDefinition,
   RemoveAttribute
@@ -518,6 +519,33 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
     )
 
     entities shouldBe empty
+  }
+
+  behavior of "updateEntity"
+
+  it should "correctly update an entity in the database" in withMinimalTestDatabase { _ =>
+    val entityType = "typeA"
+    val entityName = "name1"
+    val provider = defaultProvider()
+
+    // create the pre-existing base entity
+    val baseEntity = Entity(entityName, entityType, Map(AttributeName.withDefaultNS("foo") -> AttributeString("bar")))
+    val setup = Await.result(provider.createEntity(baseEntity, defaultRequestContext), atMost)
+    setup shouldBe baseEntity
+
+    // ask to apply an update to that entity
+    val operations: Seq[AttributeUpdateOperation] = Seq(
+      AddUpdateAttribute(AttributeName.withDefaultNS("baz"), AttributeString("qux"))
+    )
+    val actual = Await.result(provider.updateEntity(entityType, entityName, operations, defaultRequestContext), atMost)
+
+    actual shouldBe Entity(entityName,
+                           entityType,
+                           Map(AttributeName.withDefaultNS("foo") -> AttributeString("bar"),
+                               AttributeName.withDefaultNS("baz") -> AttributeString("qux")
+                           )
+    )
+
   }
 
   // ====================================================================================================

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -8,15 +8,22 @@ import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.CountAndSource
-import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{EntityNotFoundException, EntityReferenceNotFoundException}
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
+  AddUpdateAttribute,
+  AttributeUpdateOperation,
+  EntityUpdateDefinition
+}
 import org.broadinstitute.dsde.rawls.entities.exceptions.{
   DataEntityException,
   DeleteEntitiesConflictException,
-  DeleteEntitiesOfTypeConflictException
+  DeleteEntitiesOfTypeConflictException,
+  EntityNotFoundException,
+  EntityReferenceNotFoundException,
+  UnsupportedEntityOperationException
 }
 import org.broadinstitute.dsde.rawls.model.{
   Attributable,
+  AttributeBoolean,
   AttributeEntityReference,
   AttributeEntityReferenceList,
   AttributeName,
@@ -35,7 +42,7 @@ import org.broadinstitute.dsde.rawls.model.{
   UserInfo,
   Workspace
 }
-import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
+import org.broadinstitute.dsde.rawls.util.{AttributeSupport, MockitoTestUtils}
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, anyString, eq => mockitoEq}
 import org.mockito.{ArgumentMatchers, Mockito}
@@ -48,7 +55,10 @@ import java.util.UUID
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
-class CompactEntityProviderSpec extends TestDriverComponentWithFlatSpecAndMatchers with MockitoTestUtils {
+class CompactEntityProviderSpec
+    extends TestDriverComponentWithFlatSpecAndMatchers
+    with MockitoTestUtils
+    with AttributeSupport {
 
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
   implicit val system: ActorSystem = ActorSystem("CompactEntityProviderSpec")
@@ -107,12 +117,9 @@ class CompactEntityProviderSpec extends TestDriverComponentWithFlatSpecAndMatche
     Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
 
     // should have called one batch-insert to write the entities
-    verify(mockQuery, times(1)).batchCreateEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID),
-                                                    any(),
-                                                    mockitoEq(true)
-    )
-    // entities have no references, so the input to upsertReferences should be empty
-    verify(mockQuery, times(1)).insertReferences(defaultWorkspace.workspaceIdAsUUID, Set())
+    verify(mockQuery, times(1)).batchCreateEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), any())
+    // entities have no references, so it should skip insertReferences
+    verify(mockQuery, never()).insertReferences(any(), any())
   }
 
   it should "issue multiple insert statements when given large batches" in {
@@ -145,9 +152,9 @@ class CompactEntityProviderSpec extends TestDriverComponentWithFlatSpecAndMatche
 
     // should have called batchCreateEntities multiple times to write the entities
     verify(mockQuery, Mockito.atLeast(2))
-      .batchCreateEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), mockitoEq(true))
-    // entities have no references, so the input to upsertReferences should be empty
-    verify(mockQuery, Mockito.atLeast(2)).insertReferences(defaultWorkspace.workspaceIdAsUUID, Set())
+      .batchCreateEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), any())
+    // entities have no references, so it should skip insertReferences
+    verify(mockQuery, never()).insertReferences(any(), any())
 
   }
 
@@ -192,10 +199,7 @@ class CompactEntityProviderSpec extends TestDriverComponentWithFlatSpecAndMatche
     val ref3 = EntityPointer("typeB", "name3")
 
     // should have called one batch-insert to write the entities
-    verify(mockQuery, times(1)).batchCreateEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID),
-                                                    any(),
-                                                    mockitoEq(true)
-    )
+    verify(mockQuery, times(1)).batchCreateEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), any())
     // entities found references, so should ask to upsert those.
     // given the mock response defined above, we expect references from name2->targetName and name3->targetName
     verify(mockQuery, times(1)).insertReferences(defaultWorkspace.workspaceIdAsUUID,
@@ -870,7 +874,45 @@ class CompactEntityProviderSpec extends TestDriverComponentWithFlatSpecAndMatche
     result shouldBe 5
   }
 
-  "updateEntity" should "have tests" is pending
+  behavior of "updateEntity"
+
+  it should "throw if the user specified zero operations" in {
+    val entityType = "entityType"
+    val entityName = "entityName"
+    val operations = Seq.empty[AttributeUpdateOperation]
+
+    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    val provider = providerWithMocks(mockQueries)
+
+    val actual = intercept[UnsupportedEntityOperationException] {
+      Await.result(provider.updateEntity(entityType, entityName, operations, testContext), atMost)
+    }
+
+    actual.code shouldBe StatusCodes.BadRequest
+  }
+
+  it should "throw if the entity does not exist" in {
+    val entityType = "entityType"
+    val entityName = "entityName"
+    val operations: Seq[AttributeUpdateOperation] = Seq(
+      AddUpdateAttribute(
+        AttributeName.withDefaultNS("foo"),
+        AttributeNumber(42)
+      )
+    )
+
+    val mockQueries = mock[slickDataSource.dataAccess.compactEntityQuery.type]
+    // mock: batchUpdate does not find the pre-existing entity
+    when(mockQueries.getEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any()))
+      .thenAnswer(_ => throw new EntityNotFoundException())
+    val provider = providerWithMocks(mockQueries)
+
+    val actual = intercept[EntityNotFoundException] {
+      Await.result(provider.updateEntity(entityType, entityName, operations, testContext), atMost)
+    }
+
+    actual.code shouldBe StatusCodes.NotFound
+  }
 
   // ====================================================================================================
   // tests for CompactEntityProvider helper methods


### PR DESCRIPTION
Ticket: CORE-472: Implement the `update_entity` API.

The implementation delegates to `batchUpdate`; essentially, `update_entity` is a `batchUpdate` with batch size 1.

Because this is almost completely a delegation, test coverage is relatively light.

However, in the course of this PR I discovered some cleanup and bugs in `batchUpdate`, which I have fixed.