### PR TITLE
CORE-495: Quicksilver hard deletes

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -370,7 +370,21 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
   }
 
   /**
-    * Hard-delete all Quicksilver entities which do not have any foreign keys pointed at them.
+    * Hard-delete all of the specified entities that do not have any foreign keys pointed at them.
+    *
+    * execution plan: admittedly a mess, but no full table scans. Uses indexes and wheres. Lots of joins and unions
+    *   and requires a temporary table for the big union.
+    */
+  def deleteEntities(workspaceId: UUID, entities: Seq[EntityPointer]): ReadWriteAction[Int] = {
+    // join all the clauses with "or": `(entity_type = ? and name in (?)) or `(entity_type = ? and name in (?))`
+    val criteriaSql: SQLActionBuilder = reduceSqlActionsWithDelim(generateTypeNameSql(entities.toSet).toSeq, sql" or ")
+    val whereClause = concatSqlActions(sql"where (", criteriaSql, sql")")
+    val finalSql = deleteEntitiesImpl(workspaceId, whereClause)
+    finalSql.asUpdate
+  }
+
+  /**
+    * Hard-delete all entities of a given type that do not have any foreign keys pointed at them.
     *
     * Note this does not have a "where deleted=0" clause. Thus, it will also hard-delete any entities
     * that were previously soft-deleted but which no longer have anything pointing at them (this is unlikely)
@@ -378,14 +392,21 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
     * execution plan: admittedly a mess, but no full table scans. Uses indexes and wheres. Lots of joins and unions
     *   and requires a temporary table for the big union.
     */
-  def deleteEntitiesOfType(workspaceId: UUID, entityType: String): ReadWriteAction[Int] =
-    sql"""with
+  def deleteEntitiesOfType(workspaceId: UUID, entityType: String): ReadWriteAction[Int] = {
+    val whereClause = sql"where entity_type = $entityType"
+    val finalSql = deleteEntitiesImpl(workspaceId, whereClause)
+    finalSql.asUpdate
+  }
+
+  // private helper for deleteEntities and deleteEntitiesOfType
+  private def deleteEntitiesImpl(workspaceId: UUID, whereClause: SQLActionBuilder): SQLActionBuilder = {
+    val startSql = sql"""with
             CANDIDATE_WORKFLOWS as (select wf.ID, wf.ENTITY_ID
               from WORKFLOW wf, SUBMISSION s
               where wf.SUBMISSION_ID = s.ID and s.WORKSPACE_ID = $workspaceId)
-          delete e from ENTITY e
-          where e.entity_type = $entityType
-          and e.workspace_id = $workspaceId
+          delete e from ENTITY e """
+
+    val endSql = sql""" and e.workspace_id = $workspaceId
           and e.id not in (
             select value_entity_ref from WORKSPACE_ATTRIBUTE where owner_id = $workspaceId
               union
@@ -397,7 +418,10 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
             from SUBMISSION_ATTRIBUTE sa, SUBMISSION_VALIDATION sv, CANDIDATE_WORKFLOWS cw
             where sa.owner_id = sv.id and sv.WORKFLOW_ID = cw.ID
           )
-       """.asUpdate
+       """
+
+    concatSqlActions(startSql, whereClause, endSql)
+  }
 
   // Gets any entities that have references to the entities in the given list
   // Excludes entities that are in the list

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -369,6 +369,36 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
     query.asUpdate
   }
 
+  /**
+    * Hard-delete all Quicksilver entities which do not have any foreign keys pointed at them.
+    *
+    * Note this does not have a "where deleted=0" clause. Thus, it will also hard-delete any entities
+    * that were previously soft-deleted but which no longer have anything pointing at them (this is unlikely)
+    *
+    * execution plan: admittedly a mess, but no full table scans. Uses indexes and wheres. Lots of joins and unions
+    *   and requires a temporary table for the big union.
+    */
+  def deleteEntitiesOfType(workspaceId: UUID, entityType: String): ReadWriteAction[Int] =
+    sql"""with
+            CANDIDATE_WORKFLOWS as (select wf.ID, wf.ENTITY_ID
+              from WORKFLOW wf, SUBMISSION s
+              where wf.SUBMISSION_ID = s.ID and s.WORKSPACE_ID = $workspaceId)
+          delete e from ENTITY e
+          where e.entity_type = $entityType
+          and e.workspace_id = $workspaceId
+          and e.id not in (
+            select value_entity_ref from WORKSPACE_ATTRIBUTE where owner_id = $workspaceId
+              union
+            select ENTITY_ID from SUBMISSION where WORKSPACE_ID = $workspaceId
+              union
+            select cw.ENTITY_ID as entity_id from CANDIDATE_WORKFLOWS cw
+              union
+            select sa.value_entity_ref as entity_id
+            from SUBMISSION_ATTRIBUTE sa, SUBMISSION_VALIDATION sv, CANDIDATE_WORKFLOWS cw
+            where sa.owner_id = sv.id and sv.WORKFLOW_ID = cw.ID
+          )
+       """.asUpdate
+
   // Gets any entities that have references to the entities in the given list
   // Excludes entities that are in the list
   // `execution plan: uses idx_to index. Extra: Using where; Using index` (I think this may also use unq_from_to in some cases)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -406,15 +406,17 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
               where wf.SUBMISSION_ID = s.ID and s.WORKSPACE_ID = $workspaceId)
           delete e from ENTITY e """
 
+    // where clause gets inserted here, e.g. `where e.entity_type = ?`
+
     val endSql = sql""" and e.workspace_id = $workspaceId
           and e.id not in (
             select value_entity_ref from WORKSPACE_ATTRIBUTE where owner_id = $workspaceId
               union
             select ENTITY_ID from SUBMISSION where WORKSPACE_ID = $workspaceId
               union
-            select cw.ENTITY_ID as entity_id from CANDIDATE_WORKFLOWS cw
+            select cw.ENTITY_ID from CANDIDATE_WORKFLOWS cw
               union
-            select sa.value_entity_ref as entity_id
+            select sa.value_entity_ref
             from SUBMISSION_ATTRIBUTE sa, SUBMISSION_VALIDATION sv, CANDIDATE_WORKFLOWS cw
             where sa.owner_id = sv.id and sv.WORKFLOW_ID = cw.ID
           )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -168,6 +168,8 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         }
         // remove all references from these entities
         _ <- repository.queries.deleteAllReferencesFrom(workspaceId, pointers.toSet)
+        // TODO CORE-495: hard-delete everything we can
+        // soft-delete (i.e. hide) everything that could not be hard-deleted
         res <- repository.queries.batchHide(workspaceId, pointers)
       } yield res
     }
@@ -183,6 +185,9 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         }
         // remove all references from these entities
         _ <- repository.queries.deleteAllReferencesFromType(workspaceId, entityType)
+        // hard-delete everything we can
+        _ <- repository.queries.deleteEntitiesOfType(workspaceId, entityType)
+        // soft-delete (i.e. hide) everything that could not be hard-deleted
         res <- repository.queries.batchHideType(
           workspaceId,
           entityType

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -168,7 +168,8 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         }
         // remove all references from these entities
         _ <- repository.queries.deleteAllReferencesFrom(workspaceId, pointers.toSet)
-        // TODO CORE-495: hard-delete everything we can
+        // hard-delete everything we can
+        _ <- repository.queries.deleteEntities(workspaceId, pointers)
         // soft-delete (i.e. hide) everything that could not be hard-deleted
         res <- repository.queries.batchHide(workspaceId, pointers)
       } yield res

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -20,12 +20,14 @@ import org.broadinstitute.dsde.rawls.model.{
   WorkspaceFieldSpecs
 }
 import slick.dbio.Effect.Read
+import slick.jdbc.GetResult
 import slick.sql.SqlStreamingAction
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 import java.sql.SQLIntegrityConstraintViolationException
 import java.util.UUID
+import scala.concurrent.Future
 import scala.util.Random
 
 class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers {
@@ -774,6 +776,126 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     hidden3 should not be empty
     hidden3.get.attributes shouldBe empty
 
+  }
+
+  behavior of "deleteEntities"
+
+  it should "have tests" is pending
+
+  behavior of "deleteEntitiesOfType"
+
+  it should "delete entities of the given type in the given workspace" in withMinimalTestDatabase { _ =>
+    import driver.api._ // for bespoke SQL queries
+
+    val wsid2 = minimalTestData.workspace2.workspaceIdAsUUID
+
+    val entityType1 = "entityType1"
+    val entityType2 = "entityType2"
+    val entity1 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity2 = Entity(UUID.randomUUID().toString, entityType2, Map())
+    val entity3 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity4 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    insertAndGet(entity1) // should be deleted
+    insertAndGet(entity2) // should NOT be deleted; different entity type
+    insertAndGet(entity3) // should be deleted
+    insertAndGet(entity4) // should be deleted
+    insertAndGet(entity4, wsid2) // should NOT be deleted; different workspace
+
+    // validate counts before
+    getRawCounts should contain theSameElementsAs Seq(
+      (wsid, entityType1, 3),
+      (wsid, entityType2, 1),
+      (wsid2, entityType1, 1)
+    )
+
+    // perform the delete
+    val deletedCount = runAndWait(q.deleteEntitiesOfType(wsid, entityType1))
+
+    deletedCount shouldBe 3
+
+    // validate counts after
+    getRawCounts should contain theSameElementsAs Seq(
+      (wsid, entityType2, 1),
+      (wsid2, entityType1, 1)
+    )
+  }
+
+  it should "not delete entities which have a foreign key pointed at them" in withMinimalTestDatabase { _ =>
+    import driver.api._ // for bespoke SQL queries
+
+    val wsid2 = minimalTestData.workspace2.workspaceIdAsUUID
+
+    val entityType1 = "entityType1"
+    val entityType2 = "entityType2"
+    val entity1 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity2 = Entity(UUID.randomUUID().toString, entityType2, Map())
+    val entity3 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity4 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity5 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity6 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity7 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity8 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    insertAndGet(entity1) // should be deleted
+    insertAndGet(entity2) // should NOT be deleted; different entity type
+    insertAndGet(entity3) // should be deleted
+    insertAndGet(entity4) // should be deleted
+    insertAndGet(entity4, wsid2) // should NOT be deleted; different workspace
+    val entityRec5 = insertAndGet(entity5) // should NOT be deleted due to FK from WORKSPACE_ATTRIBUTE
+    val entityRec6 = insertAndGet(entity6) // should NOT be deleted due to FK from SUBMISSION
+    val entityRec7 = insertAndGet(entity7) // should NOT be deleted due to FK from WORKFLOW
+    val entityRec8 = insertAndGet(entity8) // should NOT be deleted due to FK from SUBMISSION_ATTRIBUTE
+
+    // set up foreign keys
+
+    // a workspace attribute points at entity5
+    runAndWait(
+      sql"""insert into WORKSPACE_ATTRIBUTE(name, owner_id, value_entity_ref)
+            values ('n', $wsid, ${entityRec5.id})""".asUpdate
+    )
+    // a submission points at entity6
+    runAndWait(
+      sql"""insert into METHOD_CONFIG(NAMESPACE, NAME, WORKSPACE_ID)
+            values ('nn', 'n', $wsid)""".asUpdate
+    )
+    val methodConfigId = runAndWait(
+      sql"select ID from METHOD_CONFIG where NAMESPACE = 'nn' and NAME = 'n' and WORKSPACE_ID = $wsid".as[Long].head
+    )
+    runAndWait(sql"""insert into SUBMISSION(ID, WORKSPACE_ID, SUBMITTER, METHOD_CONFIG_ID, SUBMISSION_ROOT, ENTITY_ID)
+            values (${UUID.randomUUID()}, $wsid, 'submitter', $methodConfigId, 'subroot', ${entityRec6.id})""".asUpdate)
+    val submissionId = runAndWait(sql"select ID from SUBMISSION where WORKSPACE_ID = $wsid".as[UUID].head)
+    // a workflow points at entity7
+    runAndWait(sql"""insert into WORKFLOW(SUBMISSION_ID, record_version, ENTITY_ID)
+        values($submissionId, 1, ${entityRec7.id})""".asUpdate)
+    val workflowId = runAndWait(sql"select ID from WORKFLOW where SUBMISSION_ID = $submissionId".as[Long].head)
+    // a submission attribute points at entity8
+    runAndWait(
+      sql"""insert into SUBMISSION_VALIDATION(WORKFLOW_ID, INPUT_NAME) values($workflowId, 'input')""".asUpdate
+    )
+    val submissionValidationId =
+      runAndWait(sql"select id from SUBMISSION_VALIDATION where WORKFLOW_ID = $workflowId".as[Long].head)
+    runAndWait(
+      sql"""insert into SUBMISSION_ATTRIBUTE(name, owner_id, value_entity_ref)
+            values ('s', $submissionValidationId, ${entityRec8.id})""".asUpdate
+    )
+
+    // validate counts before
+    getRawCounts should contain theSameElementsAs Seq(
+      (wsid, entityType1, 7),
+      (wsid, entityType2, 1),
+      (wsid2, entityType1, 1)
+    )
+
+    // perform the delete
+    val deletedCount = runAndWait(q.deleteEntitiesOfType(wsid, entityType1))
+
+    deletedCount shouldBe 3
+
+    // validate counts after
+    getRawCounts should contain theSameElementsAs Seq(
+      (wsid, entityType1, 4),
+      (wsid, entityType2, 1),
+      (wsid2, entityType1, 1)
+    )
   }
 
   behavior of "getReferencesTo"
@@ -1904,6 +2026,16 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
             desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux")))
         )
       )
+    )
+  }
+
+  // helper to validate counts of entities by workspace and type. Note this does not have a `where deleted=0` clause.
+  def getRawCounts: Seq[(UUID, String, Int)] = {
+    import driver.api._ // for bespoke SQL queries
+    implicit val getter: GetResult[(UUID, String, Int)] = GetResult(r => (r.<<, r.<<, r.<<))
+    runAndWait(
+      sql"select workspace_id, entity_type, count(1) from ENTITY group by workspace_id, entity_type"
+        .as[(UUID, String, Int)]
     )
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -775,12 +775,131 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val hidden3 = runAndWait(q.getDeletedEntity(wsid, entity3.entityType, entity3.name))
     hidden3 should not be empty
     hidden3.get.attributes shouldBe empty
-
   }
 
   behavior of "deleteEntities"
 
-  it should "have tests" is pending
+  it should "delete the specified entities in the given workspace" in withMinimalTestDatabase { _ =>
+    import driver.api._ // for bespoke SQL queries
+
+    val wsid2 = minimalTestData.workspace2.workspaceIdAsUUID
+
+    val entityType1 = "entityType1"
+    val entityType2 = "entityType2"
+    val entity1 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity2 = Entity(UUID.randomUUID().toString, entityType2, Map())
+    val entity3 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity4 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    insertAndGet(entity1) // targeted for deletion
+    insertAndGet(entity2) // targeted for deletion
+    insertAndGet(entity3) // should be deleted
+    insertAndGet(entity4) // targeted for deletion
+    insertAndGet(entity4, wsid2) // should NOT be deleted; different workspace
+
+    // validate counts before
+    getRawCounts should contain theSameElementsAs Seq(
+      (wsid, entityType1, 3),
+      (wsid, entityType2, 1),
+      (wsid2, entityType1, 1)
+    )
+
+    // perform the delete
+    val pointers = Seq(entity1.toPointer, entity2.toPointer, entity4.toPointer)
+    val deletedCount = runAndWait(q.deleteEntities(wsid, pointers))
+
+    deletedCount shouldBe 3
+
+    // validate counts after
+    getRawCounts should contain theSameElementsAs Seq(
+      (wsid, entityType1, 1),
+      (wsid2, entityType1, 1)
+    )
+  }
+
+  it should "not delete entities which have a foreign key pointed at them" in withMinimalTestDatabase { _ =>
+    import driver.api._ // for bespoke SQL queries
+
+    val wsid2 = minimalTestData.workspace2.workspaceIdAsUUID
+
+    val entityType1 = "entityType1"
+    val entityType2 = "entityType2"
+    val entity1 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity2 = Entity(UUID.randomUUID().toString, entityType2, Map())
+    val entity3 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity4 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity5 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity6 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity7 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity8 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    insertAndGet(entity1) // targeted for deletion
+    insertAndGet(entity2) // targeted for deletion
+    insertAndGet(entity3) // should be deleted
+    insertAndGet(entity4) // targeted for deletion
+    insertAndGet(entity4, wsid2) // should NOT be deleted; different workspace
+    val entityRec5 = insertAndGet(entity5) // targeted, but should NOT be deleted due to FK from WORKSPACE_ATTRIBUTE
+    val entityRec6 = insertAndGet(entity6) // targeted, but should NOT be deleted due to FK from SUBMISSION
+    val entityRec7 = insertAndGet(entity7) // targeted, but should NOT be deleted due to FK from WORKFLOW
+    val entityRec8 = insertAndGet(entity8) // targeted, but should NOT be deleted due to FK from SUBMISSION_ATTRIBUTE
+
+    // set up foreign keys
+
+    // a workspace attribute points at entity5
+    runAndWait(
+      sql"""insert into WORKSPACE_ATTRIBUTE(name, owner_id, value_entity_ref)
+            values ('n', $wsid, ${entityRec5.id})""".asUpdate
+    )
+    // a submission points at entity6
+    runAndWait(
+      sql"""insert into METHOD_CONFIG(NAMESPACE, NAME, WORKSPACE_ID)
+            values ('nn', 'n', $wsid)""".asUpdate
+    )
+    val methodConfigId = runAndWait(
+      sql"select ID from METHOD_CONFIG where NAMESPACE = 'nn' and NAME = 'n' and WORKSPACE_ID = $wsid".as[Long].head
+    )
+    runAndWait(sql"""insert into SUBMISSION(ID, WORKSPACE_ID, SUBMITTER, METHOD_CONFIG_ID, SUBMISSION_ROOT, ENTITY_ID)
+            values (${UUID.randomUUID()}, $wsid, 'submitter', $methodConfigId, 'subroot', ${entityRec6.id})""".asUpdate)
+    val submissionId = runAndWait(sql"select ID from SUBMISSION where WORKSPACE_ID = $wsid".as[UUID].head)
+    // a workflow points at entity7
+    runAndWait(sql"""insert into WORKFLOW(SUBMISSION_ID, record_version, ENTITY_ID)
+        values($submissionId, 1, ${entityRec7.id})""".asUpdate)
+    val workflowId = runAndWait(sql"select ID from WORKFLOW where SUBMISSION_ID = $submissionId".as[Long].head)
+    // a submission attribute points at entity8
+    runAndWait(
+      sql"""insert into SUBMISSION_VALIDATION(WORKFLOW_ID, INPUT_NAME) values($workflowId, 'input')""".asUpdate
+    )
+    val submissionValidationId =
+      runAndWait(sql"select id from SUBMISSION_VALIDATION where WORKFLOW_ID = $workflowId".as[Long].head)
+    runAndWait(
+      sql"""insert into SUBMISSION_ATTRIBUTE(name, owner_id, value_entity_ref)
+            values ('s', $submissionValidationId, ${entityRec8.id})""".asUpdate
+    )
+
+    // validate counts before
+    getRawCounts should contain theSameElementsAs Seq(
+      (wsid, entityType1, 7),
+      (wsid, entityType2, 1),
+      (wsid2, entityType1, 1)
+    )
+
+    // perform the delete
+    val pointers = Seq(entity1.toPointer,
+                       entity2.toPointer,
+                       entity4.toPointer,
+                       entity5.toPointer,
+                       entity6.toPointer,
+                       entity7.toPointer,
+                       entity8.toPointer
+    )
+    val deletedCount = runAndWait(q.deleteEntities(wsid, pointers))
+
+    deletedCount shouldBe 3
+
+    // validate counts after
+    getRawCounts should contain theSameElementsAs Seq(
+      (wsid, entityType1, 5),
+      (wsid2, entityType1, 1)
+    )
+  }
 
   behavior of "deleteEntitiesOfType"
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -525,6 +525,7 @@ class CompactEntityProviderSpec extends TestDriverComponentWithFlatSpecAndMatche
     val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
     when(mockQuery.getReferencesTo(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.deleteAllReferencesFrom(any(), any())).thenReturn(DBIO.successful(1))
+    when(mockQuery.deleteEntities(any(), any())).thenReturn(DBIO.successful(0))
     when(
       mockQuery.getEntity(any[UUID],
                           ArgumentMatchers.eq(createdEntityRec1.entityType),
@@ -639,6 +640,7 @@ class CompactEntityProviderSpec extends TestDriverComponentWithFlatSpecAndMatche
     val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
     when(mockQuery.getReferencesToType(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.deleteAllReferencesFromType(any(), any())).thenReturn(DBIO.successful(1))
+    when(mockQuery.deleteEntitiesOfType(any(), any())).thenReturn(DBIO.successful(0))
     when(mockQuery.batchHideType(any(), any())).thenReturn(DBIO.successful(1))
 
     // provider using mocks


### PR DESCRIPTION
Ticket: CORE-495

Implement hard deletes for Quicksilver delete APIs.

The implementation hard-deletes any entities which do not have a foreign key pointing to them, then soft-deletes (hides) the remainder.