### PR TITLE
CORE-532: skip noop updates during batchUpsert/batchUpdate

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -108,14 +108,7 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
 
         // Apply the incoming operations to the existing entities (or to an empty entity if none pre-existed).
         // This skips unchanged entities
-        allUpdatedEntities = applyAll(updates, existingEntitiesByIdentifier)
-
-        // If the same entity appears multiple times in our update, take the last one.
-        updatedEntities = allUpdatedEntities
-          .groupBy(_.toPointer)
-          .values
-          .map(_.last)
-          .toSeq
+        updatedEntities = applyAll(updates, existingEntitiesByIdentifier)
 
         // How many updates do we have for each entity being updated?
         updateCounts = updatedEntities
@@ -175,8 +168,14 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
                  accum: Seq[Entity]
     ): Seq[Entity] =
       if (updates.isEmpty) {
-        //  end of updates; return the accumulator
+        // end of updates.
+        // now that everything has been applied, de-duplicate the entities.
+        // If the same entity appears multiple times in our update, take the last one.
         accum
+          .groupBy(_.toPointer)
+          .values
+          .map(_.last)
+          .toSeq
       } else {
         val thisUpdate = updates.head
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -108,7 +108,14 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
 
         // Apply the incoming operations to the existing entities (or to an empty entity if none pre-existed).
         // This skips unchanged entities
-        updatedEntities = applyAll(updates, existingEntitiesByIdentifier)
+        allUpdatedEntities = applyAll(updates, existingEntitiesByIdentifier)
+
+        // If the same entity appears multiple times in our update, take the last one.
+        updatedEntities = allUpdatedEntities
+          .groupBy(_.toPointer)
+          .values
+          .map(_.last)
+          .toSeq
 
         // How many updates do we have for each entity being updated?
         updateCounts = updatedEntities

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -106,11 +106,15 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
           .map(rec => rec.toPointer -> rec.toEntity)
           .toMap
 
+        // Apply the incoming operations to the existing entities (or to an empty entity if none pre-existed).
+        // This skips unchanged entities
+        updatedEntities = applyAll(updates, existingEntitiesByIdentifier)
+
         // How many updates do we have for each entity being updated?
-        updateCounts = updateIdentifiers
-          .groupBy(identity)
-          .map { case (updateIdentifier, updateDefinitions) =>
-            updateIdentifier -> updateDefinitions.size
+        updateCounts = updatedEntities
+          .groupBy(_.toPointer)
+          .map { case (updateIdentifier, updates) =>
+            updateIdentifier -> updates.size
           }
         // what are the existing record_versions?
         existingVersionsByIdentifier = existingEntities
@@ -123,14 +127,16 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
           identifier -> (existingVersion + updateCount)
         }
 
-        // Apply the incoming operations to the existing entities (or to an empty entity if none pre-existed)
-        updatedEntities = applyAll(updates, existingEntitiesByIdentifier)
-
         // Persist the updated entities to the database
-        writeCount <- insertOrUpdateBatch(updatedEntities)
+        _ <- insertOrUpdateBatch(updatedEntities)
+
+        // insertOrUpdateBatch uses an `insert into ... on duplicate key update` statement.
+        // MySQL behavior is to return 1 if a row was inserted and 2 if it was updated.
+        // So, to return the actual number of entities written, we need to count the number of unique pointers.
+        writeCount = updatedEntities.map(_.toPointer).toSet.size
 
         // Re-retrieve the entities we just wrote. This gets the actual record_version values.
-        finalRecordVersions <- repository.queries.getEntityVersions(workspaceId, updateIdentifiers.toSet)
+        finalRecordVersions <- repository.queries.getEntityVersions(workspaceId, updatedEntities.map(_.toPointer).toSet)
 
         // Compare the actual record versions, after writing the entities, to the expected record versions
         _ = finalRecordVersions.foreach { rec =>
@@ -166,18 +172,27 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
         accum
       } else {
         val thisUpdate = updates.head
-        val thisBaseEntity = existingEntitiesByIdentifier.getOrElse(
-          EntityPointer(thisUpdate.entityType, thisUpdate.name),
-          Entity(thisUpdate.name, thisUpdate.entityType, Map())
-        )
+
+        val thisUpdatePointer = EntityPointer(thisUpdate.entityType, thisUpdate.name)
+
+        val isPreExisting = existingEntitiesByIdentifier.contains(thisUpdatePointer)
+
+        val thisBaseEntity =
+          existingEntitiesByIdentifier.getOrElse(
+            thisUpdatePointer,
+            Entity(thisUpdate.name, thisUpdate.entityType, Map())
+          )
 
         val updatedEntity = applyOperationsToEntity(thisBaseEntity, thisUpdate.operations)
 
-        applyOne(updates.tail,
-                 existingEntitiesByIdentifier + (updatedEntity.toPointer -> updatedEntity),
-                 accum :+ updatedEntity
-        )
+        // If the entity has not changed and already exists, we can skip it.
+        val newAccum = if (isPreExisting && thisBaseEntity == updatedEntity) {
+          accum
+        } else {
+          accum :+ updatedEntity
+        }
 
+        applyOne(updates.tail, existingEntitiesByIdentifier + (updatedEntity.toPointer -> updatedEntity), newAccum)
       }
 
     applyOne(updates, existingEntitiesByIdentifier, Seq())

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -76,7 +76,8 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
       EntityUpdateDefinition("name3", "typeB", Seq())
     )
 
-    Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+    val numUpdated = Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+    numUpdated shouldBe 3
 
     val metadataAfter = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
     metadataAfter.size shouldBe 2
@@ -115,7 +116,8 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
       )
     )
 
-    Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+    val numUpdated = Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+    numUpdated shouldBe 3
 
     val metadataAfter = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
     metadataAfter.size shouldBe 2
@@ -202,7 +204,8 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
       )
     )
 
-    Await.result(provider.batchUpsertEntities(updates, defaultRequestContext), atMost)
+    val numUpdated = Await.result(provider.batchUpsertEntities(updates, defaultRequestContext), atMost)
+    numUpdated shouldBe 1
 
     // validate the references after our batchUpsert
     val finalReferences =
@@ -254,7 +257,8 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
       )
     )
 
-    Await.result(provider.batchUpsertEntities(updates, defaultRequestContext), atMost)
+    val numUpdated = Await.result(provider.batchUpsertEntities(updates, defaultRequestContext), atMost)
+    numUpdated shouldBe 1
 
     // validate the references after our batchUpsert
     val finalReferences =
@@ -287,7 +291,8 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
       )
     }
 
-    Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+    val numUpdated = Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+    numUpdated shouldBe 1000
 
     val metadataAfter = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
     metadataAfter.size shouldBe 1
@@ -341,7 +346,8 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
       )
     )
 
-    Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+    val numUpdated = Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+    numUpdated shouldBe 2
 
     // cursory validation of the entity creation
     val metadataAfter = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
@@ -434,6 +440,47 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
     }.toMap
 
     actual shouldBe Entity("name1", "typeA", expectedAttributes)
+
+  }
+
+  it should "handle noop updates" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+
+    // create the pre-existing base entities
+    val baseEntity1 = Entity("name1", "myType", Map(AttributeName.withDefaultNS("foo") -> AttributeString("bar")))
+    val setup1 = Await.result(provider.createEntity(baseEntity1, defaultRequestContext), atMost)
+    setup1 shouldBe baseEntity1
+
+    val baseEntity2 = Entity("name2", "myType", Map(AttributeName.withDefaultNS("baz") -> AttributeString("qux")))
+    val setup2 = Await.result(provider.createEntity(baseEntity2, defaultRequestContext), atMost)
+    setup2 shouldBe baseEntity2
+
+    // issue multiple updates to the same entity
+    val updates = Seq(
+      EntityUpdateDefinition(
+        "name1",
+        "myType",
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("foo"), AttributeString("bar"))) // this is a noop update
+      ),
+      EntityUpdateDefinition(
+        "name2",
+        "myType",
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("baz"), AttributeString("changed!"))) // this is an update
+      )
+    )
+
+    val numUpdated = Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+    numUpdated shouldBe 1 // only one entity was actually updated
+
+    // entity1 remains unchanged
+    val actual1 = Await.result(provider.getEntity("myType", "name1", defaultRequestContext), atMost)
+    actual1 shouldBe baseEntity1
+
+    // entity2 has been updated
+    val actual2 = Await.result(provider.getEntity("myType", "name2", defaultRequestContext), atMost)
+    actual2 shouldBe baseEntity2.copy(attributes =
+      Map(AttributeName.withDefaultNS("baz") -> AttributeString("changed!"))
+    )
 
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -1484,7 +1484,7 @@ class CompactEntityProviderSpec
     )
 
     val actual = provider.applyAll(updates, existingEntitiesByIdentifier)
-    // The actual result is two entities, because we applied the two sets of operations in order
+    // The actual result is the entity after all operations are applied to it; the noop operations are skipped
     actual shouldBe Seq(
       Entity("name2",
              "typeA",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -1393,13 +1393,8 @@ class CompactEntityProviderSpec
     )
 
     val actual = provider.applyAll(updates, existingEntitiesByIdentifier)
-    // The actual result is two entities, because we applied the two sets of operations in order
+    // The actual result is the entity after all operations are applied to it
     actual shouldBe Seq(
-      Entity(
-        "name1",
-        "typeA",
-        Map(AttributeName.withDefaultNS("col1") -> AttributeString("val1"))
-      ),
       Entity(
         "name1",
         "typeA",
@@ -1442,15 +1437,8 @@ class CompactEntityProviderSpec
     )
 
     val actual = provider.applyAll(updates, existingEntitiesByIdentifier)
-    // The actual result is two entities, because we applied the two sets of operations in order
+    // The actual result is the entity after all operations are applied to it
     actual shouldBe Seq(
-      Entity(
-        "name1",
-        "typeA",
-        Map(AttributeName.withDefaultNS("col1") -> AttributeString("val1"),
-            AttributeName.withDefaultNS("existingCol") -> AttributeNumber(42)
-        )
-      ),
       Entity(
         "name1",
         "typeA",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -1463,6 +1463,50 @@ class CompactEntityProviderSpec
     )
   }
 
+  it should "skip noop updates" in {
+    val mockRepository = mock[CompactEntityRepository]
+
+    // provider using mocks
+    val provider = providerWithMocks(mockRepository, defaultEntityRequestArguments)
+
+    val updates: Seq[EntityUpdateDefinition] = Seq(
+      EntityUpdateDefinition("name1",
+                             "typeA",
+                             Seq(AddUpdateAttribute(AttributeName.withDefaultNS("col1"), AttributeString("val1")))
+      ),
+      EntityUpdateDefinition("name2",
+                             "typeA",
+                             Seq(AddUpdateAttribute(AttributeName.withDefaultNS("col1"), AttributeString("val2")))
+      )
+    )
+
+    val existingEntitiesByIdentifier: Map[EntityPointer, Entity] = Map(
+      EntityPointer("typeA", "name1") -> Entity("name1",
+                                                "typeA",
+                                                Map(
+                                                  AttributeName.withDefaultNS("col1") -> AttributeString("val1")
+                                                )
+      ),
+      EntityPointer("typeA", "name2") -> Entity("name2",
+                                                "typeA",
+                                                Map(
+                                                  AttributeName.withDefaultNS("col1") -> AttributeString("val1")
+                                                )
+      )
+    )
+
+    val actual = provider.applyAll(updates, existingEntitiesByIdentifier)
+    // The actual result is two entities, because we applied the two sets of operations in order
+    actual shouldBe Seq(
+      Entity("name2",
+             "typeA",
+             Map(
+               AttributeName.withDefaultNS("col1") -> AttributeString("val2")
+             )
+      )
+    )
+  }
+
   // ====================================================================================================
   //  helper methods
   // ====================================================================================================


### PR DESCRIPTION
Ticket: <Link to Jira ticket>

Two changes for Quicksilver batchUpsert/batchUpdate:
1. if we notice that an entity is unchanged, do not include that entity in db operations.
2. if we notice that an entity has multiple updates, apply them all and take the final result instead of applying each incrementally.

The first change optimizes for the case in which an end user downloads a TSV of their data table containing, say, 1000 rows; then changes 2-3 rows and re-uploads the TSV. Before this PR, we would issue an update for all 1000 rows, even if the update didn't change anything. Now, we only include the 2-3 rows in the update.

The second case is rare afaik but feels worth optimizing for anyway and was confusing; see https://github.com/broadinstitute/rawls/pull/3302#discussion_r2089514650.

As a bonus, this PR makes the value returned by batchUpsert/batchUpdate more accurate. Previously, updates were double-counted because we relied on the number returned by MySQL. MySQL returns 1 for inserts but 2 for updates; see "With ON DUPLICATE KEY UPDATE, the affected-rows value per row …" in [their documentation](https://dev.mysql.com/doc/refman/8.4/en/insert-on-duplicate.html)
