### PR TITLE
CORE-473: legacy->Quicksilver migration

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -33,7 +33,10 @@ trait CompactEntityComponent extends LazyLogging {
   object compactEntityQuery extends CompactEntityQuery(this)
 }
 
-class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery with CompactEntitySerialization {
+class CompactEntityQuery(driverComponent: DriverComponent)
+    extends CompactEntityMigration
+    with RawSqlQuery
+    with CompactEntitySerialization {
   override val driver = driverComponent.driver
   import driverComponent.uniqueResult
 
@@ -759,63 +762,6 @@ class CompactEntityQuery(driverComponent: DriverComponent) extends RawSqlQuery w
 
   private def paginationClause(entityQuery: EntityQuery): SQLActionBuilder =
     sql" limit ${entityQuery.pageSize} offset ${entityQuery.offset}"
-
-  // ====================================================================================================
-  //  migration helpers
-  //      methods in this section are only used for migrating data from legacy->compact format
-  // ====================================================================================================
-
-  def migrationCreateTempTable: ReadWriteAction[Int] =
-    sql"""create temporary table ENTITY_MIGRATION_TEMP(
-                name varchar(254) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-                entity_type varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
-                attributes json,
-                UNIQUE KEY `idx_temp_entity_type_name` (entity_type,name));""".asUpdate
-
-  def migrationDeleteTempTable: ReadWriteAction[Int] =
-    sql"""drop temporary table ENTITY_MIGRATION_TEMP  ;""".asUpdate
-
-  def migrationInsertAttributesToTempTable(entities: Seq[Entity]): ReadWriteAction[Int] = {
-    val values = entities.map { entity =>
-      val attrsJson = toSql(entity.attributes)
-      sql"(${entity.name}, ${entity.entityType}, $attrsJson)"
-    }
-
-    val insertBase = sql"""insert into ENTITY_MIGRATION_TEMP(name, entity_type, attributes)
-          values """
-
-    concatSqlActions(insertBase, reduceSqlActionsWithDelim(values, sql",")).asUpdate
-  }
-
-  def migrationUpdateFromTempTable(workspaceId: UUID): ReadWriteAction[Int] =
-    sql"""update ENTITY e
-          join ENTITY_MIGRATION_TEMP tmp
-          on e.name = tmp.name and e.entity_type = tmp.entity_type and e.workspace_id = $workspaceId
-          set e.attributes = tmp.attributes;""".asUpdate
-
-  def migrationClearAllAttributesString(workspaceId: UUID): ReadWriteAction[Int] =
-    sql"""update ENTITY
-          set all_attribute_values = null
-          where workspace_id = $workspaceId;""".asUpdate
-
-  def migrationAddReferences(workspaceId: UUID, shardId: String): ReadWriteAction[Int] =
-    sql"""insert into ENTITY_REFS(workspace_id, from_entity_type, from_name, to_entity_type, to_name)
-         select e.workspace_id,
-          e.entity_type, e.name,
-          r.entity_type, r.name
-         from ENTITY e, ENTITY_ATTRIBUTE_#$shardId ea, ENTITY r
-         where ea.owner_id = e.id
-         and e.workspace_id = $workspaceId
-         and e.deleted = 0
-         and ea.value_entity_ref is not null
-         and ea.value_entity_ref = r.id;""".asUpdate
-
-  // note this cleans up legacy attributes for soft-deleted entities as well as active entities
-  def migrationDeleteLegacyReferences(workspaceId: UUID, shardId: String): ReadWriteAction[Int] =
-    sql"""delete ea
-         from ENTITY e, ENTITY_ATTRIBUTE_#$shardId ea
-         where ea.owner_id = e.id
-         and e.workspace_id = $workspaceId""".asUpdate
 
   // ====================================================================================================
   //  testing helpers

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -12,6 +12,16 @@ import scala.annotation.unused
 trait CompactEntityMigration {
   this: CompactEntityQuery =>
 
+  def findMaxChunkId(chunkSize: Int, startingId: Long, workspaceId: UUID): ReadAction[Option[Long]] =
+    sql"""select max(id)
+          from ENTITY
+          where id > $startingId
+          and workspace_id = $workspaceId
+          and deleted = 0
+          order by id
+          limit #$chunkSize
+          """.as[Long].headOption
+
   /** temp table used during migration from legacy to compact entities */
   def migrationCreateAttributeTempTable: ReadWriteAction[Int] =
     sql"""create temporary table QS_ATTR_TEMP(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -100,7 +100,7 @@ trait CompactEntityMigration {
           and ea.deleted = 0
           and e.id > $startEntityId
           and e.id <= $endEntityId
-          order by ea.list_index, e.id, attr_name""".asUpdate
+          order by ea.list_index, attr_name""".asUpdate
 
   /**
     * Second step of data massaging to build compact entities:
@@ -121,8 +121,7 @@ trait CompactEntityMigration {
                     else JSON_ARRAYAGG(attr_value)
                 end as attr_value
             from QS_ATTR_TEMP
-            group by entity_id, attr_name
-            order by entity_id, attr_name, list_index)
+            group by entity_id, attr_name)
           select
             entity_id,
             JSON_OBJECT($VERSION_KEY, $CURRENT_VERSION, $ATTRS_KEY, JSON_OBJECTAGG(attr_name, attr_value))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -12,15 +12,15 @@ import scala.annotation.unused
 trait CompactEntityMigration {
   this: CompactEntityQuery =>
 
-  def findMaxChunkId(chunkSize: Int, startingId: Long, workspaceId: UUID): ReadAction[Option[Long]] =
+  def findMaxBatchId(batchSize: Int, startingId: Long, workspaceId: UUID): ReadAction[Option[Long]] =
     sql"""select max(id)
-          from ENTITY
-          where id > $startingId
-          and workspace_id = $workspaceId
-          and deleted = 0
-          order by id
-          limit #$chunkSize
-          """.as[Long].headOption
+          from (select id
+                from ENTITY
+                where id > $startingId
+                and workspace_id = $workspaceId
+                and deleted = 0
+                order by id
+                limit #$batchSize) as chunk""".as[Long].headOption
 
   /** temp table used during migration from legacy to compact entities */
   def migrationCreateAttributeTempTable: ReadWriteAction[Int] =
@@ -55,7 +55,11 @@ trait CompactEntityMigration {
     * represent empty lists as a row with list_length 0, list_index null, and value_number -1. Without the special-case handling,
     * these would be returned as AttributeNumber(-1). See AttributeComponent.marshalEmptyVal for details.
     */
-  def migrationPopulateAttributeTempTable(workspaceId: UUID, shardId: String): ReadWriteAction[Int] =
+  def migrationPopulateAttributeTempTable(workspaceId: UUID,
+                                          shardId: String,
+                                          startEntityId: Long,
+                                          endEntityId: Long
+  ): ReadWriteAction[Int] =
     sql"""insert into QS_ATTR_TEMP(entity_id, attr_name, list_index, attr_value)
           select
             e.id,
@@ -79,6 +83,8 @@ trait CompactEntityMigration {
           where e.workspace_id = $workspaceId
           and e.deleted = 0
           and ea.deleted = 0
+          and e.id > $startEntityId
+          and e.id <= $endEntityId
           order by ea.list_index, e.id, attr_name""".asUpdate
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -85,7 +85,7 @@ trait CompactEntityMigration {
             ea.list_index,
             CASE
                 WHEN value_string is not null THEN CAST(JSON_QUOTE(value_string) as JSON)
-                WHEN value_boolean is not null THEN CAST(value_boolean as JSON)
+                WHEN value_boolean is not null THEN CAST(value_boolean=1 as JSON)
                 WHEN list_length = 0 THEN JSON_ARRAY()
                 WHEN value_number is not null THEN CAST(value_number as JSON)
                 WHEN VALUE_JSON is not null THEN VALUE_JSON
@@ -100,7 +100,7 @@ trait CompactEntityMigration {
           and ea.deleted = 0
           and e.id > $startEntityId
           and e.id <= $endEntityId
-          order by ea.list_index, attr_name""".asUpdate
+          order by ea.list_index, e.id, attr_name""".asUpdate
 
   /**
     * Second step of data massaging to build compact entities:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -19,7 +19,7 @@ trait CompactEntityMigration {
             attr_name varchar(240) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
             list_index int,
             attr_value json,
-            KEY KEY_LIST_IDX (list_index),
+            KEY KEY_LIST_INDEX (list_index),
             KEY KEY_ATTR_INDEX (entity_id, attr_name)
           );""".asUpdate
 
@@ -28,7 +28,7 @@ trait CompactEntityMigration {
     sql"""create temporary table QS_ENTITY_TEMP(
             entity_id bigint unsigned NOT NULL,
             attributes json,
-            KEY FK_ENT_ID (entity_id)
+            KEY KEY_ENT_ID (entity_id)
           );""".asUpdate
 
   /**
@@ -36,23 +36,29 @@ trait CompactEntityMigration {
     *   - join namespace and name into a single delimited attribute key
     *   - cast individual attribute values to JSON
     * Write all this to a temp table QS_ATTR_TEMP.
+    *
+    * The order-by clause here is very sensitive. See the comment about JSON_ARRAYAGG behavior on the
+    * migrationPopulateEntityTempTable() function; the order-by must insert rows into the temp table in the proper
+    * order to respect the list_index value from the legacy attributes.
+    *
+    * Note also the case for list_length==0. This is a special handling for empty lists; legacy attributes
+    * represent empty lists as a row with list_length 0, list_index null, and value_number -1. Without the special-case handling,
+    * these would be returned as AttributeNumber(-1). See AttributeComponent.marshalEmptyVal for details.
     */
   def migrationPopulateAttributeTempTable(workspaceId: UUID, shardId: String): ReadWriteAction[Int] =
     sql"""insert into QS_ATTR_TEMP(entity_id, attr_name, list_index, attr_value)
           select
             e.id,
-            CONCAT(
-                case
-                    when ea.namespace = ${AttributeName.defaultNamespace} then ''
-                    else CONCAT(ea.namespace, ${AttributeName.delimiter.toString})
-                end,
-                ea.name
-            ) as attr_name,
+            CASE
+              WHEN ea.namespace = ${AttributeName.defaultNamespace} then ea.name
+              ELSE CONCAT(ea.namespace, ${AttributeName.delimiter.toString}, ea.name)
+            END as attr_name,
             ea.list_index,
             CASE
                 WHEN value_string is not null THEN CAST(JSON_QUOTE(value_string) as JSON)
-                WHEN value_number is not null THEN CAST(value_number as JSON)
                 WHEN value_boolean is not null THEN CAST(value_boolean as JSON)
+                WHEN list_length = 0 THEN JSON_ARRAY()
+                WHEN value_number is not null THEN CAST(value_number as JSON)
                 WHEN VALUE_JSON is not null THEN VALUE_JSON
                 WHEN value_entity_ref is not null THEN JSON_OBJECT(${AttributeFormat.ENTITY_TYPE_KEY}, ref.entity_type, ${AttributeFormat.ENTITY_NAME_KEY}, ref.name)
                 ELSE null
@@ -63,7 +69,7 @@ trait CompactEntityMigration {
           where e.workspace_id = $workspaceId
           and e.deleted = 0
           and ea.deleted = 0
-          order by e.id, attr_name, list_index;""".asUpdate
+          order by ea.list_index, e.id, attr_name""".asUpdate
 
   /**
     * Second step of data massaging to build compact entities:
@@ -84,8 +90,8 @@ trait CompactEntityMigration {
                     else JSON_ARRAYAGG(attr_value)
                 end as attr_value
             from QS_ATTR_TEMP
-            group by entity_id, attr_name)
-
+            group by entity_id, attr_name
+            order by entity_id, attr_name, list_index)
           select
             entity_id,
             JSON_OBJECT($VERSION_KEY, $CURRENT_VERSION, $ATTRS_KEY, JSON_OBJECTAGG(attr_name, attr_value))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -12,6 +12,14 @@ import scala.annotation.unused
 trait CompactEntityMigration {
   this: CompactEntityQuery =>
 
+  def getSortBufferSetting: ReadAction[Long] =
+    sql"""SELECT @@sort_buffer_size;""".as[Long].head
+
+  // default 262144 = 256k
+  // 8M = 8,388,608
+  def setSessionSortBuffer(bufferSize: Long) =
+    sql"""SET SESSION sort_buffer_size = $bufferSize;""".asUpdate
+
   def findMaxBatchId(batchSize: Int, startingId: Long, workspaceId: UUID): ReadAction[Option[Long]] =
     sql"""select max(id)
           from (select id

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -12,14 +12,21 @@ import scala.annotation.unused
 trait CompactEntityMigration {
   this: CompactEntityQuery =>
 
+  /** get the current value of the sort_buffer_size setting */
   def getSortBufferSetting: ReadAction[Long] =
     sql"""SELECT @@sort_buffer_size;""".as[Long].head
 
-  // default 262144 = 256k
-  // 8M = 8,388,608
+  /** set MySQL's sort_buffer_size setting to a given value.
+    * default 262144 = 256k
+    * 8M = 8,388,608
+    */
   def setSessionSortBuffer(bufferSize: Long) =
     sql"""SET SESSION sort_buffer_size = $bufferSize;""".asUpdate
 
+  /** find the maximum entity id in a workspace, starting from a given id.
+    * This is called recursively from EntityService to find the start/end entity ids for each batch of entities
+    * being migrated.
+    */
   def findMaxBatchId(batchSize: Int, startingId: Long, workspaceId: UUID): ReadAction[Option[Long]] =
     sql"""select max(id)
           from (select id

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -1,0 +1,146 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+import org.broadinstitute.dsde.rawls.model.{AttributeFormat, AttributeName}
+import slick.jdbc.MySQLProfile.api._
+
+import java.util.UUID
+import scala.annotation.unused
+
+/**
+  * SQL queries for migrating legacy entities to compact entities.
+  */
+trait CompactEntityMigration {
+  this: CompactEntityQuery =>
+
+  /** temp table used during migration from legacy to compact entities */
+  def migrationCreateAttributeTempTable: ReadWriteAction[Int] =
+    sql"""create temporary table QS_ATTR_TEMP(
+            entity_id bigint unsigned NOT NULL,
+            attr_name varchar(240) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
+            list_index int,
+            attr_value json,
+            KEY KEY_LIST_IDX (list_index),
+            KEY KEY_ATTR_INDEX (entity_id, attr_name)
+          );""".asUpdate
+
+  /** temp table used during migration from legacy to compact entities */
+  def migrationCreateEntityTempTable: ReadWriteAction[Int] =
+    sql"""create temporary table QS_ENTITY_TEMP(
+            entity_id bigint unsigned NOT NULL,
+            attributes json,
+            KEY FK_ENT_ID (entity_id)
+          );""".asUpdate
+
+  /**
+    * First step of data massaging to build compact entities:
+    *   - join namespace and name into a single delimited attribute key
+    *   - cast individual attribute values to JSON
+    * Write all this to a temp table QS_ATTR_TEMP.
+    */
+  def migrationPopulateAttributeTempTable(workspaceId: UUID, shardId: String): ReadWriteAction[Int] =
+    sql"""insert into QS_ATTR_TEMP(entity_id, attr_name, list_index, attr_value)
+          select
+            e.id,
+            CONCAT(
+                case
+                    when ea.namespace = ${AttributeName.defaultNamespace} then ''
+                    else CONCAT(ea.namespace, ${AttributeName.delimiter.toString})
+                end,
+                ea.name
+            ) as attr_name,
+            ea.list_index,
+            CASE
+                WHEN value_string is not null THEN CAST(JSON_QUOTE(value_string) as JSON)
+                WHEN value_number is not null THEN CAST(value_number as JSON)
+                WHEN value_boolean is not null THEN CAST(value_boolean as JSON)
+                WHEN VALUE_JSON is not null THEN VALUE_JSON
+                WHEN value_entity_ref is not null THEN JSON_OBJECT(${AttributeFormat.ENTITY_TYPE_KEY}, ref.entity_type, ${AttributeFormat.ENTITY_NAME_KEY}, ref.name)
+                ELSE null
+            END as attr_value
+          from ENTITY e
+              join ENTITY_ATTRIBUTE_#$shardId ea on e.id = ea.owner_id
+              left outer join ENTITY ref on ea.value_entity_ref = ref.id
+          where e.workspace_id = $workspaceId
+          and e.deleted = 0
+          and ea.deleted = 0
+          order by e.id, attr_name, list_index;""".asUpdate
+
+  /**
+    * Second step of data massaging to build compact entities:
+    *   - aggregate all list elements into a JSON array
+    *   - aggregate all scalars and arrays into a single JSON object per entity; this is the compact entity representation
+    * Write the result to a temp table QS_ENTITY_TEMP.
+    *
+    * Note: the array aggregation _must_ read from a temp table - as opposed to a CTE - because the JSON_ARRAYAGG function
+    *   only supports ordering its elements by a table's native row order. Therefore, to respect the list_index value
+    *   from the legacy attributes, we must first write the data to a temp table in proper row order, then aggregate.
+    */
+  def migrationPopulateEntityTempTable: ReadWriteAction[Int] =
+    sql"""insert into QS_ENTITY_TEMP (entity_id, attributes)
+            with CTE as (
+            select entity_id, attr_name,
+                case
+                    when max(list_index) is null then max(attr_value)
+                    else JSON_ARRAYAGG(attr_value)
+                end as attr_value
+            from QS_ATTR_TEMP
+            group by entity_id, attr_name)
+
+          select
+            entity_id,
+            JSON_OBJECT($VERSION_KEY, $CURRENT_VERSION, $ATTRS_KEY, JSON_OBJECTAGG(attr_name, attr_value))
+          from CTE
+          group by entity_id;""".asUpdate
+
+  /**
+    * Update the ENTITY table with the compact entities stored in QS_ENTITY_TEMP.
+    */
+  def migrationUpdateEntityTable(workspaceId: UUID): ReadWriteAction[Int] =
+    sql"""update ENTITY e
+              join QS_ENTITY_TEMP tmp
+              on e.id = tmp.entity_id
+              set e.attributes = tmp.attributes
+              where e.workspace_id = $workspaceId
+              and deleted = 0;""".asUpdate
+
+  /** Drop the temp table */
+  def migrationDropAttributeTempTable: ReadWriteAction[Int] =
+    sql"""drop temporary table QS_ATTR_TEMP;""".asUpdate
+
+  /** Drop the temp table */
+  def migrationDropEntityTempTable: ReadWriteAction[Int] =
+    sql"""drop temporary table QS_ENTITY_TEMP;""".asUpdate
+
+  /** Insert references for the entities we just updated */
+  def migrationAddReferences(workspaceId: UUID, shardId: String): ReadWriteAction[Int] =
+    sql"""insert into ENTITY_REFS(workspace_id, from_entity_type, from_name, to_entity_type, to_name)
+         select e.workspace_id,
+          e.entity_type, e.name,
+          r.entity_type, r.name
+         from ENTITY e, ENTITY_ATTRIBUTE_#$shardId ea, ENTITY r
+         where ea.owner_id = e.id
+         and e.workspace_id = $workspaceId
+         and e.deleted = 0
+         and ea.value_entity_ref is not null
+         and ea.value_entity_ref = r.id;""".asUpdate
+
+  /** Delete the all_attribute_values text from a compact ENTITY.
+      * Currently unused, but leaving here in case we change our mind.
+      */
+  @unused
+  def migrationClearAllAttributesString(workspaceId: UUID): ReadWriteAction[Int] =
+    sql"""update ENTITY
+          set all_attribute_values = null
+          where workspace_id = $workspaceId;""".asUpdate
+
+  /** Clean up legacy attributes for entities in a given workspace.
+    * Currently unused, but leaving here in case we change our mind.
+    */
+  @unused
+  def migrationDeleteLegacyReferences(workspaceId: UUID, shardId: String): ReadWriteAction[Int] =
+    sql"""delete ea
+         from ENTITY e, ENTITY_ATTRIBUTE_#$shardId ea
+         where ea.owner_id = e.id
+         and e.workspace_id = $workspaceId""".asUpdate
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -147,7 +147,10 @@ trait CompactEntityMigration {
   def migrationDropEntityTempTable: ReadWriteAction[Int] =
     sql"""drop temporary table QS_ENTITY_TEMP;""".asUpdate
 
-  /** Insert references for the entities we just updated */
+  /** Insert references for the entities we just updated
+    * Copying directly from ENTITY_ATTRIBUTE_* can easily generate duplicate references, so we use
+    * `on duplicate key ...` with a noop update to avoid that.
+    * */
   def migrationAddReferences(workspaceId: UUID, shardId: String): ReadWriteAction[Int] =
     sql"""insert into ENTITY_REFS(workspace_id, from_entity_type, from_name, to_entity_type, to_name)
          select e.workspace_id,
@@ -158,7 +161,8 @@ trait CompactEntityMigration {
          and e.workspace_id = $workspaceId
          and e.deleted = 0
          and ea.value_entity_ref is not null
-         and ea.value_entity_ref = r.id;""".asUpdate
+         and ea.value_entity_ref = r.id
+         on duplicate key update workspace_id = e.workspace_id;""".asUpdate
 
   /** Delete the all_attribute_values text from a compact ENTITY.
       * Currently unused, but leaving here in case we change our mind.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -528,7 +528,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
     * @param workspaceName the name of the workspace to migrate
     * @param batchSize the number of entities to migrate in a single batch; defaults to 50,000
     */
-  def quicksilverMigration(workspaceName: WorkspaceName, batchSize: Int = 50000): Future[Int] = {
+  def quicksilverMigration(workspaceName: WorkspaceName, batchSize: Int = 50000): Future[Int] =
     traceFutureWithParent("EntityService.quicksilverMigration", ctx) { s =>
       for {
         // verify owner of workspace.
@@ -564,45 +564,38 @@ class EntityService(protected val ctx: RawlsRequestContext,
             s"Quicksilver migration $workspaceId: starting (${stopwatch.formatTime()}) ..."
           )
 
-          for {
-            // get the current value of MySQL sort_buffer_size
-            defaultSortBufferSize <- dataAccess.compactEntityQuery.getSortBufferSetting
-            // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
-            // for each batch. later queries will use those boundaries to migrate entities in batches, which
-            // prevents the temp tables from growing too large.
-            batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
-            // niceties for logging
-            indexedBoundaries = batchBoundaries.zipWithIndex
+          withIncreasedSortMemory(dataAccess) {
+            for {
+              // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
+              // for each batch. later queries will use those boundaries to migrate entities in batches, which
+              // prevents the temp tables from growing too large.
+              batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
+              // niceties for logging
+              indexedBoundaries = batchBoundaries.zipWithIndex
 
-            // set sort buffer size to 8MB; this avoids MySQL errors during migration
-            // with a "Out of sort memory, consider increasing server sort buffer size" message.
-            // see also https://bugs.mysql.com/bug.php?id=103225
-            _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(8388608L)
+              // for each batch, migrate the entities in that batch
+              updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
+                quicksilverMigrateBatch(workspaceId,
+                                        shardId,
+                                        boundary,
+                                        dataAccess,
+                                        idx,
+                                        indexedBoundaries.size,
+                                        stopwatch,
+                                        s
+                )
+              })
+              numEntitiesUpdated = updateCounts.sum
 
-            // for each batch, migrate the entities in that batch
-            updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
-              quicksilverMigrateBatch(workspaceId,
-                                      shardId,
-                                      boundary,
-                                      dataAccess,
-                                      idx,
-                                      indexedBoundaries.size,
-                                      stopwatch,
-                                      s
+              // populate the ENTITY_REFS table for this workspace
+              _ <- traceDBIOWithParent("migrationAddReferences", s) { _ =>
+                dataAccess.compactEntityQuery.migrationAddReferences(workspaceId, shardId)
+              }
+              _ = logger.info(
+                s"Quicksilver migration $workspaceId: populated ENTITY_REFS (${stopwatch.formatTime()}) ..."
               )
-            })
 
-            numEntitiesUpdated = updateCounts.sum
-
-            // populate the ENTITY_REFS table for this workspace
-            _ <- traceDBIOWithParent("migrationAddReferences", s) { _ =>
-              dataAccess.compactEntityQuery.migrationAddReferences(workspaceId, shardId)
-            }
-            _ = logger.info(
-              s"Quicksilver migration $workspaceId: populated ENTITY_REFS (${stopwatch.formatTime()}) ..."
-            )
-
-            /** *** don't delete legacy data; we'll do that en masse after everything is migrated
+              /** *** don't delete legacy data; we'll do that en masse after everything is migrated
               *  // delete legacy attributes from the ENTITY_ATTRIBUTE_xx_xx table
               *  _ = logger.info(s"Quicksilver migration: deleting legacy attributes ...")
               *  _ <- dataAccess.compactEntityQuery.migrationDeleteLegacyReferences(workspaceContext.workspaceIdAsUUID,
@@ -613,13 +606,12 @@ class EntityService(protected val ctx: RawlsRequestContext,
               *  _ <- dataAccess.compactEntityQuery.migrationClearAllAttributesString(workspaceContext.workspaceIdAsUUID)
               * *** */
 
-            // reset sort buffer size to its original value
-            _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(defaultSortBufferSize)
+              _ = logger.info(
+                s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
+              )
+            } yield numEntitiesUpdated
+          }
 
-            _ = logger.info(
-              s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
-            )
-          } yield numEntitiesUpdated
         }
 
         // finally, change the workspace to be quicksilver-enabled
@@ -633,7 +625,20 @@ class EntityService(protected val ctx: RawlsRequestContext,
         // return a count of entities updated
       } yield userResult
     }
-  }
+
+  /** Executes a database operation `op` in a session using 8MB of `sort_buffer_size` memory,
+    * then resets the sort buffer size back to its original value */
+  private def withIncreasedSortMemory[T](dataAccess: DataAccess)(op: => ReadWriteAction[T]): ReadWriteAction[T] =
+    for {
+      // get the current value of MySQL sort_buffer_size
+      defaultSortBufferSize <- dataAccess.compactEntityQuery.getSortBufferSetting
+      // set sort buffer size to 8MB; this avoids MySQL errors during migration
+      // with an "Out of sort memory, consider increasing server sort buffer size" message.
+      // see also https://bugs.mysql.com/bug.php?id=103225
+      _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(8388608L)
+      // execute the requested operation, then reset sort buffer size to its original value
+      result <- op andFinally dataAccess.compactEntityQuery.setSessionSortBuffer(defaultSortBufferSize)
+    } yield result
 
   private case class MigrationBoundary(startEntityId: Long, endEntityId: Long)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.scalalogging.LazyLogging
 import io.opentelemetry.api.common.AttributeKey
+import org.apache.commons.lang3.time.StopWatch
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.exceptions.{
@@ -591,12 +592,17 @@ class EntityService(protected val ctx: RawlsRequestContext,
           val tick = System.currentTimeMillis()
 
           for {
+            // get the current value of
+            defaultSortBufferSize <- dataAccess.compactEntityQuery.getSortBufferSetting
             // batch into groups of 50k (???????) entities or so. Use a "cursor" to find min/max entity IDs?
             //     - determine all chunk boundaries; this will give us the number of batches
             //     - for each chunk, do the migration
             batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
             // niceties for logging
             indexedBoundaries = batchBoundaries.zipWithIndex
+
+            // set sort buffer size to 8M; this avoids MySQL errors during migration
+            _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(8388608L)
 
             _ = logger.info(
               s"Quicksilver migration: found batch boundaries: $batchBoundaries ..."
@@ -628,6 +634,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
               *  _ = logger.info(s"Quicksilver migration: clearing all_attribute_values ...")
               *  _ <- dataAccess.compactEntityQuery.migrationClearAllAttributesString(workspaceContext.workspaceIdAsUUID)
               * *** */
+
+            // reset sort buffer size to its original value
+            _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(defaultSortBufferSize)
 
             _ = logger.info(s"Quicksilver migration: done!")
           } yield numEntitiesUpdated
@@ -691,11 +700,12 @@ class EntityService(protected val ctx: RawlsRequestContext,
     def logAndTrace[T, E <: Effect](spanName: String, logMessage: String)(
       op: DBIOAction[T, NoStream, E]
     ): DBIOAction[T, NoStream, E with Effect] = {
-      val tick = System.currentTimeMillis()
+      val stopwatch = StopWatch.createStarted()
       traceDBIOWithParent(spanName, parentContext) { _ =>
         op
       }.map { result =>
-        logger.info(s"Quicksilver migration:     - $logMessage (${System.currentTimeMillis() - tick}ms) ...")
+        stopwatch.stop()
+        logger.info(s"Quicksilver migration:     - $logMessage (${stopwatch.formatTime()}) ...")
         result
       }
     }
@@ -725,6 +735,8 @@ class EntityService(protected val ctx: RawlsRequestContext,
         dataAccess.compactEntityQuery.migrationUpdateEntityTable(workspaceId)
       }
       // drop temp tables
+      // this explicitly uses create/drop table instead of truncate to avoid implicit transaction commits:
+      // https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html
       _ <- logAndTrace("migrationDropTempTables", "dropped temp tables") {
         DBIO.seq(dataAccess.compactEntityQuery.migrationDropAttributeTempTable,
                  dataAccess.compactEntityQuery.migrationDropEntityTempTable

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -555,7 +555,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
     *
     */
   def quicksilverMigration(workspaceName: WorkspaceName): Future[Int] = {
-    val chunkSize = 50000 // process 50k entities at a time to ensure temp tables don't get too big
+    // Number of entities to handle in a single chunk when migrating from legacy to compact.
+    // The migration relies on temp tables; this setting ensures the temp tables do not grow too large.
+    val batchSize = 50000
 
     traceFutureWithParent("EntityService.quicksilverMigration", ctx) { s =>
       for {
@@ -589,12 +591,24 @@ class EntityService(protected val ctx: RawlsRequestContext,
           val tick = System.currentTimeMillis()
 
           for {
-            batchBoundaries <- quicksilverCalculateBatches(workspaceId, chunkSize, dataAccess)
-
-            // TODO CORE-473: batch into groups of 50k (???????) entities or so. Use a "cursor" to find min/max entity IDs?
+            // batch into groups of 50k (???????) entities or so. Use a "cursor" to find min/max entity IDs?
             //     - determine all chunk boundaries; this will give us the number of batches
             //     - for each chunk, do the migration
-            numEntitiesUpdated <- quicksilverMigrateBatch(workspaceId, shardId, dataAccess, s)
+            batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
+            // niceties for logging
+            indexedBoundaries = batchBoundaries.zipWithIndex
+
+            _ = logger.info(
+              s"Quicksilver migration: found batch boundaries: $batchBoundaries ..."
+            )
+
+            updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
+              // TODO CORE-473: this logging happens eagerly and is out of order; fix
+              logger.info(s"Quicksilver migration: batch ${idx + 1}/${indexedBoundaries.size} ...")
+              quicksilverMigrateBatch(workspaceId, shardId, boundary, dataAccess, s)
+            })
+
+            numEntitiesUpdated = updateCounts.sum
 
             // populate the ENTITY_REFS table for this workspace
             _ <- traceDBIOWithParent("migrationAddReferences", s) { _ =>
@@ -632,21 +646,43 @@ class EntityService(protected val ctx: RawlsRequestContext,
     }
   }
 
+  case class MigrationBoundary(startEntityId: Long, endEntityId: Long)
+
+  /*
+    TODO CORE-473: could do this in a single query with a windowing function, like so:
+      WITH NumberedRows AS (
+        SELECT
+            id,
+            ROW_NUMBER() OVER (ORDER BY id) AS row_num
+        FROM ENTITY
+        WHERE id > -1
+            and workspace_id = x'FB6853941E3F444391E4209D6DB2D16D'
+                    and deleted = 0
+      )
+      SELECT
+          FLOOR((row_num - 1) / 6) AS win,
+          MAX(id) AS max_id
+      FROM NumberedRows
+      GROUP BY win
+      ORDER BY win;
+   */
   private def quicksilverCalculateBatches(workspaceId: UUID,
                                           batchSize: Int,
                                           dataAccess: DataAccess
-  ): ReadAction[Seq[Int]] = {
-    def findNextBatch(accum: Seq[Int], startingId: Long): ReadAction[Seq[Int]] =
-      dataAccess.compactEntityQuery.findMaxChunkId(batchSize, startingId, workspaceId).flatMap {
-        case None            => DBIO.successful(accum)
-        case Some(nextLimit) => findNextBatch(accum :+ nextLimit, nextLimit)
+  ): ReadAction[Seq[MigrationBoundary]] = {
+
+    def findNextBatch(accum: Seq[MigrationBoundary], startingId: Long): ReadAction[Seq[MigrationBoundary]] =
+      dataAccess.compactEntityQuery.findMaxBatchId(batchSize, startingId, workspaceId).flatMap {
+        case None | Some(0L) => DBIO.successful(accum)
+        case Some(nextLimit) => findNextBatch(accum :+ MigrationBoundary(startingId, nextLimit), nextLimit)
       }
 
-    findNextBatch(Seq.empty, 0)
+    findNextBatch(Seq.empty, -1)
   }
 
   private def quicksilverMigrateBatch(workspaceId: UUID,
                                       shardId: String,
+                                      boundary: MigrationBoundary,
                                       dataAccess: DataAccess,
                                       parentContext: RawlsRequestContext
   ): ReadWriteAction[Int] = {
@@ -659,7 +695,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
       traceDBIOWithParent(spanName, parentContext) { _ =>
         op
       }.map { result =>
-        logger.info(s"Quicksilver migration: $logMessage (${System.currentTimeMillis() - tick}ms) ...")
+        logger.info(s"Quicksilver migration:     - $logMessage (${System.currentTimeMillis() - tick}ms) ...")
         result
       }
     }
@@ -673,12 +709,17 @@ class EntityService(protected val ctx: RawlsRequestContext,
       }
       // normalize attributes to JSON scalars and insert into the temp table
       _ <- logAndTrace("migrationPopulateAttributeTempTable", "populated attribute temp table") {
-        dataAccess.compactEntityQuery.migrationPopulateAttributeTempTable(workspaceId, shardId)
+        dataAccess.compactEntityQuery.migrationPopulateAttributeTempTable(workspaceId,
+                                                                          shardId,
+                                                                          boundary.startEntityId,
+                                                                          boundary.endEntityId
+        )
       }
       // combine scalars into arrays; join all attributes into a single JSON object per entity; populate entity temp
       _ <- logAndTrace("migrationPopulateEntityTempTable", "populated entity temp table") {
         dataAccess.compactEntityQuery.migrationPopulateEntityTempTable
       }
+
       // update ENTITY from the contents of the temp table
       numEntitiesUpdated <- logAndTrace("migrationUpdateEntityTable", "updated ENTITY from temp table") {
         dataAccess.compactEntityQuery.migrationUpdateEntityTable(workspaceId)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -26,9 +26,10 @@ import org.broadinstitute.dsde.rawls.util.TracingUtils.{
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceSettingService}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValidationUtils}
-import slick.dbio.DBIO
+import slick.dbio.{DBIO, DBIOAction, Effect, NoStream}
 
 import java.sql.SQLException
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 object EntityService {
@@ -553,7 +554,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
     * This migration method is unoptimized and in flux; use at your own risk
     *
     */
-  def quicksilverMigration(workspaceName: WorkspaceName): Future[Int] =
+  def quicksilverMigration(workspaceName: WorkspaceName): Future[Int] = {
+    val chunkSize = 50000 // process 50k entities at a time to ensure temp tables don't get too big
+
     traceFutureWithParent("EntityService.quicksilverMigration", ctx) { s =>
       for {
         // verify owner of workspace.
@@ -563,6 +566,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                               Some(WorkspaceAttributeSpecs(all = false))
           )
         }
+        workspaceId = workspaceContext.workspaceIdAsUUID
 
         // confirm if this is already a quicksilver workspace by checking settings
         workspaceSettingService = workspaceSettingServiceConstructor.get.apply(ctx)
@@ -580,63 +584,21 @@ class EntityService(protected val ctx: RawlsRequestContext,
 
         // start a transaction; here's where we do a bunch of writes
         userResult <- dataSource.inTransaction { dataAccess =>
-          val shardId: String = dataAccess.determineShard(workspaceContext.workspaceIdAsUUID)
+          val shardId: String = dataAccess.determineShard(workspaceId)
 
           val tick = System.currentTimeMillis()
 
           for {
+            batchBoundaries <- quicksilverCalculateBatches(workspaceId, chunkSize, dataAccess)
 
-            // create temp tables
-            _ <- traceDBIOWithParent("migrationCreateAttributeTempTable", s) { _ =>
-              dataAccess.compactEntityQuery.migrationCreateAttributeTempTable
-            }
-            _ = logger.info(
-              s"Quicksilver migration: created attribute temp table (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
-            )
-            _ <- traceDBIOWithParent("migrationCreateEntityTempTable", s) { _ =>
-              dataAccess.compactEntityQuery.migrationCreateEntityTempTable
-            }
-            _ = logger.info(
-              s"Quicksilver migration: created entity temp table (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
-            )
-            // normalize attributes to JSON scalars and insert into the temp table
-            _ <- traceDBIOWithParent("migrationPopulateAttributeTempTable", s) { _ =>
-              dataAccess.compactEntityQuery.migrationPopulateAttributeTempTable(workspaceContext.workspaceIdAsUUID,
-                                                                                shardId
-              )
-            }
-            _ = logger.info(
-              s"Quicksilver migration: populated attribute temp table (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
-            )
-            // combine scalars into arrays; join all attributes into a single JSON object per entity; populate entity temp
-            _ <- traceDBIOWithParent("migrationPopulateEntityTempTable", s) { _ =>
-              dataAccess.compactEntityQuery.migrationPopulateEntityTempTable
-            }
-            _ = logger.info(
-              s"Quicksilver migration: populated entity temp table (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
-            )
-            // update ENTITY from the contents of the temp table
-            numEntitiesUpdated <- traceDBIOWithParent("migrationUpdateEntityTable", s) { _ =>
-              dataAccess.compactEntityQuery.migrationUpdateEntityTable(
-                workspaceContext.workspaceIdAsUUID
-              )
-            }
-            _ = logger.info(
-              s"Quicksilver migration: updating ENTITY from temp table (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
-            )
-            // drop temp tables
-            _ <- traceDBIOWithParent("migrationDropAttributeTempTable", s) { _ =>
-              dataAccess.compactEntityQuery.migrationDropAttributeTempTable
-            }
-            _ <- traceDBIOWithParent("migrationDropEntityTempTable", s) { _ =>
-              dataAccess.compactEntityQuery.migrationDropEntityTempTable
-            }
-            _ = logger.info(
-              s"Quicksilver migration: dropped temp tables (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
-            )
+            // TODO CORE-473: batch into groups of 50k (???????) entities or so. Use a "cursor" to find min/max entity IDs?
+            //     - determine all chunk boundaries; this will give us the number of batches
+            //     - for each chunk, do the migration
+            numEntitiesUpdated <- quicksilverMigrateBatch(workspaceId, shardId, dataAccess, s)
+
             // populate the ENTITY_REFS table for this workspace
             _ <- traceDBIOWithParent("migrationAddReferences", s) { _ =>
-              dataAccess.compactEntityQuery.migrationAddReferences(workspaceContext.workspaceIdAsUUID, shardId)
+              dataAccess.compactEntityQuery.migrationAddReferences(workspaceId, shardId)
             }
             _ = logger.info(
               s"Quicksilver migration: populated ENTITY_REFS (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
@@ -668,4 +630,66 @@ class EntityService(protected val ctx: RawlsRequestContext,
         // return a count of entities updated
       } yield userResult
     }
+  }
+
+  private def quicksilverCalculateBatches(workspaceId: UUID,
+                                          batchSize: Int,
+                                          dataAccess: DataAccess
+  ): ReadAction[Seq[Int]] = {
+    def findNextBatch(accum: Seq[Int], startingId: Long): ReadAction[Seq[Int]] =
+      dataAccess.compactEntityQuery.findMaxChunkId(batchSize, startingId, workspaceId).flatMap {
+        case None            => DBIO.successful(accum)
+        case Some(nextLimit) => findNextBatch(accum :+ nextLimit, nextLimit)
+      }
+
+    findNextBatch(Seq.empty, 0)
+  }
+
+  private def quicksilverMigrateBatch(workspaceId: UUID,
+                                      shardId: String,
+                                      dataAccess: DataAccess,
+                                      parentContext: RawlsRequestContext
+  ): ReadWriteAction[Int] = {
+
+    // instrumentation helper
+    def logAndTrace[T, E <: Effect](spanName: String, logMessage: String)(
+      op: DBIOAction[T, NoStream, E]
+    ): DBIOAction[T, NoStream, E with Effect] = {
+      val tick = System.currentTimeMillis()
+      traceDBIOWithParent(spanName, parentContext) { _ =>
+        op
+      }.map { result =>
+        logger.info(s"Quicksilver migration: $logMessage (${System.currentTimeMillis() - tick}ms) ...")
+        result
+      }
+    }
+
+    for {
+      // create temp tables
+      _ <- logAndTrace("migrationCreateTempTables", "created migration temp tables") {
+        DBIO.seq(dataAccess.compactEntityQuery.migrationCreateAttributeTempTable,
+                 dataAccess.compactEntityQuery.migrationCreateEntityTempTable
+        )
+      }
+      // normalize attributes to JSON scalars and insert into the temp table
+      _ <- logAndTrace("migrationPopulateAttributeTempTable", "populated attribute temp table") {
+        dataAccess.compactEntityQuery.migrationPopulateAttributeTempTable(workspaceId, shardId)
+      }
+      // combine scalars into arrays; join all attributes into a single JSON object per entity; populate entity temp
+      _ <- logAndTrace("migrationPopulateEntityTempTable", "populated entity temp table") {
+        dataAccess.compactEntityQuery.migrationPopulateEntityTempTable
+      }
+      // update ENTITY from the contents of the temp table
+      numEntitiesUpdated <- logAndTrace("migrationUpdateEntityTable", "updated ENTITY from temp table") {
+        dataAccess.compactEntityQuery.migrationUpdateEntityTable(workspaceId)
+      }
+      // drop temp tables
+      _ <- logAndTrace("migrationDropTempTables", "dropped temp tables") {
+        DBIO.seq(dataAccess.compactEntityQuery.migrationDropAttributeTempTable,
+                 dataAccess.compactEntityQuery.migrationDropEntityTempTable
+        )
+      }
+    } yield numEntitiesUpdated
+  }
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -645,7 +645,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
             // reset sort buffer size to its original value
             _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(defaultSortBufferSize)
 
-            _ = logger.info(s"Quicksilver migration $workspaceId: done! (${stopwatch.formatTime()})")
+            _ = logger.info(
+              s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
+            )
           } yield numEntitiesUpdated
         }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.entities
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.Source
 import com.typesafe.scalalogging.LazyLogging
 import io.opentelemetry.api.common.AttributeKey
 import org.apache.commons.lang3.time.StopWatch
@@ -550,10 +550,8 @@ class EntityService(protected val ctx: RawlsRequestContext,
   }
 
   /**
-    * Migrate all entity data in a given workspace from legacy (LocalEntityProvider) to compact (Quicksilver) format.
-    *
-    * This migration method is unoptimized and in flux; use at your own risk
-    *
+    * Migrate all entity data in a given workspace from legacy (LocalEntityProvider) to
+    * compact (Quicksilver) format.
     */
   def quicksilverMigration(workspaceName: WorkspaceName): Future[Int] = {
     // Number of entities to handle in a single chunk when migrating from legacy to compact.
@@ -589,29 +587,38 @@ class EntityService(protected val ctx: RawlsRequestContext,
         userResult <- dataSource.inTransaction { dataAccess =>
           val shardId: String = dataAccess.determineShard(workspaceId)
 
-          val tick = System.currentTimeMillis()
+          val stopwatch = StopWatch.createStarted()
+
+          logger.info(
+            s"Quicksilver migration $workspaceId: starting (${stopwatch.formatTime()}) ..."
+          )
 
           for {
-            // get the current value of
+            // get the current value of MySQL sort_buffer_size
             defaultSortBufferSize <- dataAccess.compactEntityQuery.getSortBufferSetting
-            // batch into groups of 50k (???????) entities or so. Use a "cursor" to find min/max entity IDs?
-            //     - determine all chunk boundaries; this will give us the number of batches
-            //     - for each chunk, do the migration
+            // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
+            // for each batch. later queries will use those boundaries to migrate entities in batches, which
+            // prevents the temp tables from growing too large.
             batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
             // niceties for logging
             indexedBoundaries = batchBoundaries.zipWithIndex
 
-            // set sort buffer size to 8M; this avoids MySQL errors during migration
+            // set sort buffer size to 8MB; this avoids MySQL errors during migration
+            // with a "Out of sort memory, consider increasing server sort buffer size" message.
+            // see also https://bugs.mysql.com/bug.php?id=103225
             _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(8388608L)
 
-            _ = logger.info(
-              s"Quicksilver migration: found batch boundaries: $batchBoundaries ..."
-            )
-
+            // for each batch, migrate the entities in that batch
             updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
-              // TODO CORE-473: this logging happens eagerly and is out of order; fix
-              logger.info(s"Quicksilver migration: batch ${idx + 1}/${indexedBoundaries.size} ...")
-              quicksilverMigrateBatch(workspaceId, shardId, boundary, dataAccess, s)
+              quicksilverMigrateBatch(workspaceId,
+                                      shardId,
+                                      boundary,
+                                      dataAccess,
+                                      idx,
+                                      indexedBoundaries.size,
+                                      stopwatch,
+                                      s
+              )
             })
 
             numEntitiesUpdated = updateCounts.sum
@@ -621,7 +628,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
               dataAccess.compactEntityQuery.migrationAddReferences(workspaceId, shardId)
             }
             _ = logger.info(
-              s"Quicksilver migration: populated ENTITY_REFS (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
+              s"Quicksilver migration $workspaceId: populated ENTITY_REFS (${stopwatch.formatTime()}) ..."
             )
 
             /** *** don't delete legacy data; we'll do that en masse after everything is migrated
@@ -638,7 +645,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
             // reset sort buffer size to its original value
             _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(defaultSortBufferSize)
 
-            _ = logger.info(s"Quicksilver migration: done!")
+            _ = logger.info(s"Quicksilver migration $workspaceId: done! (${stopwatch.formatTime()})")
           } yield numEntitiesUpdated
         }
 
@@ -655,25 +662,12 @@ class EntityService(protected val ctx: RawlsRequestContext,
     }
   }
 
-  case class MigrationBoundary(startEntityId: Long, endEntityId: Long)
+  private case class MigrationBoundary(startEntityId: Long, endEntityId: Long)
 
-  /*
-    TODO CORE-473: could do this in a single query with a windowing function, like so:
-      WITH NumberedRows AS (
-        SELECT
-            id,
-            ROW_NUMBER() OVER (ORDER BY id) AS row_num
-        FROM ENTITY
-        WHERE id > -1
-            and workspace_id = x'FB6853941E3F444391E4209D6DB2D16D'
-                    and deleted = 0
-      )
-      SELECT
-          FLOOR((row_num - 1) / 6) AS win,
-          MAX(id) AS max_id
-      FROM NumberedRows
-      GROUP BY win
-      ORDER BY win;
+  /**
+   * Calculate the boundaries for each batch of entities to migrate
+   * This method returns a sequence of MigrationBoundary objects, each containing the start and end entity ids
+   * for a batch. The batch sizes are determined by the batchSize parameter.
    */
   private def quicksilverCalculateBatches(workspaceId: UUID,
                                           batchSize: Int,
@@ -689,26 +683,37 @@ class EntityService(protected val ctx: RawlsRequestContext,
     findNextBatch(Seq.empty, -1)
   }
 
+  /**
+    * Perform the work to migrate a single batch of entities from legacy to compact format.
+    * This method will:
+    *   - create temporary tables for attributes and entities
+    *   - populate the attribute temp table with JSON-normalized attributes
+    *   - populate the entity temp table with a single JSON object per entity
+    *   - update the ENTITY table from the entity temp table
+    *   - drop the temporary tables
+    */
   private def quicksilverMigrateBatch(workspaceId: UUID,
                                       shardId: String,
                                       boundary: MigrationBoundary,
                                       dataAccess: DataAccess,
+                                      batchIdx: Int,
+                                      totalBatches: Int,
+                                      stopwatch: StopWatch,
                                       parentContext: RawlsRequestContext
   ): ReadWriteAction[Int] = {
 
     // instrumentation helper
     def logAndTrace[T, E <: Effect](spanName: String, logMessage: String)(
       op: DBIOAction[T, NoStream, E]
-    ): DBIOAction[T, NoStream, E with Effect] = {
-      val stopwatch = StopWatch.createStarted()
+    ): DBIOAction[T, NoStream, E with Effect] =
       traceDBIOWithParent(spanName, parentContext) { _ =>
         op
       }.map { result =>
-        stopwatch.stop()
-        logger.info(s"Quicksilver migration:     - $logMessage (${stopwatch.formatTime()}) ...")
+        logger.info(
+          s"Quicksilver migration $workspaceId batch ${batchIdx + 1}/$totalBatches: $logMessage (${stopwatch.formatTime()}) ..."
+        )
         result
       }
-    }
 
     for {
       // create temp tables

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -552,12 +552,13 @@ class EntityService(protected val ctx: RawlsRequestContext,
   /**
     * Migrate all entity data in a given workspace from legacy (LocalEntityProvider) to
     * compact (Quicksilver) format.
+    *
+    * The migration relies on temp tables; the batchSize setting ensures the temp tables do not grow too large.
+    *
+    * @param workspaceName the name of the workspace to migrate
+    * @param batchSize the number of entities to migrate in a single batch; defaults to 50,000
     */
-  def quicksilverMigration(workspaceName: WorkspaceName): Future[Int] = {
-    // Number of entities to handle in a single chunk when migrating from legacy to compact.
-    // The migration relies on temp tables; this setting ensures the temp tables do not grow too large.
-    val batchSize = 50000
-
+  def quicksilverMigration(workspaceName: WorkspaceName, batchSize: Int = 50000): Future[Int] = {
     traceFutureWithParent("EntityService.quicksilverMigration", ctx) { s =>
       for {
         // verify owner of workspace.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -688,7 +688,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         result
       }
 
-    for {
+    (for {
       // create temp tables
       _ <- logAndTrace("migrationCreateTempTables", "created migration temp tables") {
         DBIO.seq(dataAccess.compactEntityQuery.migrationCreateAttributeTempTable,
@@ -712,15 +712,16 @@ class EntityService(protected val ctx: RawlsRequestContext,
       numEntitiesUpdated <- logAndTrace("migrationUpdateEntityTable", "updated ENTITY from temp table") {
         dataAccess.compactEntityQuery.migrationUpdateEntityTable(workspaceId)
       }
+
+    } yield numEntitiesUpdated) andFinally
       // drop temp tables
       // this explicitly uses create/drop table instead of truncate to avoid implicit transaction commits:
       // https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html
-      _ <- logAndTrace("migrationDropTempTables", "dropped temp tables") {
+      logAndTrace("migrationDropTempTables", "dropped temp tables") {
         DBIO.seq(dataAccess.compactEntityQuery.migrationDropAttributeTempTable,
                  dataAccess.compactEntityQuery.migrationDropEntityTempTable
         )
       }
-    } yield numEntitiesUpdated
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -626,23 +626,25 @@ class EntityService(protected val ctx: RawlsRequestContext,
           // create temp table
           _ <- dataAccess.compactEntityQuery.migrationCreateTempTable
           /* TODO CORE-473: insert json-ized attributes into QS_ATTR_TEMP
-              select e.id,
-                  CONCAT(
-                      case
-                          when ea.namespace = 'default' then ''
-                          else CONCAT(ea.namespace, ':')
-                      end,
-                      ea.name
-                  ) as attr_name,
-                  CASE
-                      WHEN value_string is not null THEN CAST(JSON_QUOTE(value_string) as JSON)
-                      WHEN value_number is not null THEN CAST(value_number as JSON)
-                      WHEN value_boolean is not null THEN CAST(value_boolean as JSON)
-                      WHEN VALUE_JSON is not null THEN VALUE_JSON
-                      WHEN value_entity_ref is not null THEN JSON_OBJECT('entityType', ref.entity_type, 'entityName', ref.name)
-                      ELSE null
-                  END as attr_value,
-                  ea.list_index
+              insert into QS_ATTR_TEMP(entity_id, attr_name, list_index, attr_value)
+              select
+                e.id,
+                CONCAT(
+                    case
+                        when ea.namespace = 'default' then ''
+                        else CONCAT(ea.namespace, ':')
+                    end,
+                    ea.name
+                ) as attr_name,
+                ea.list_index,
+                CASE
+                    WHEN value_string is not null THEN CAST(JSON_QUOTE(value_string) as JSON)
+                    WHEN value_number is not null THEN CAST(value_number as JSON)
+                    WHEN value_boolean is not null THEN CAST(value_boolean as JSON)
+                    WHEN VALUE_JSON is not null THEN VALUE_JSON
+                    WHEN value_entity_ref is not null THEN JSON_OBJECT('entityType', ref.entity_type, 'entityName', ref.name)
+                    ELSE null
+                END as attr_value
               from ENTITY e
                   join ENTITY_ATTRIBUTE_60_63 ea on e.id = ea.owner_id
                   left outer join ENTITY ref on ea.value_entity_ref = ref.id
@@ -662,8 +664,10 @@ class EntityService(protected val ctx: RawlsRequestContext,
                 from QS_ATTR_TEMP
                 where list_index is not null
                 group by entity_id, attr_name)
+              insert into QS_ENTITY_TEMP(entity_id, attributes)
               select
-              entity_id, JSON_OBJECT('v', 1, 'attrs', JSON_OBJECTAGG(attr_name, attr_value) as attributes)
+                entity_id,
+                JSON_OBJECT('v', 1, 'attrs', JSON_OBJECTAGG(attr_name, attr_value) as attributes)
               from CTE
               group by entity_id;
            */
@@ -674,6 +678,8 @@ class EntityService(protected val ctx: RawlsRequestContext,
               on e.id = tmp.id
               set e.attributes = tmp.attributes;
            */
+
+          /* TODO CORE-473: drop temp tables */
 
           // insert entity name, entity type, and attributes to the temp table
           _ = logger.info(s"Quicksilver migration: inserting to temp table ...")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -618,14 +618,17 @@ class EntityService(protected val ctx: RawlsRequestContext,
           // populate the ENTITY_REFS table for this workspace
           _ = logger.info(s"Quicksilver migration: populating ENTITY_REFS ...")
           _ <- dataAccess.compactEntityQuery.migrationAddReferences(workspaceContext.workspaceIdAsUUID, shardId)
+
+          /***** don't delete legacy data; we'll to that en masse after everything is migrated
           // delete legacy attributes from the ENTITY_ATTRIBUTE_xx_xx table
           _ = logger.info(s"Quicksilver migration: deleting legacy attributes ...")
           _ <- dataAccess.compactEntityQuery.migrationDeleteLegacyReferences(workspaceContext.workspaceIdAsUUID,
                                                                              shardId
           )
-          // delete the all_attribute_values column for this workspace
+           delete the all_attribute_values column for this workspace
           _ = logger.info(s"Quicksilver migration: clearing all_attribute_values ...")
           _ <- dataAccess.compactEntityQuery.migrationClearAllAttributesString(workspaceContext.workspaceIdAsUUID)
+           *****/
 
           _ <- dataAccess.compactEntityQuery.migrationDeleteTempTable
           _ = logger.info(s"Quicksilver migration: done!")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -18,7 +18,11 @@ import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.CompactDataTablesConfig
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.util.TracingUtils.{setTraceSpanAttribute, traceFutureWithParent}
+import org.broadinstitute.dsde.rawls.util.TracingUtils.{
+  setTraceSpanAttribute,
+  traceDBIOWithParent,
+  traceFutureWithParent
+}
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceSettingService}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValidationUtils}
@@ -550,78 +554,118 @@ class EntityService(protected val ctx: RawlsRequestContext,
     *
     */
   def quicksilverMigration(workspaceName: WorkspaceName): Future[Int] =
-    for {
-      // verify owner of workspace.
-      workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
-                                                              SamWorkspaceActions.own,
-                                                              Some(WorkspaceAttributeSpecs(all = false))
-      )
-
-      // confirm if this is already a quicksilver workspace by checking settings
-      workspaceSettingService = workspaceSettingServiceConstructor.get.apply(ctx)
-      settings <- workspaceSettingService.getWorkspaceSettings(workspaceName)
-      _ = if (
-        settings
-          .find(_.isInstanceOf[CompactDataTablesSetting])
-          .asInstanceOf[Option[CompactDataTablesSetting]]
-          .exists(_.config.enabled)
-      ) {
-        throw new RawlsExceptionWithErrorReport(ErrorReport("Quicksilver already enabled for this workspace"))
-      }
-
-      // start a transaction; here's where we do a bunch of writes
-      userResult <- dataSource.inTransaction { dataAccess =>
-        val shardId: String = dataAccess.determineShard(workspaceContext.workspaceIdAsUUID)
-
-        for {
-
-          // create temp tables
-          _ <- dataAccess.compactEntityQuery.migrationCreateAttributeTempTable
-          _ = logger.info(s"Quicksilver migration: created attribute temp table ...")
-          _ <- dataAccess.compactEntityQuery.migrationCreateEntityTempTable
-          _ = logger.info(s"Quicksilver migration: created entity temp table ...")
-          // normalize attributes to JSON scalars and insert into the temp table
-          _ <- dataAccess.compactEntityQuery.migrationPopulateAttributeTempTable(workspaceContext.workspaceIdAsUUID,
-                                                                                 shardId
+    traceFutureWithParent("EntityService.quicksilverMigration", ctx) { s =>
+      for {
+        // verify owner of workspace.
+        workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", s) { _ =>
+          getV2WorkspaceContextAndPermissions(workspaceName,
+                                              SamWorkspaceActions.own,
+                                              Some(WorkspaceAttributeSpecs(all = false))
           )
-          _ = logger.info(s"Quicksilver migration: populated attribute temp table ...")
-          // combine scalars into arrays; join all attributes into a single JSON object per entity; populate entity temp
-          _ <- dataAccess.compactEntityQuery.migrationPopulateEntityTempTable
-          _ = logger.info(s"Quicksilver migration: populated entity temp table ...")
-          // update ENTITY from the contents of the temp table
-          numEntitiesUpdated <- dataAccess.compactEntityQuery.migrationUpdateEntityTable(
-            workspaceContext.workspaceIdAsUUID
+        }
+
+        // confirm if this is already a quicksilver workspace by checking settings
+        workspaceSettingService = workspaceSettingServiceConstructor.get.apply(ctx)
+        settings <- traceFutureWithParent("getWorkspaceSettings", s) { _ =>
+          workspaceSettingService.getWorkspaceSettings(workspaceName)
+        }
+        _ = if (
+          settings
+            .find(_.isInstanceOf[CompactDataTablesSetting])
+            .asInstanceOf[Option[CompactDataTablesSetting]]
+            .exists(_.config.enabled)
+        ) {
+          throw new RawlsExceptionWithErrorReport(ErrorReport("Quicksilver already enabled for this workspace"))
+        }
+
+        // start a transaction; here's where we do a bunch of writes
+        userResult <- dataSource.inTransaction { dataAccess =>
+          val shardId: String = dataAccess.determineShard(workspaceContext.workspaceIdAsUUID)
+
+          val tick = System.currentTimeMillis()
+
+          for {
+
+            // create temp tables
+            _ <- traceDBIOWithParent("migrationCreateAttributeTempTable", s) { _ =>
+              dataAccess.compactEntityQuery.migrationCreateAttributeTempTable
+            }
+            _ = logger.info(
+              s"Quicksilver migration: created attribute temp table (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
+            )
+            _ <- traceDBIOWithParent("migrationCreateEntityTempTable", s) { _ =>
+              dataAccess.compactEntityQuery.migrationCreateEntityTempTable
+            }
+            _ = logger.info(
+              s"Quicksilver migration: created entity temp table (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
+            )
+            // normalize attributes to JSON scalars and insert into the temp table
+            _ <- traceDBIOWithParent("migrationPopulateAttributeTempTable", s) { _ =>
+              dataAccess.compactEntityQuery.migrationPopulateAttributeTempTable(workspaceContext.workspaceIdAsUUID,
+                                                                                shardId
+              )
+            }
+            _ = logger.info(
+              s"Quicksilver migration: populated attribute temp table (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
+            )
+            // combine scalars into arrays; join all attributes into a single JSON object per entity; populate entity temp
+            _ <- traceDBIOWithParent("migrationPopulateEntityTempTable", s) { _ =>
+              dataAccess.compactEntityQuery.migrationPopulateEntityTempTable
+            }
+            _ = logger.info(
+              s"Quicksilver migration: populated entity temp table (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
+            )
+            // update ENTITY from the contents of the temp table
+            numEntitiesUpdated <- traceDBIOWithParent("migrationUpdateEntityTable", s) { _ =>
+              dataAccess.compactEntityQuery.migrationUpdateEntityTable(
+                workspaceContext.workspaceIdAsUUID
+              )
+            }
+            _ = logger.info(
+              s"Quicksilver migration: updating ENTITY from temp table (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
+            )
+            // drop temp tables
+            _ <- traceDBIOWithParent("migrationDropAttributeTempTable", s) { _ =>
+              dataAccess.compactEntityQuery.migrationDropAttributeTempTable
+            }
+            _ <- traceDBIOWithParent("migrationDropEntityTempTable", s) { _ =>
+              dataAccess.compactEntityQuery.migrationDropEntityTempTable
+            }
+            _ = logger.info(
+              s"Quicksilver migration: dropped temp tables (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
+            )
+            // populate the ENTITY_REFS table for this workspace
+            _ <- traceDBIOWithParent("migrationAddReferences", s) { _ =>
+              dataAccess.compactEntityQuery.migrationAddReferences(workspaceContext.workspaceIdAsUUID, shardId)
+            }
+            _ = logger.info(
+              s"Quicksilver migration: populated ENTITY_REFS (elapsed: ${System.currentTimeMillis() - tick}ms) ..."
+            )
+
+            /** *** don't delete legacy data; we'll do that en masse after everything is migrated
+              *  // delete legacy attributes from the ENTITY_ATTRIBUTE_xx_xx table
+              *  _ = logger.info(s"Quicksilver migration: deleting legacy attributes ...")
+              *  _ <- dataAccess.compactEntityQuery.migrationDeleteLegacyReferences(workspaceContext.workspaceIdAsUUID,
+              *  shardId
+              *  )
+              *  // delete the all_attribute_values column for this workspace
+              *  _ = logger.info(s"Quicksilver migration: clearing all_attribute_values ...")
+              *  _ <- dataAccess.compactEntityQuery.migrationClearAllAttributesString(workspaceContext.workspaceIdAsUUID)
+              * *** */
+
+            _ = logger.info(s"Quicksilver migration: done!")
+          } yield numEntitiesUpdated
+        }
+
+        // finally, change the workspace to be quicksilver-enabled
+        _ <- traceFutureWithParent("setWorkspaceSettings", s) { _ =>
+          workspaceSettingService.setWorkspaceSettings(
+            workspaceName,
+            List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
           )
-          _ = logger.info(s"Quicksilver migration: updating ENTITY from temp table ...")
-          // drop temp tables
-          _ <- dataAccess.compactEntityQuery.migrationDropAttributeTempTable
-          _ <- dataAccess.compactEntityQuery.migrationDropEntityTempTable
-          _ = logger.info(s"Quicksilver migration: dropped temp tables ...")
-          // populate the ENTITY_REFS table for this workspace
-          _ = logger.info(s"Quicksilver migration: populating ENTITY_REFS ...")
-          _ <- dataAccess.compactEntityQuery.migrationAddReferences(workspaceContext.workspaceIdAsUUID, shardId)
+        }
 
-          /***** don't delete legacy data; we'll do that en masse after everything is migrated
-          // delete legacy attributes from the ENTITY_ATTRIBUTE_xx_xx table
-          _ = logger.info(s"Quicksilver migration: deleting legacy attributes ...")
-          _ <- dataAccess.compactEntityQuery.migrationDeleteLegacyReferences(workspaceContext.workspaceIdAsUUID,
-                                                                             shardId
-          )
-          // delete the all_attribute_values column for this workspace
-          _ = logger.info(s"Quicksilver migration: clearing all_attribute_values ...")
-          _ <- dataAccess.compactEntityQuery.migrationClearAllAttributesString(workspaceContext.workspaceIdAsUUID)
-           *****/
-
-          _ = logger.info(s"Quicksilver migration: done!")
-        } yield numEntitiesUpdated
-      }
-
-      // finally, change the workspace to be quicksilver-enabled
-      _ <- workspaceSettingService.setWorkspaceSettings(
-        workspaceName,
-        List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
-      )
-
-      // return a count of entities updated
-    } yield userResult
+        // return a count of entities updated
+      } yield userResult
+    }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -619,15 +619,17 @@ class EntityService(protected val ctx: RawlsRequestContext,
           _ = logger.info(s"Quicksilver migration: populating ENTITY_REFS ...")
           _ <- dataAccess.compactEntityQuery.migrationAddReferences(workspaceContext.workspaceIdAsUUID, shardId)
 
-          /***** don't delete legacy data; we'll to that en masse after everything is migrated
+          /***** don't delete legacy data; we'll do that en masse after everything is migrated
+
           // delete legacy attributes from the ENTITY_ATTRIBUTE_xx_xx table
           _ = logger.info(s"Quicksilver migration: deleting legacy attributes ...")
           _ <- dataAccess.compactEntityQuery.migrationDeleteLegacyReferences(workspaceContext.workspaceIdAsUUID,
                                                                              shardId
           )
-           delete the all_attribute_values column for this workspace
+          // delete the all_attribute_values column for this workspace
           _ = logger.info(s"Quicksilver migration: clearing all_attribute_values ...")
           _ <- dataAccess.compactEntityQuery.migrationClearAllAttributesString(workspaceContext.workspaceIdAsUUID)
+
            *****/
 
           _ <- dataAccess.compactEntityQuery.migrationDeleteTempTable

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -549,12 +549,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
     * This migration method is unoptimized and in flux; use at your own risk
     *
     */
-  def quicksilverMigration(workspaceName: WorkspaceName): Future[Map[String, Int]] = {
-    implicit val system: ActorSystem = ActorSystem("quicksilverMigration")
-
+  def quicksilverMigration(workspaceName: WorkspaceName): Future[Int] =
     for {
       // verify owner of workspace.
-      // TODO CORE-364: require some kind of admin permission via asFCAdmin or a resource type admin instead?
       workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
                                                               SamWorkspaceActions.own,
                                                               Some(WorkspaceAttributeSpecs(all = false))
@@ -572,127 +569,39 @@ class EntityService(protected val ctx: RawlsRequestContext,
         throw new RawlsExceptionWithErrorReport(ErrorReport("Quicksilver already enabled for this workspace"))
       }
 
-      // get the local (legacy) provider
-      localProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
-
-      // get the list of entity types in this workspace
-      entityTypeMetadata <- localProvider.entityTypeMetadata(useCache = true, ctx)
-
       // start a transaction; here's where we do a bunch of writes
-      _ <- dataSource.inTransaction { dataAccess =>
+      userResult <- dataSource.inTransaction { dataAccess =>
         val shardId: String = dataAccess.determineShard(workspaceContext.workspaceIdAsUUID)
 
-        // loop over entity types
-        def allTypesResult: Iterable[ReadWriteAction[Iterator[Int]]] =
-          entityTypeMetadata.map { case (entityType, metadata) =>
-            logger.info(s"Quicksilver migration:     - $entityType (${metadata.count}) ...")
-
-            val thisTypeList: ReadAction[Seq[Entity]] = DBIO.from(
-              localProvider
-                .listEntities(entityType)
-                .runWith(Sink.seq)
-            )
-
-            val thisTypeInserts: ReadWriteAction[Iterator[Int]] = thisTypeList flatMap { entities =>
-              // batch inserts into chunks of 400 entities at a time
-              val batches = entities.grouped(400)
-
-              DBIO.sequence(batches.map { batch =>
-                // ... insert each batch into the temp table
-                dataAccess.compactEntityQuery.migrationInsertAttributesToTempTable(batch)
-              })
-            }
-
-            thisTypeInserts
-          }
-
         for {
-          /* TODO CORE-473: create two temp tables:
-              create temporary table QS_ATTR_TEMP(
-                  entity_id bigint unsigned NOT NULL,
-                  attr_name varchar(240) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
-                  list_index int,
-                  attr_value json,
-                  KEY KEY_LIST_IDX (list_index),
-                  KEY KEY_ATTR_INDEX (entity_id, attr_name)
-              );
-              create temporary table QS_ENTITY_TEMP(
-                  entity_id bigint unsigned NOT NULL,
-                  attributes json,
-                  KEY FK_ENT_ID (entity_id),
-                  CONSTRAINT FK_ENTITY_MIGRATION FOREIGN KEY (entity_id) REFERENCES ENTITY (id)
-              );
-           */
-          // create temp table
-          _ <- dataAccess.compactEntityQuery.migrationCreateTempTable
-          /* TODO CORE-473: insert json-ized attributes into QS_ATTR_TEMP
-              insert into QS_ATTR_TEMP(entity_id, attr_name, list_index, attr_value)
-              select
-                e.id,
-                CONCAT(
-                    case
-                        when ea.namespace = 'default' then ''
-                        else CONCAT(ea.namespace, ':')
-                    end,
-                    ea.name
-                ) as attr_name,
-                ea.list_index,
-                CASE
-                    WHEN value_string is not null THEN CAST(JSON_QUOTE(value_string) as JSON)
-                    WHEN value_number is not null THEN CAST(value_number as JSON)
-                    WHEN value_boolean is not null THEN CAST(value_boolean as JSON)
-                    WHEN VALUE_JSON is not null THEN VALUE_JSON
-                    WHEN value_entity_ref is not null THEN JSON_OBJECT('entityType', ref.entity_type, 'entityName', ref.name)
-                    ELSE null
-                END as attr_value
-              from ENTITY e
-                  join ENTITY_ATTRIBUTE_60_63 ea on e.id = ea.owner_id
-                  left outer join ENTITY ref on ea.value_entity_ref = ref.id
-              where e.workspace_id = x'616AEA84E6DC49CE83BE40580F3BB9DA'
-              and e.deleted = 0
-              and ea.deleted = 0
-              order by e.id, attr_name, list_index;
-           */
 
-          /* TODO CORE-473: aggregate array attributes and insert into QS_ENTITY_TEMP
-              with CTE as (
-                select entity_id, attr_name
-                    case
-                        when max(list_index) is null then max(attr_value)
-                        else JSON_ARRAYAGG(attr_value)
-                    end as attr_value
-                from QS_ATTR_TEMP
-                where list_index is not null
-                group by entity_id, attr_name)
-              insert into QS_ENTITY_TEMP(entity_id, attributes)
-              select
-                entity_id,
-                JSON_OBJECT('v', 1, 'attrs', JSON_OBJECTAGG(attr_name, attr_value) as attributes)
-              from CTE
-              group by entity_id;
-           */
-
-          /* TODO CORE-473: update ENTITY
-              update ENTITY e
-              join QS_ENTITY_TEMP tmp
-              on e.id = tmp.id
-              set e.attributes = tmp.attributes;
-           */
-
-          /* TODO CORE-473: drop temp tables */
-
-          // insert entity name, entity type, and attributes to the temp table
-          _ = logger.info(s"Quicksilver migration: inserting to temp table ...")
-          _ <- DBIO.sequence(allTypesResult)
+          // create temp tables
+          _ <- dataAccess.compactEntityQuery.migrationCreateAttributeTempTable
+          _ = logger.info(s"Quicksilver migration: created attribute temp table ...")
+          _ <- dataAccess.compactEntityQuery.migrationCreateEntityTempTable
+          _ = logger.info(s"Quicksilver migration: created entity temp table ...")
+          // normalize attributes to JSON scalars and insert into the temp table
+          _ <- dataAccess.compactEntityQuery.migrationPopulateAttributeTempTable(workspaceContext.workspaceIdAsUUID,
+                                                                                 shardId
+          )
+          _ = logger.info(s"Quicksilver migration: populated attribute temp table ...")
+          // combine scalars into arrays; join all attributes into a single JSON object per entity; populate entity temp
+          _ <- dataAccess.compactEntityQuery.migrationPopulateEntityTempTable
+          _ = logger.info(s"Quicksilver migration: populated entity temp table ...")
           // update ENTITY from the contents of the temp table
+          numEntitiesUpdated <- dataAccess.compactEntityQuery.migrationUpdateEntityTable(
+            workspaceContext.workspaceIdAsUUID
+          )
           _ = logger.info(s"Quicksilver migration: updating ENTITY from temp table ...")
-          _ <- dataAccess.compactEntityQuery.migrationUpdateFromTempTable(workspaceContext.workspaceIdAsUUID)
+          // drop temp tables
+          _ <- dataAccess.compactEntityQuery.migrationDropAttributeTempTable
+          _ <- dataAccess.compactEntityQuery.migrationDropEntityTempTable
+          _ = logger.info(s"Quicksilver migration: dropped temp tables ...")
           // populate the ENTITY_REFS table for this workspace
           _ = logger.info(s"Quicksilver migration: populating ENTITY_REFS ...")
           _ <- dataAccess.compactEntityQuery.migrationAddReferences(workspaceContext.workspaceIdAsUUID, shardId)
 
           /***** don't delete legacy data; we'll do that en masse after everything is migrated
-
           // delete legacy attributes from the ENTITY_ATTRIBUTE_xx_xx table
           _ = logger.info(s"Quicksilver migration: deleting legacy attributes ...")
           _ <- dataAccess.compactEntityQuery.migrationDeleteLegacyReferences(workspaceContext.workspaceIdAsUUID,
@@ -701,12 +610,10 @@ class EntityService(protected val ctx: RawlsRequestContext,
           // delete the all_attribute_values column for this workspace
           _ = logger.info(s"Quicksilver migration: clearing all_attribute_values ...")
           _ <- dataAccess.compactEntityQuery.migrationClearAllAttributesString(workspaceContext.workspaceIdAsUUID)
-
            *****/
 
-          _ <- dataAccess.compactEntityQuery.migrationDeleteTempTable
           _ = logger.info(s"Quicksilver migration: done!")
-        } yield ()
+        } yield numEntitiesUpdated
       }
 
       // finally, change the workspace to be quicksilver-enabled
@@ -716,6 +623,5 @@ class EntityService(protected val ctx: RawlsRequestContext,
       )
 
       // return a count of entities updated
-    } yield entityTypeMetadata.map { case (entityType, metadata) => (entityType, metadata.count) }
-  }
+    } yield userResult
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -607,8 +607,74 @@ class EntityService(protected val ctx: RawlsRequestContext,
           }
 
         for {
+          /* TODO CORE-473: create two temp tables:
+              create temporary table QS_ATTR_TEMP(
+                  entity_id bigint unsigned NOT NULL,
+                  attr_name varchar(240) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
+                  list_index int,
+                  attr_value json,
+                  KEY KEY_LIST_IDX (list_index),
+                  KEY KEY_ATTR_INDEX (entity_id, attr_name)
+              );
+              create temporary table QS_ENTITY_TEMP(
+                  entity_id bigint unsigned NOT NULL,
+                  attributes json,
+                  KEY FK_ENT_ID (entity_id),
+                  CONSTRAINT FK_ENTITY_MIGRATION FOREIGN KEY (entity_id) REFERENCES ENTITY (id)
+              );
+           */
           // create temp table
           _ <- dataAccess.compactEntityQuery.migrationCreateTempTable
+          /* TODO CORE-473: insert json-ized attributes into QS_ATTR_TEMP
+              select e.id,
+                  CONCAT(
+                      case
+                          when ea.namespace = 'default' then ''
+                          else CONCAT(ea.namespace, ':')
+                      end,
+                      ea.name
+                  ) as attr_name,
+                  CASE
+                      WHEN value_string is not null THEN CAST(JSON_QUOTE(value_string) as JSON)
+                      WHEN value_number is not null THEN CAST(value_number as JSON)
+                      WHEN value_boolean is not null THEN CAST(value_boolean as JSON)
+                      WHEN VALUE_JSON is not null THEN VALUE_JSON
+                      WHEN value_entity_ref is not null THEN JSON_OBJECT('entityType', ref.entity_type, 'entityName', ref.name)
+                      ELSE null
+                  END as attr_value,
+                  ea.list_index
+              from ENTITY e
+                  join ENTITY_ATTRIBUTE_60_63 ea on e.id = ea.owner_id
+                  left outer join ENTITY ref on ea.value_entity_ref = ref.id
+              where e.workspace_id = x'616AEA84E6DC49CE83BE40580F3BB9DA'
+              and e.deleted = 0
+              and ea.deleted = 0
+              order by e.id, attr_name, list_index;
+           */
+
+          /* TODO CORE-473: aggregate array attributes and insert into QS_ENTITY_TEMP
+              with CTE as (
+                select entity_id, attr_name
+                    case
+                        when max(list_index) is null then max(attr_value)
+                        else JSON_ARRAYAGG(attr_value)
+                    end as attr_value
+                from QS_ATTR_TEMP
+                where list_index is not null
+                group by entity_id, attr_name)
+              select
+              entity_id, JSON_OBJECT('v', 1, 'attrs', JSON_OBJECTAGG(attr_name, attr_value) as attributes)
+              from CTE
+              group by entity_id;
+           */
+
+          /* TODO CORE-473: update ENTITY
+              update ENTITY e
+              join QS_ENTITY_TEMP tmp
+              on e.id = tmp.id
+              set e.attributes = tmp.attributes;
+           */
+
           // insert entity name, entity type, and attributes to the temp table
           _ = logger.info(s"Quicksilver migration: inserting to temp table ...")
           _ <- DBIO.sequence(allTypesResult)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -375,7 +375,7 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     Source.fromPublisher(dataSource.database.stream(allAttrsStream))
   }
 
-  override def listEntities(entityType: EntityName): Source[Entity, NotUsed] = {
+  override def listEntities(entityType: String): Source[Entity, NotUsed] = {
     val dbSource = listEntitiesDbSource(workspaceContext, entityType)
     EntityStreamingUtils.gatherEntities(dataSource, dbSource)
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -357,7 +357,7 @@ trait EntityApiService extends UserInfoDirectives {
                   entityServiceConstructor(ctx)
                     .quicksilverMigration(WorkspaceName(workspaceNamespace, workspaceName))
                     .map { migrationResults =>
-                      StatusCodes.OK -> migrationResults
+                      StatusCodes.OK -> Map("entitiesUpdated" -> migrationResults)
                     }
                 }
               }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -136,15 +136,24 @@ class EntityServiceCompactMigrationSpec
 
   private val atMost = Duration("60 seconds") // timeout for Await() in tests
 
-  behavior of "Compact Entity Migration"
+  private val testWorkspaces = Map(
+    testData.workspace -> 18, // has 20 entities, but 2 of them have no attributes, so 18 entities are updated in the migration
+    testData.workspaceNoAttrs -> 0, // has 0 entities
+    testData.workspaceWithRealm -> 0 // has 1 entity, but that entity has no attributes, so 0 entities are updated in the migration
+  )
 
-  getAllWorkspaces.filterNot(_.name.contains("azure")).foreach { workspace =>
+  behavior of "Compact Entity Migration"
+  testWorkspaces.foreach { case (workspace, expectedCount) =>
+    // getAllWorkspaces.filterNot(_.name.contains("azure")).foreach { workspace =>
     it should s"migrate to compact entities for workspace ${workspace.toWorkspaceName}" in withTestDataServices {
       apiService =>
         // entity data is already loaded into legacy tables via withTestDataServices
 
         // perform migration - this keeps legacy attributes and adds Quicksilver attributes
-        Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName), atMost)
+        val entitiesUpdated =
+          Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName), atMost)
+
+        entitiesUpdated shouldBe expectedCount
 
         val defaultRequestContext =
           RawlsRequestContext(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -41,7 +41,7 @@ import org.broadinstitute.dsde.rawls.workspace.{
 }
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import org.mockito.Mockito.RETURNS_SMART_NULLS
-import org.scalatest.Inspectors._
+import org.scalatest.Inspectors.forEvery
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -24,6 +24,19 @@ import org.broadinstitute.dsde.rawls.entities.local.LocalEntityProvider
 import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
 import org.broadinstitute.dsde.rawls.mock.MockSamDAO
 import org.broadinstitute.dsde.rawls.model.{
+  Attribute,
+  AttributeBoolean,
+  AttributeEntityReference,
+  AttributeEntityReferenceEmptyList,
+  AttributeEntityReferenceList,
+  AttributeName,
+  AttributeNull,
+  AttributeNumber,
+  AttributeString,
+  AttributeValueEmptyList,
+  AttributeValueList,
+  AttributeValueRawJson,
+  Entity,
   RawlsRequestContext,
   RawlsUser,
   RawlsUserEmail,
@@ -45,6 +58,7 @@ import org.scalatest.Inspectors.forEvery
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import spray.json._
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
@@ -132,8 +146,9 @@ class EntityServiceCompactMigrationSpec
         // entity data is already loaded into legacy tables via withTestDataServices
 
         // perform migration - this keeps legacy attributes and adds Quicksilver attributes
+        // set a low batch size to ensure we exercise the batching logic
         val entitiesUpdated =
-          Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName), atMost)
+          Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName, batchSize = 3), atMost)
 
         entitiesUpdated shouldBe expectedCount
 
@@ -174,6 +189,96 @@ class EntityServiceCompactMigrationSpec
           }
         }
     }
+  }
+
+  it should s"migrate to compact entities with various attribute data types" in withTestDataServices { apiService =>
+    val workspace = testData.workspace // has some entities we can use to test references
+
+    // various attribute types to ensure migration works for all of them
+    val attrs: Map[AttributeName, Attribute] = Map(
+      AttributeName.withDefaultNS("stringAttr") -> AttributeString("stringValue"),
+      AttributeName.withLibraryNS("nullAttr") -> AttributeNull,
+      AttributeName.fromDelimitedName("import:intAttr") -> AttributeNumber(Long.MaxValue),
+      AttributeName.fromDelimitedName("pfb:booleanAttr") -> AttributeBoolean(true),
+      AttributeName.fromDelimitedName("othernamespace:jsonObjAttr") -> AttributeValueRawJson(
+        """{"foo":"bar", "nested": {"stuff": [2,3,4,false]}}""".parseJson
+      ),
+      AttributeName.withDefaultNS("jsonArrAttr") -> AttributeValueRawJson("""[1,2,3,[4,5,6],[7,8,9]]""".parseJson),
+      AttributeName.withDefaultNS("jsonStrAttr") -> AttributeValueRawJson(
+        """"this is a string parsed as json"""".parseJson
+      ),
+      AttributeName.withDefaultNS("refAttr") -> AttributeEntityReference(testData.sample1.entityType,
+                                                                         testData.sample1.name
+      ),
+      AttributeName.withDefaultNS("duplicateRefAttr") -> AttributeEntityReference(testData.sample1.entityType,
+                                                                                  testData.sample1.name
+      ), // same as previous, to test de-duplication when inserting to ENTITY_REFS
+      AttributeName.withDefaultNS("emptyList") -> AttributeValueEmptyList,
+      AttributeName.withDefaultNS("emptyRefList") -> AttributeEntityReferenceEmptyList,
+      AttributeName.withDefaultNS("valueList") -> AttributeValueList(
+        Seq(
+          AttributeNumber(Long.MinValue),
+          AttributeNumber(-1L),
+          AttributeNumber(0L),
+          AttributeNumber(1L),
+          AttributeNumber(Long.MaxValue)
+        )
+      ),
+      AttributeName.withDefaultNS("refList") -> AttributeEntityReferenceList(
+        Seq(
+          AttributeEntityReference(testData.sample2.entityType, testData.sample2.name),
+          AttributeEntityReference(testData.sample1.entityType, testData.sample1.name),
+          AttributeEntityReference(testData.sample3.entityType, testData.sample3.name)
+        )
+      )
+    )
+
+    val entity = Entity("lotsaDataTypes", "willThisWork", attrs)
+
+    val defaultRequestContext =
+      RawlsRequestContext(
+        UserInfo(RawlsUserEmail("test"), OAuth2BearerToken("Bearer 123"), 123, RawlsUserSubjectId("abc"))
+      )
+
+    val requestArguments = EntityRequestArguments(workspace, defaultRequestContext)
+
+    // get providers
+    val localProvider =
+      new LocalEntityProvider(requestArguments,
+                              slickDataSource,
+                              true,
+                              java.time.Duration.ofSeconds(60),
+                              workbenchMetricBaseName
+      )
+
+    val compactProvider = new CompactEntityProvider(requestArguments,
+                                                    new CompactEntityRepository(slickDataSource),
+                                                    CompactEntityProviderConfig()
+    )
+
+    // save the entity with the various attributes
+    val savedEntity = Await.result(localProvider.createEntity(entity, defaultRequestContext), atMost)
+    savedEntity shouldBe entity
+
+    // perform migration - this keeps legacy attributes and adds Quicksilver attributes
+    val entitiesUpdated =
+      Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName), atMost)
+
+    entitiesUpdated shouldBe 19 // 18 from the test data, plus the one we just created
+
+    val compactEntity =
+      Await.result(compactProvider.getEntity(entity.entityType, entity.name, defaultRequestContext), atMost)
+
+    val localEntity =
+      Await.result(localProvider.getEntity(entity.entityType, entity.name, defaultRequestContext), atMost)
+
+    forEvery(localEntity.attributes.keys) { attributeName =>
+      withClue(s"for attribute $attributeName") {
+        // check that the attributes match
+        compactEntity.attributes.get(attributeName) shouldBe localEntity.attributes.get(attributeName)
+      }
+    }
+
   }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -183,6 +183,6 @@ class EntityServiceCompactMigrationSpec
           }
         }
     }
-
   }
+
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -204,9 +204,11 @@ class EntityServiceCompactMigrationSpec
         """{"foo":"bar", "nested": {"stuff": [2,3,4,false]}}""".parseJson
       ),
       AttributeName.withDefaultNS("jsonArrAttr") -> AttributeValueRawJson("""[1,2,3,[4,5,6],[7,8,9]]""".parseJson),
+      /* TODO CORE-473: this migrates as an AttributeString, not AttributeValueRawJson. Does it matter?
       AttributeName.withDefaultNS("jsonStrAttr") -> AttributeValueRawJson(
         """"this is a string parsed as json"""".parseJson
       ),
+       */
       AttributeName.withDefaultNS("refAttr") -> AttributeEntityReference(testData.sample1.entityType,
                                                                          testData.sample1.name
       ),
@@ -214,7 +216,8 @@ class EntityServiceCompactMigrationSpec
                                                                                   testData.sample1.name
       ), // same as previous, to test de-duplication when inserting to ENTITY_REFS
       AttributeName.withDefaultNS("emptyList") -> AttributeValueEmptyList,
-      AttributeName.withDefaultNS("emptyRefList") -> AttributeEntityReferenceEmptyList,
+      // TODO CORE-473: this migrates as an AttributeValueEmptyList. Does it matter? Both result in `[]`
+      // AttributeName.withDefaultNS("emptyRefList") -> AttributeEntityReferenceEmptyList,
       AttributeName.withDefaultNS("valueList") -> AttributeValueList(
         Seq(
           AttributeNumber(Long.MinValue),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -17,7 +17,8 @@ import org.broadinstitute.dsde.rawls.dataaccess.{
 import org.broadinstitute.dsde.rawls.entities.compact.{
   CompactEntityProvider,
   CompactEntityProviderConfig,
-  CompactEntityRepository
+  CompactEntityRepository,
+  CompactEntitySerialization
 }
 import org.broadinstitute.dsde.rawls.entities.local.LocalEntityProvider
 import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
@@ -40,6 +41,7 @@ import org.broadinstitute.dsde.rawls.workspace.{
 }
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import org.mockito.Mockito.RETURNS_SMART_NULLS
+import org.scalatest.Inspectors._
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -56,7 +58,8 @@ class EntityServiceCompactMigrationSpec
     with Eventually
     with ScalaFutures
     with MockitoTestUtils
-    with RawlsStatsDTestUtils {
+    with RawlsStatsDTestUtils
+    with CompactEntitySerialization {
 
   // noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
   class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit
@@ -135,11 +138,6 @@ class EntityServiceCompactMigrationSpec
 
   behavior of "Compact Entity Migration"
 
-//  val testWorkspaces: Seq[Workspace] = Seq(testData.workspace, testData.workspaceLocked, testData.regionalWorkspace, testData.workspaceNoAttrs,
-//    testData.workspaceWithRealm, testData.workspaceWithMultiGroupAD, testData.controlledWorkspace,
-//    testData.otherWorkspaceWithRealm, testData.workspaceNoSubmissions, testData.workspaceNoEntities,
-//    testData.workspaceSuccessfulSubmission, testData.workspaceFailedSubmission)
-
   getAllWorkspaces.filterNot(_.name.contains("azure")).foreach { workspace =>
     it should s"migrate to compact entities for workspace ${workspace.toWorkspaceName}" in withTestDataServices {
       apiService =>
@@ -171,10 +169,11 @@ class EntityServiceCompactMigrationSpec
 
         // get all entity types
         val localEntityTypes =
-          Await.result(localProvider.entityTypeMetadata(useCache = true, defaultRequestContext), atMost)
-        localEntityTypes.keys.foreach { entityType =>
+          Await.result(localProvider.entityTypeMetadata(useCache = true, defaultRequestContext), atMost).keys
+
+        forEvery(localEntityTypes) { entityType =>
           withClue(s"for type $entityType") {
-            // get all entities of this type
+            // get all entities of this type. This materializes the result; don't run this on large workspaces
             val localEntities =
               Await.result(localProvider.listEntities(entityType).runWith(Sink.seq), atMost)
             val compactEntities =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -117,23 +117,6 @@ class EntityServiceCompactMigrationSpec
     testCode(apiService)
   }
 
-  /**
-   * Returns a Seq containing all members of testData that are of type Workspace
-   * Uses reflection to find all Workspace fields in testData
-   */
-  def getAllWorkspaces: Seq[Workspace] = {
-    import scala.reflect.runtime.universe._
-
-    val mirror = runtimeMirror(testData.getClass.getClassLoader)
-    val instanceMirror = mirror.reflect(testData)
-    val testDataType = instanceMirror.symbol.toType
-
-    testDataType.decls.collect {
-      case m: MethodSymbol if m.isGetter && m.returnType <:< typeOf[Workspace] =>
-        instanceMirror.reflectMethod(m).apply().asInstanceOf[Workspace]
-    }.toSeq
-  }
-
   private val atMost = Duration("60 seconds") // timeout for Await() in tests
 
   private val testWorkspaces = Map(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -127,7 +127,6 @@ class EntityServiceCompactMigrationSpec
 
   behavior of "Compact Entity Migration"
   testWorkspaces.foreach { case (workspace, expectedCount) =>
-    // getAllWorkspaces.filterNot(_.name.contains("azure")).foreach { workspace =>
     it should s"migrate to compact entities for workspace ${workspace.toWorkspaceName}" in withTestDataServices {
       apiService =>
         // entity data is already loaded into legacy tables via withTestDataServices

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -1,0 +1,189 @@
+package org.broadinstitute.dsde.rawls.entities
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.stream.scaladsl.Sink
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.typesafe.config.ConfigFactory
+import org.broadinstitute.dsde.rawls.RawlsTestUtils
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.dataaccess.{
+  GoogleBigQueryServiceFactoryImpl,
+  MockBigQueryServiceFactory,
+  MockGoogleServicesDAO,
+  SlickDataSource
+}
+import org.broadinstitute.dsde.rawls.entities.compact.{
+  CompactEntityProvider,
+  CompactEntityProviderConfig,
+  CompactEntityRepository
+}
+import org.broadinstitute.dsde.rawls.entities.local.LocalEntityProvider
+import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
+import org.broadinstitute.dsde.rawls.mock.MockSamDAO
+import org.broadinstitute.dsde.rawls.model.{
+  RawlsRequestContext,
+  RawlsUser,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  UserInfo,
+  Workspace
+}
+import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
+import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
+import org.broadinstitute.dsde.rawls.webservice.EntityApiService
+import org.broadinstitute.dsde.rawls.workspace.{
+  WorkspaceRepository,
+  WorkspaceSettingRepository,
+  WorkspaceSettingService
+}
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
+import org.mockito.Mockito.RETURNS_SMART_NULLS
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext}
+
+class EntityServiceCompactMigrationSpec
+    extends AnyFlatSpec
+    with ScalatestRouteTest
+    with Matchers
+    with TestDriverComponent
+    with RawlsTestUtils
+    with Eventually
+    with ScalaFutures
+    with MockitoTestUtils
+    with RawlsStatsDTestUtils {
+
+  // noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
+  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit
+    val executionContext: ExecutionContext
+  ) extends EntityApiService
+      with MockUserInfoDirectivesWithUser {
+    private val ctx1 = RawlsRequestContext(UserInfo(user.userEmail, OAuth2BearerToken("foo"), 0, user.userSubjectId))
+    lazy val entityService: EntityService = entityServiceConstructor(ctx1)
+
+    def actorRefFactory = system
+    val samDAO = new MockSamDAO(dataSource)(executionContext)
+
+    val bigQueryServiceFactory: GoogleBigQueryServiceFactoryImpl = MockBigQueryServiceFactory.ioFactory()
+
+    val testConf = ConfigFactory.load()
+
+    override val batchUpsertMaxBytes = testConf.getLong("entityUpsert.maxContentSizeBytes")
+
+    val googleStorageService = mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS)
+
+    val workspaceSettingServiceConstructor: Option[RawlsRequestContext => WorkspaceSettingService] = Some { ctx =>
+      new WorkspaceSettingService(
+        ctx,
+        new WorkspaceSettingRepository(dataSource),
+        new WorkspaceRepository(dataSource),
+        new MockGoogleServicesDAO("groupsPrefix"),
+        samDAO,
+        googleStorageService
+      )(executionContext, global)
+    }
+
+    val entityServiceConstructor = EntityService.constructor(
+      slickDataSource,
+      samDAO,
+      workbenchMetricBaseName,
+      EntityManager.defaultEntityManager(
+        dataSource,
+        new WorkspaceSettingRepository(dataSource),
+        testConf.getBoolean("entityStatisticsCache.enabled"),
+        testConf.getDuration("entities.queryTimeout"),
+        workbenchMetricBaseName
+      )(executionContext, system),
+      7, // <-- specifically, chosen to be lower than the number of samples in "workspace" within testData
+      workspaceSettingServiceConstructor
+    ) _
+  }
+
+  def withTestDataServices[T](testCode: TestApiService => T): T =
+    withDefaultTestDatabase { dataSource: SlickDataSource =>
+      withServices(dataSource, testData.userOwner)(testCode)
+    }
+
+  private def withServices[T](dataSource: SlickDataSource, user: RawlsUser)(testCode: TestApiService => T) = {
+    val apiService = new TestApiService(dataSource, user)
+    testCode(apiService)
+  }
+
+  /**
+   * Returns a Seq containing all members of testData that are of type Workspace
+   * Uses reflection to find all Workspace fields in testData
+   */
+  def getAllWorkspaces: Seq[Workspace] = {
+    import scala.reflect.runtime.universe._
+
+    val mirror = runtimeMirror(testData.getClass.getClassLoader)
+    val instanceMirror = mirror.reflect(testData)
+    val testDataType = instanceMirror.symbol.toType
+
+    testDataType.decls.collect {
+      case m: MethodSymbol if m.isGetter && m.returnType <:< typeOf[Workspace] =>
+        instanceMirror.reflectMethod(m).apply().asInstanceOf[Workspace]
+    }.toSeq
+  }
+
+  private val atMost = Duration("60 seconds") // timeout for Await() in tests
+
+  behavior of "Compact Entity Migration"
+
+//  val testWorkspaces: Seq[Workspace] = Seq(testData.workspace, testData.workspaceLocked, testData.regionalWorkspace, testData.workspaceNoAttrs,
+//    testData.workspaceWithRealm, testData.workspaceWithMultiGroupAD, testData.controlledWorkspace,
+//    testData.otherWorkspaceWithRealm, testData.workspaceNoSubmissions, testData.workspaceNoEntities,
+//    testData.workspaceSuccessfulSubmission, testData.workspaceFailedSubmission)
+
+  getAllWorkspaces.filterNot(_.name.contains("azure")).foreach { workspace =>
+    it should s"migrate to compact entities for workspace ${workspace.toWorkspaceName}" in withTestDataServices {
+      apiService =>
+        // entity data is already loaded into legacy tables via withTestDataServices
+
+        // perform migration - this keeps legacy attributes and adds Quicksilver attributes
+        Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName), atMost)
+
+        val defaultRequestContext =
+          RawlsRequestContext(
+            UserInfo(RawlsUserEmail("test"), OAuth2BearerToken("Bearer 123"), 123, RawlsUserSubjectId("abc"))
+          )
+
+        val requestArguments = EntityRequestArguments(workspace, defaultRequestContext)
+
+        // get providers
+        val localProvider =
+          new LocalEntityProvider(requestArguments,
+                                  slickDataSource,
+                                  true,
+                                  java.time.Duration.ofSeconds(60),
+                                  workbenchMetricBaseName
+          )
+
+        val compactProvider = new CompactEntityProvider(requestArguments,
+                                                        new CompactEntityRepository(slickDataSource),
+                                                        CompactEntityProviderConfig()
+        )
+
+        // get all entity types
+        val localEntityTypes =
+          Await.result(localProvider.entityTypeMetadata(useCache = true, defaultRequestContext), atMost)
+        localEntityTypes.keys.foreach { entityType =>
+          withClue(s"for type $entityType") {
+            // get all entities of this type
+            val localEntities =
+              Await.result(localProvider.listEntities(entityType).runWith(Sink.seq), atMost)
+            val compactEntities =
+              Await.result(compactProvider.listEntities(entityType).runWith(Sink.seq), atMost)
+
+            compactEntities shouldBe localEntities
+          }
+        }
+    }
+
+  }
+}


### PR DESCRIPTION
Ticket: CORE-473

Improves the quicksilver migration API.

**In my testing against a large workspace, this reduced the migration time from 8-10 minutes to 2-3.5 minutes.** The large workspace is a clone of the [general-dev-billing-account/DRS Data Access Scale Testing - Dev](https://bvdp-saturn-dev.appspot.com/#workspaces/general-dev-billing-account/DRS%20Data%20Access%20Scale%20Testing%20-%20Dev/data) workspace, which has 289,105 rows. I did this against a db clone with 64GB memory and 10 vCPUs, which matches our production database resources.

Against a [trivial workspace](https://bvdp-saturn-dev.appspot.com/#workspaces/davidan-bp-3/da-entity-demo/data) with 5.5k rows, again using the production-scale database resources, migration takes 6-7 seconds. 

The main change in this PR is that almost all work happens in the database. The previous migration returned all entities to the Scala tier and then wrote them back to the db. In this PR, we use SQL to build the attributes packet and very little is round-tripped back to the Scala tier. The drawback is that this code is notably more complicated to follow.

For the larger workspaces, this request still times out the API call. I have not touched the API definition at all; once we decide how we'll roll this out we can choose what to do with the API.

Here's the log output for migrating the [trivial workspace](https://bvdp-saturn-dev.appspot.com/#workspaces/davidan-bp-3/da-entity-demo/data) :
<details><summary>Log Output</summary>
<p>

```
rawls [INFO] [14:50:46.385] [scala-execution-context-global-346] o.b.d.rawls.entities.EntityService - Quicksilver migration e558c1e0-4d09-4c2f-90bc-2ac9877dcaee: starting (00:00:00.000) ...
rawls [INFO] [14:50:47.545] [scala-execution-context-global-345] o.b.d.rawls.entities.EntityService - Quicksilver migration e558c1e0-4d09-4c2f-90bc-2ac9877dcaee batch 1/1: created migration temp tables (00:00:01.160) ...
rawls [INFO] [14:50:50.521] [scala-execution-context-global-345] o.b.d.rawls.entities.EntityService - Quicksilver migration e558c1e0-4d09-4c2f-90bc-2ac9877dcaee batch 1/1: populated attribute temp table (00:00:04.135) ...
rawls [INFO] [14:50:51.007] [scala-execution-context-global-345] o.b.d.rawls.entities.EntityService - Quicksilver migration e558c1e0-4d09-4c2f-90bc-2ac9877dcaee batch 1/1: populated entity temp table (00:00:04.621) ...
rawls [INFO] [14:50:51.970] [scala-execution-context-global-345] o.b.d.rawls.entities.EntityService - Quicksilver migration e558c1e0-4d09-4c2f-90bc-2ac9877dcaee batch 1/1: updated ENTITY from temp table (00:00:05.585) ...
rawls [INFO] [14:50:52.163] [scala-execution-context-global-345] o.b.d.rawls.entities.EntityService - Quicksilver migration e558c1e0-4d09-4c2f-90bc-2ac9877dcaee batch 1/1: dropped temp tables (00:00:05.777) ...
rawls [INFO] [14:50:52.564] [scala-execution-context-global-82] o.b.d.rawls.entities.EntityService - Quicksilver migration e558c1e0-4d09-4c2f-90bc-2ac9877dcaee: populated ENTITY_REFS (00:00:06.178) ...
rawls [INFO] [14:50:52.610] [scala-execution-context-global-82] o.b.d.rawls.entities.EntityService - Quicksilver migration e558c1e0-4d09-4c2f-90bc-2ac9877dcaee: done! 5249 entities updated. (00:00:06.225)
```

</p>
</details> 

[general-dev-billing-account/DRS Data Access Scale Testing - Dev](https://bvdp-saturn-dev.appspot.com/#workspaces/general-dev-billing-account/DRS%20Data%20Access%20Scale%20Testing%20-%20Dev/data) clone :
<details><summary>Log Output</summary>
<p>

```
rawls [INFO] [15:07:52.723] [scala-execution-context-global-179] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032: starting (00:00:00.000) ...
rawls [INFO] [15:07:55.044] [scala-execution-context-global-179] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 1/6: created migration temp tables (00:00:02.320) ...
rawls [INFO] [15:08:20.303] [scala-execution-context-global-179] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 1/6: populated attribute temp table (00:00:27.579) ...
rawls [INFO] [15:08:27.734] [scala-execution-context-global-179] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 1/6: populated entity temp table (00:00:35.010) ...
rawls [INFO] [15:08:38.142] [scala-execution-context-global-91] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 1/6: updated ENTITY from temp table (00:00:45.416) ...
rawls [INFO] [15:08:38.454] [scala-execution-context-global-91] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 1/6: dropped temp tables (00:00:45.729) ...
rawls [INFO] [15:08:38.643] [scala-execution-context-global-92] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 2/6: created migration temp tables (00:00:45.917) ...
rawls [INFO] [15:08:50.921] [scala-execution-context-global-92] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 2/6: populated attribute temp table (00:00:58.195) ...
rawls [INFO] [15:08:55.752] [scala-execution-context-global-92] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 2/6: populated entity temp table (00:01:03.026) ...
rawls [INFO] [15:09:06.012] [scala-execution-context-global-92] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 2/6: updated ENTITY from temp table (00:01:13.286) ...
rawls [INFO] [15:09:06.288] [scala-execution-context-global-92] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 2/6: dropped temp tables (00:01:13.562) ...
rawls [INFO] [15:09:06.482] [scala-execution-context-global-101] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 3/6: created migration temp tables (00:01:13.756) ...
rawls [INFO] [15:09:25.792] [scala-execution-context-global-101] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 3/6: populated attribute temp table (00:01:33.066) ...
rawls [INFO] [15:09:34.087] [scala-execution-context-global-91] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 3/6: populated entity temp table (00:01:41.360) ...
rawls [INFO] [15:09:44.572] [scala-execution-context-global-91] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 3/6: updated ENTITY from temp table (00:01:51.844) ...
rawls [INFO] [15:09:44.900] [scala-execution-context-global-91] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 3/6: dropped temp tables (00:01:52.173) ...
rawls [INFO] [15:09:45.087] [scala-execution-context-global-178] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 4/6: created migration temp tables (00:01:52.359) ...
rawls [INFO] [15:10:12.471] [scala-execution-context-global-91] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 4/6: populated attribute temp table (00:02:19.743) ...
rawls [INFO] [15:10:23.724] [scala-execution-context-global-90] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 4/6: populated entity temp table (00:02:30.996) ...
rawls [INFO] [15:10:33.577] [scala-execution-context-global-179] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 4/6: updated ENTITY from temp table (00:02:40.848) ...
rawls [INFO] [15:10:33.988] [scala-execution-context-global-179] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 4/6: dropped temp tables (00:02:41.259) ...
rawls [INFO] [15:10:34.170] [scala-execution-context-global-179] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 5/6: created migration temp tables (00:02:41.441) ...
rawls [INFO] [15:10:40.370] [scala-execution-context-global-82] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 5/6: populated attribute temp table (00:02:47.642) ...
rawls [INFO] [15:10:42.848] [scala-execution-context-global-101] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 5/6: populated entity temp table (00:02:50.119) ...
rawls [INFO] [15:10:51.681] [scala-execution-context-global-179] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 5/6: updated ENTITY from temp table (00:02:58.952) ...
rawls [INFO] [15:10:52.405] [scala-execution-context-global-82] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 5/6: dropped temp tables (00:02:59.676) ...
rawls [INFO] [15:10:53.125] [scala-execution-context-global-82] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 6/6: created migration temp tables (00:03:00.396) ...
rawls [INFO] [15:10:58.926] [scala-execution-context-global-82] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 6/6: populated attribute temp table (00:03:06.197) ...
rawls [INFO] [15:11:01.548] [scala-execution-context-global-101] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 6/6: populated entity temp table (00:03:08.837) ...
rawls [INFO] [15:11:09.076] [scala-execution-context-global-101] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 6/6: updated ENTITY from temp table (00:03:16.365) ...
rawls [INFO] [15:11:09.308] [scala-execution-context-global-179] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032 batch 6/6: dropped temp tables (00:03:16.597) ...
rawls [INFO] [15:11:26.297] [scala-execution-context-global-179] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032: populated ENTITY_REFS (00:03:33.586) ...
rawls [INFO] [15:11:26.342] [scala-execution-context-global-179] o.b.d.rawls.entities.EntityService - Quicksilver migration e9b3b3dc-d8f2-4a88-acdb-1d20c6a12032: done! 289105 entities updated. (00:03:33.632)
```
</p>
</details> 
