### PR TITLE
CORE-531: add provider info to tracing in EntityService

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -506,9 +506,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
   ): Future[EntityProvider] =
     for {
       entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-        entityManager.resolveProviderFuture(
-          EntityRequestArguments(workspaceContext, s)
-        )
+        entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
       }
       _ = setTraceSpanAttribute(localContext,
                                 AttributeKey.stringKey("providerType"),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -8,6 +8,7 @@ import com.typesafe.scalalogging.LazyLogging
 import io.opentelemetry.api.common.AttributeKey
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.entities.base.EntityProvider
 import org.broadinstitute.dsde.rawls.entities.exceptions.{
   DataEntityException,
   DeleteEntitiesConflictException,
@@ -78,9 +79,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                                 Some(WorkspaceAttributeSpecs(all = false))
             )
           }
-          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-            entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
-          }
+          entityProvider <- getProviderWithTracing(workspaceContext, localContext)
           result <- traceFutureWithParent("EntityProvider.createEntity", localContext) { s =>
             entityProvider.createEntity(entity, s)
           }
@@ -97,11 +96,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         )
       } flatMap { workspaceContext =>
         val entityFuture = for {
-          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-            entityManager.resolveProviderFuture(
-              EntityRequestArguments(workspaceContext, s)
-            )
-          }
+          entityProvider <- getProviderWithTracing(workspaceContext, localContext)
           entity <- traceFutureWithParent("EntityProvider.getEntity", localContext) { s =>
             entityProvider.getEntity(entityType, entityName, s)
           }
@@ -133,9 +128,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                                 Some(WorkspaceAttributeSpecs(all = false))
             )
           }
-          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-            entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
-          }
+          entityProvider <- getProviderWithTracing(workspaceContext, localContext)
           result <- traceFutureWithParent("EntityProvider.updateEntity", localContext) { s =>
             entityProvider.updateEntity(entityType, entityName, operations, s)
           }
@@ -160,11 +153,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
           )
         } flatMap { workspaceContext =>
           val deleteFuture = for {
-            entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-              entityManager.resolveProviderFuture(
-                EntityRequestArguments(workspaceContext, s)
-              )
-            }
+            entityProvider <- getProviderWithTracing(workspaceContext, localContext)
             _ <- traceFutureWithParent("entityProvider.deleteEntities", localContext) { s =>
               entityProvider.deleteEntities(entRefs.map(_.toPointer), s)
             }
@@ -193,11 +182,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         )
       } flatMap { workspaceContext =>
         val deleteFuture = for {
-          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-            entityManager.resolveProviderFuture(
-              EntityRequestArguments(workspaceContext, s)
-            )
-          }
+          entityProvider <- getProviderWithTracing(workspaceContext, localContext)
           numberOfEntitiesDeleted <- traceFutureWithParent("EntityProvider.deleteEntitiesOfType", localContext) { s =>
             entityProvider.deleteEntitiesOfType(entityType, s)
           }
@@ -230,9 +215,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                               Some(WorkspaceAttributeSpecs(all = false))
           )
         }
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-          entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
-        }
+        entityProvider <- getProviderWithTracing(workspaceContext, localContext)
         result <- traceFutureWithParent("EntityProvider.deleteEntityAttributes", localContext) { s =>
           entityProvider.deleteEntityAttributes(entityType, attributeNames, s)
         }
@@ -253,9 +236,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                               Some(WorkspaceAttributeSpecs(all = false))
           )
         }
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-          entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
-        }
+        entityProvider <- getProviderWithTracing(workspaceContext, localContext)
         result <- traceFutureWithParent("EntityProvider.renameEntity", localContext) { s =>
           entityProvider.renameEntity(entityType, entityName, newName, s)
         }
@@ -274,9 +255,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                               Some(WorkspaceAttributeSpecs(all = false))
           )
         }
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-          entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
-        }
+        entityProvider <- getProviderWithTracing(workspaceContext, localContext)
         result <- traceFutureWithParent("EntityProvider.renameEntityType", localContext) { s =>
           entityProvider.renameEntityType(oldName, renameInfo, s)
         }
@@ -298,9 +277,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                               Some(WorkspaceAttributeSpecs(all = false))
           )
         }
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-          entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
-        }
+        entityProvider <- getProviderWithTracing(workspaceContext, localContext)
         result <- traceFutureWithParent("EntityProvider.evaluateExpression", localContext) { s =>
           entityProvider.evaluateExpression(entityType, entityName, expression, s)
         }
@@ -318,15 +295,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         )
       } flatMap { workspaceContext =>
         val metadataFuture = for {
-          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-            entityManager.resolveProviderFuture(
-              EntityRequestArguments(workspaceContext, s)
-            )
-          }
-          _ = setTraceSpanAttribute(localContext,
-                                    AttributeKey.stringKey("providerType"),
-                                    entityProvider.getClass.getSimpleName
-          )
+          entityProvider <- getProviderWithTracing(workspaceContext, localContext)
           metadata <- traceFutureWithParent("EntityProvider.entityTypeMetadata", localContext) { s =>
             entityProvider.entityTypeMetadata(useCache, s)
           }
@@ -347,9 +316,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                               Some(WorkspaceAttributeSpecs(all = false))
           )
         }
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-          entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
-        }
+        entityProvider <- getProviderWithTracing(workspaceContext, localContext)
         result = entityProvider.listEntities(entityType)
       } yield result).recover(
         sqlLoggingRecover(s"listEntities: $workspaceName $entityType")
@@ -374,11 +341,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         )
       } flatMap { workspaceContext =>
         val queryFuture = for {
-          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-            entityManager.resolveProviderFuture(
-              EntityRequestArguments(workspaceContext, s)
-            )
-          }
+          entityProvider <- getProviderWithTracing(workspaceContext, localContext)
           metadataAndEntitySource <- traceFutureWithParent("EntityProvider.queryEntitiesSource", localContext) { s =>
             entityProvider.queryEntitiesSource(entityType, query, s)
           }
@@ -410,9 +373,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
           samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, destWsCtx.workspaceId, s)
         }
         _ = authDomainCheck(sourceAD.toSet, destAD.toSet)
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-          entityManager.resolveProviderFuture(EntityRequestArguments(destWsCtx, s))
-        }
+        entityProvider <- getProviderWithTracing(destWsCtx, localContext)
         entityCopyResponse <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
           entityProvider
             .copyEntities(sourceWsCtx,
@@ -442,11 +403,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
       )
     } flatMap { workspaceContext =>
       for {
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", parentContext) { s =>
-          entityManager.resolveProviderFuture(
-            EntityRequestArguments(workspaceContext, s)
-          )
-        }
+        entityProvider <- getProviderWithTracing(workspaceContext, parentContext)
         entities <-
           if (upsert) {
             traceFutureWithParent("EntityProvider.batchUpsertEntities", parentContext) { s =>
@@ -482,7 +439,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
     updatedEntities: Seq[Entity]
   ): ReadWriteAction[Traversable[Entity]] =
     for {
-      provider <- DBIO.from(entityManager.resolveProviderFuture(EntityRequestArguments(workspace, ctx)))
+      provider <- DBIO.from(getProviderWithTracing(workspace, ctx))
       res <- provider.saveWorkflowOutputEntities(dataAccess, workspace, updatedEntities)
     } yield res
 
@@ -491,7 +448,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                            entityIds: Seq[Long]
   ): ReadAction[Map[Long, Entity]] =
     for {
-      provider <- DBIO.from(entityManager.resolveProviderFuture(EntityRequestArguments(workspace, ctx)))
+      provider <- DBIO.from(getProviderWithTracing(workspace, ctx))
       res <- provider.listWorkflowEntities(dataAccess, workspace, entityIds)
     } yield res
 
@@ -508,9 +465,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                               Some(WorkspaceAttributeSpecs(all = false))
           )
         }
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
-          entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
-        }
+        entityProvider <- getProviderWithTracing(workspaceContext, localContext)
         result <- traceFutureWithParent("EntityProvider.renameAttribute", localContext) { s =>
           entityProvider.renameAttribute(entityType, oldAttributeName, attributeRenameRequest, s)
         }
@@ -544,6 +499,24 @@ class EntityService(protected val ctx: RawlsRequestContext,
   }
 
   /**
+    * Helper to get the appropriate EntityProvider for the workspace while also adding tracing info
+    */
+  private def getProviderWithTracing(workspaceContext: Workspace,
+                                     localContext: RawlsRequestContext
+  ): Future[EntityProvider] =
+    for {
+      entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+        entityManager.resolveProviderFuture(
+          EntityRequestArguments(workspaceContext, s)
+        )
+      }
+      _ = setTraceSpanAttribute(localContext,
+                                AttributeKey.stringKey("providerType"),
+                                entityProvider.getClass.getSimpleName
+      )
+    } yield entityProvider
+
+  /**
     * Migrate all entity data in a given workspace from legacy (LocalEntityProvider) to compact (Quicksilver) format.
     *
     * This migration method is unoptimized and in flux; use at your own risk
@@ -573,7 +546,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
       }
 
       // get the local (legacy) provider
-      localProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
+      localProvider <- getProviderWithTracing(workspaceContext, ctx)
 
       // get the list of entity types in this workspace
       entityTypeMetadata <- localProvider.entityTypeMetadata(useCache = true, ctx)


### PR DESCRIPTION
Ticket: CORE-531

Extracts a helper method in `EntityService` to consistently annotate traces with the EntityProvider used for that request.

We added this specifically for the metadata API in #3321; this PR adds it for all APIs.

Here's what it looks like for the metadata API:
![Screenshot 30-05-2025 at 13 03](https://github.com/user-attachments/assets/348af044-827f-4a39-8c7e-abc191af450f)
