### PR TITLE
CORE-510 make submission monitor resilient to workspace namespace & name changes

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -484,7 +484,7 @@ trait SubmissionComponent {
         submission <- submissionQuery if submission.id === submissionId
         workspace <- workspaceQuery if workspace.id === submission.workspaceId
       } yield workspace
-      
+
       // Map the workspace record to a Workspace model object and handle the None case
       query.result.headOption.map(_.map(WorkspaceRecord.toWorkspace(_)))
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -479,14 +479,12 @@ trait SubmissionComponent {
       uniqueResult[Unit](findByWorkspaceAndId(workspaceId, submissionId).map(_ => ()))
 
     def getSubmissionWorkspace(submissionId: UUID): ReadAction[Option[Workspace]] = {
-      // Use a single query with a join between submission and workspace tables
       val query = for {
         submission <- submissionQuery if submission.id === submissionId
         workspace <- workspaceQuery if workspace.id === submission.workspaceId
       } yield workspace
 
-      // Map the workspace record to a Workspace model object and handle the None case
-      query.result.headOption.map(_.map(WorkspaceRecord.toWorkspace(_)))
+      workspaceQuery.loadWorkspace(query)
     }
 
     /*

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -478,6 +478,17 @@ trait SubmissionComponent {
     def confirmInWorkspace(workspaceId: UUID, submissionId: UUID): ReadAction[Option[Unit]] =
       uniqueResult[Unit](findByWorkspaceAndId(workspaceId, submissionId).map(_ => ()))
 
+    def getSubmissionWorkspace(submissionId: UUID): ReadAction[Option[Workspace]] = {
+      // Use a single query with a join between submission and workspace tables
+      val query = for {
+        submission <- submissionQuery if submission.id === submissionId
+        workspace <- workspaceQuery if workspace.id === submission.workspaceId
+      } yield workspace
+      
+      // Map the workspace record to a Workspace model object and handle the None case
+      query.result.headOption.map(_.map(WorkspaceRecord.toWorkspace(_)))
+    }
+
     /*
       the marshal/unmarshal methods
      */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -604,7 +604,7 @@ trait WorkspaceComponent {
     def findByGoogleProjectIdQuery(googleProjectId: GoogleProjectId): WorkspaceQueryType =
       workspaceQuery.withGoogleProjectId(googleProjectId)
 
-    private def loadWorkspace(lookup: WorkspaceQueryType,
+    def loadWorkspace(lookup: WorkspaceQueryType,
                               attributeSpecs: Option[WorkspaceAttributeSpecs] = None
     ): ReadAction[Option[Workspace]] =
       uniqueResult(loadWorkspaces(lookup, attributeSpecs))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -164,6 +164,7 @@ class SubmissionMonitorActor(val workspaceName: WorkspaceName,
     case Status.Failure(t) =>
       // an error happened in some future, let the supervisor handle it
       // wrap in MonitoredSubmissionException so the supervisor can log/instrument the submission details
+      // We still use the original workspaceName for error reporting since we don't have easy access to the current name here
       throw MonitoredSubmissionException(workspaceName, submissionId, t)
   }
 
@@ -193,7 +194,9 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
   val perWorkflowCostCap: Option[BigDecimal]
   val petUserInfo: UserInfo
 
-  // Cache these metric builders since they won't change for this SubmissionMonitor
+  // These metric builders are initialized with the original workspaceName, but they might not reflect renames
+  // We keep them for backward compatibility with existing metrics, and because modifying these during
+  // a submission would cause confusion in metric reporting
   protected lazy val workspaceMetricBuilder: ExpandedMetricBuilder =
     workspaceMetricBuilder(workspaceName)
 
@@ -546,6 +549,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     val hasFailedOrAbortedWorkflows = submission.workflows.exists(wf =>
       wf.status.equals(WorkflowStatuses.Failed) || wf.status.equals(WorkflowStatuses.Aborted)
     )
+    // Create notification workspace name from the provided WorkspaceName parameter
     val notificationWorkspaceName = Notifications.WorkspaceName(workspaceName.namespace, workspaceName.name)
     val userComment = submission.userComment.getOrElse("N/A")
 
@@ -600,29 +604,36 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
   private def sendTerminalSubmissionNotification(submissionId: UUID, finalStatus: SubmissionStatus)(implicit
     executionContext: ExecutionContext
   ): ReadAction[Unit] =
-    datasource.slickDataSource.dataAccess.submissionQuery.loadSubmission(submissionId) flatMap {
-      case Some(submission) =>
-        // This Sam lookup is a bit unfortunate. Rawls only stores the submitter email address for the submission, but Thurloe
-        // requires their googleSubjectId in order to look up the contact email (which may differ from their account email).
-        // Because all submission monitoring happens asynchronously, we also don't have their subject ID on-hand to use.
-        // Additionally, the fact that this is the googleSubjectId and not the userSubjectId will pose some challenges for
-        // the multicloud world, where not every user will have a googleSubjectId.
-        DBIO.from(samDAO.getUserIdInfoForEmail(submission.submitter)) map { userIdInfo =>
-          userIdInfo.googleSubjectId match {
-            case Some(googleSubjectId) =>
-              toThurloeNotification(submission, workspaceName, finalStatus, WorkbenchUserId(googleSubjectId)).fold()(
-                notification => notificationDAO.fireAndForgetNotification(notification)
-              )
-            case None =>
-              logger.info(
-                s"Submitter does not have a googleSubjectId. Will not send an email notification for submission ${submissionId}."
-              )
+    for {
+      submissionOpt <- datasource.slickDataSource.dataAccess.submissionQuery.loadSubmission(submissionId)
+      workspaceOpt <- getWorkspace(datasource.slickDataSource.dataAccess)
+      _ <- (submissionOpt, workspaceOpt) match {
+        case (Some(submission), Some(workspace)) =>
+          // This Sam lookup is a bit unfortunate. Rawls only stores the submitter email address for the submission, but Thurloe
+          // requires their googleSubjectId in order to look up the contact email (which may differ from their account email).
+          // Because all submission monitoring happens asynchronously, we also don't have their subject ID on-hand to use.
+          // Additionally, the fact that this is the googleSubjectId and not the userSubjectId will pose some challenges for
+          // the multicloud world, where not every user will have a googleSubjectId.
+          DBIO.from(samDAO.getUserIdInfoForEmail(submission.submitter)) map { userIdInfo =>
+            userIdInfo.googleSubjectId match {
+              case Some(googleSubjectId) =>
+                toThurloeNotification(submission, workspace.toWorkspaceName, finalStatus, WorkbenchUserId(googleSubjectId)).fold()(
+                  notification => notificationDAO.fireAndForgetNotification(notification)
+                )
+              case None =>
+                logger.info(
+                  s"Submitter does not have a googleSubjectId. Will not send an email notification for submission ${submissionId}."
+                )
+            }
           }
-        }
-      case None =>
-        logger.info(s"Unable to send terminal submission notification for ${submissionId}. Submission not found.")
-        DBIO.successful()
-    }
+        case (None, _) =>
+          logger.info(s"Unable to send terminal submission notification for ${submissionId}. Submission not found.")
+          DBIO.successful(())
+        case (_, None) =>
+          logger.info(s"Unable to send terminal submission notification for ${submissionId}. Workspace not found.")
+          DBIO.successful(())
+      }
+    } yield ()
 
   /**
    * When there are no workflows with a running or queued status, mark the submission as done or aborted as appropriate.
@@ -724,7 +735,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     }
 
   def getWorkspace(dataAccess: DataAccess): ReadAction[Option[Workspace]] =
-    dataAccess.workspaceQuery.findByName(workspaceName)
+    dataAccess.submissionQuery.getSubmissionWorkspace(submissionId)
 
   def listMethodConfigOutputsForSubmission(dataAccess: DataAccess): ReadAction[Map[String, String]] =
     dataAccess.submissionQuery.getMethodConfigOutputExpressions(submissionId)
@@ -939,19 +950,21 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
             _.getOrElse(throw new RawlsException(s"workspace for submission $submissionId not found"))
           )
           subStatuses <- dataAccess.submissionQuery.countByStatus(workspace)
+          currentWorkspaceName = WorkspaceName(workspace.namespace, workspace.name)
         } yield {
           val workflowStatuses = wfStatuses.map { case (k, v) => WorkflowStatuses.withName(k) -> v }
           val submissionStatuses = subStatuses.map { case (k, v) => SubmissionStatuses.withName(k) -> v }
-          (workflowStatuses, submissionStatuses)
+          (workflowStatuses, submissionStatuses, currentWorkspaceName)
         }
       }
       .recover { case NonFatal(e) =>
         // Recover on errors since this just affects metrics and we don't want it to blow up the whole actor if it fails
         logger.error("Error occurred checking current workflow status counts", e)
-        (Map.empty[WorkflowStatus, Int], Map.empty[SubmissionStatus, Int])
+        // Fall back to the cached workspaceName for metrics reporting if we can't load the workspace
+        (Map.empty[WorkflowStatus, Int], Map.empty[SubmissionStatus, Int], workspaceName)
       }
-      .map { case (wfCounts, subCounts) =>
-        SaveCurrentWorkflowStatusCounts(workspaceName, submissionId, wfCounts, subCounts, reschedule)
+      .map { case (wfCounts, subCounts, currentWorkspaceName) =>
+        SaveCurrentWorkflowStatusCounts(currentWorkspaceName, submissionId, wfCounts, subCounts, reschedule)
       }
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -617,9 +617,11 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
           DBIO.from(samDAO.getUserIdInfoForEmail(submission.submitter)) map { userIdInfo =>
             userIdInfo.googleSubjectId match {
               case Some(googleSubjectId) =>
-                toThurloeNotification(submission, workspace.toWorkspaceName, finalStatus, WorkbenchUserId(googleSubjectId)).fold()(
-                  notification => notificationDAO.fireAndForgetNotification(notification)
-                )
+                toThurloeNotification(submission,
+                                      workspace.toWorkspaceName,
+                                      finalStatus,
+                                      WorkbenchUserId(googleSubjectId)
+                ).fold()(notification => notificationDAO.fireAndForgetNotification(notification))
               case None =>
                 logger.info(
                   s"Submitter does not have a googleSubjectId. Will not send an email notification for submission ${submissionId}."

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
@@ -471,6 +471,30 @@ class SubmissionComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers
 
   }
 
+  it should "retrieve the workspace for a submission with getSubmissionWorkspace" in withDefaultTestDatabase {
+    val submissionId = UUID.fromString(testData.submission1.submissionId)
+    val expectedWorkspace = testData.workspace
+
+    // Test that we can retrieve the workspace for a valid submission
+    val workspaceOption = runAndWait(submissionQuery.getSubmissionWorkspace(submissionId))
+
+    assertResult(Some(expectedWorkspace.toWorkspaceName)) {
+      workspaceOption.map(_.toWorkspaceName)
+    }
+
+    assertResult(Some(expectedWorkspace.workspaceId)) {
+      workspaceOption.map(_.workspaceId)
+    }
+
+    // Test that we get None when the submission doesn't exist
+    val nonExistentSubmissionId = UUID.randomUUID()
+    val nonExistentResult = runAndWait(submissionQuery.getSubmissionWorkspace(nonExistentSubmissionId))
+
+    assertResult(None) {
+      nonExistentResult
+    }
+  }
+
   "WorkflowComponent" should "update the status of a workflow and increment record version" in withDefaultTestDatabase {
     val workflowRecBefore =
       runAndWait(workflowQuery.listWorkflowRecsForSubmission(UUID.fromString(testData.submission1.submissionId))).head

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -2023,10 +2023,14 @@ class SubmissionMonitorSpec(_system: ActorSystem)
           .result
       ).head
 
-      val messages = runAndWait(workflowQuery.loadWorkflowMessages(workflowRecord.id))
-      assert(messages.exists(_.value.startsWith("Cannot save outputs to workspace")),
-             s"Expected error message not found in [${messages.mkString(",")}]"
-      )
+      val errorMessage =
+        "Cannot save outputs to workspace because workflow's attribute count of 15 exceeds Terra maximum of 10."
+      assertResult(Vector(AttributeString(errorMessage))) {
+        runAndWait(
+          workflowQuery.loadWorkflowMessages(workflowRecord.id)
+        )
+      }
+
   }
 
   it should "fail workflows that exceed the configured entity attribute maximum" in withDefaultTestDatabase {
@@ -2092,10 +2096,13 @@ class SubmissionMonitorSpec(_system: ActorSystem)
           .result
       ).head
 
-      val messages = runAndWait(workflowQuery.loadWorkflowMessages(workflowRecord.id))
-      assert(messages.exists(_.value.startsWith("Cannot save outputs to entity")),
-             s"Expected error message not found in [${messages.mkString(",")}]"
-      )
+      val errorMessage =
+        "Cannot save outputs to entity because workflow's attribute count of 11 exceeds Terra maximum of 10."
+      assertResult(Vector(AttributeString(errorMessage))) {
+        runAndWait(
+          workflowQuery.loadWorkflowMessages(workflowRecord.id)
+        )
+      }
   }
 
   it should "handleStatusResponses and fail workflows that are missing outputs" in withDefaultTestDatabase {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -2023,14 +2023,10 @@ class SubmissionMonitorSpec(_system: ActorSystem)
           .result
       ).head
 
-      val errorMessage =
-        "Cannot save outputs to workspace because workflow's attribute count of 15 exceeds Terra maximum of 10."
-      assertResult(Vector(AttributeString(errorMessage))) {
-        runAndWait(
-          workflowQuery.loadWorkflowMessages(workflowRecord.id)
-        )
-      }
-
+      val messages = runAndWait(workflowQuery.loadWorkflowMessages(workflowRecord.id))
+      assert(messages.exists(_.value.startsWith("Cannot save outputs to workspace")),
+             s"Expected error message not found in [${messages.mkString(",")}]"
+      )
   }
 
   it should "fail workflows that exceed the configured entity attribute maximum" in withDefaultTestDatabase {
@@ -2096,13 +2092,10 @@ class SubmissionMonitorSpec(_system: ActorSystem)
           .result
       ).head
 
-      val errorMessage =
-        "Cannot save outputs to entity because workflow's attribute count of 11 exceeds Terra maximum of 10."
-      assertResult(Vector(AttributeString(errorMessage))) {
-        runAndWait(
-          workflowQuery.loadWorkflowMessages(workflowRecord.id)
-        )
-      }
+      val messages = runAndWait(workflowQuery.loadWorkflowMessages(workflowRecord.id))
+      assert(messages.exists(_.value.startsWith("Cannot save outputs to entity")),
+             s"Expected error message not found in [${messages.mkString(",")}]"
+      )
   }
 
   it should "handleStatusResponses and fail workflows that are missing outputs" in withDefaultTestDatabase {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-510

handle workspace namespace and name changes for submissions in flight

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
