### PR TITLE
CORE-424: add tracing for entity type metadata

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -5,6 +5,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.scalalogging.LazyLogging
+import io.opentelemetry.api.common.AttributeKey
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.exceptions.{
@@ -17,7 +18,7 @@ import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.CompactDataTablesConfig
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
+import org.broadinstitute.dsde.rawls.util.TracingUtils.{setTraceSpanAttribute, traceFutureWithParent}
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceSettingService}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValidationUtils}
@@ -322,6 +323,10 @@ class EntityService(protected val ctx: RawlsRequestContext,
               EntityRequestArguments(workspaceContext, s)
             )
           }
+          _ = setTraceSpanAttribute(localContext,
+                                    AttributeKey.stringKey("providerType"),
+                                    entityProvider.getClass.getSimpleName
+          )
           metadata <- traceFutureWithParent("EntityProvider.entityTypeMetadata", localContext) { s =>
             entityProvider.entityTypeMetadata(useCache, s)
           }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -43,6 +43,7 @@ import org.broadinstitute.dsde.rawls.model.{
   SubmissionValidationEntityInputs,
   Workspace
 }
+import org.broadinstitute.dsde.rawls.util.TracingUtils.{trace, traceDBIOWithParent}
 import slick.jdbc.ResultSetConcurrency.ReadOnly
 import slick.jdbc.{ResultSetConcurrency, ResultSetType}
 import slick.jdbc.TransactionIsolation.ReadCommitted
@@ -200,9 +201,13 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
   ): Future[Map[String, EntityTypeMetadata]] =
     repository.dataSource.inTransaction(ReadOnly) { _ =>
       for {
-        entityTypeAndKeys <- repository.queries.listEntityKeys(workspaceId)
-        entityTypeAndCounts <- repository.queries.countEntitiesGroupedByType(workspaceId)
-      } yield {
+        entityTypeAndKeys <- traceDBIOWithParent("listEntityKeys", parentContext) { _ =>
+          repository.queries.listEntityKeys(workspaceId)
+        }
+        entityTypeAndCounts <- traceDBIOWithParent("countEntitiesGroupedByType", parentContext) { _ =>
+          repository.queries.countEntitiesGroupedByType(workspaceId)
+        }
+      } yield trace("resultCalculation", parentContext) { _ =>
         // note that entityTypeAndKeys only contains entity types that have at least one key
         // and that entityTypeAndCounts contains all entity types, even those with zero keys
         val keysByType = entityTypeAndKeys.groupMap(_.entityType)(_.attributeKey)


### PR DESCRIPTION
Ticket: CORE-424

Additional tracing detail for the entity type metadata API, to gather performance data as input to CORE-524.