### PR TITLE
CORE-69: update sbt and scala-sbt docker images

### DIFF
--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -136,7 +136,7 @@ jobs:
                           -v jar-cache:/root/.ivy \
                           -v jar-cache:/root/.ivy2 \
                           -w /working \
-                          sbtscala/scala-sbt:eclipse-temurin-17.0.14_7_1.10.11_2.13.16 \
+                          sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 \
                           bash -c "git config --global --add safe.directory /working && sbt -J-Xmx2g -J-XX:+UseG1GC \"project pact4s\" clean \"testOnly org.broadinstitute.dsde.rawls.consumer.*\""
 
       - name: Output consumer contract as non-breaking base64 string

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -136,7 +136,7 @@ jobs:
                           -v jar-cache:/root/.ivy \
                           -v jar-cache:/root/.ivy2 \
                           -w /working \
-                          sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 \
+                          sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16 \
                           bash -c "git config --global --add safe.directory /working && sbt -J-Xmx2g -J-XX:+UseG1GC \"project pact4s\" clean \"testOnly org.broadinstitute.dsde.rawls.consumer.*\""
 
       - name: Output consumer contract as non-breaking base64 string

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -328,7 +328,7 @@ jobs:
                           -e POSTGRES_READ_URL=localhost:5432 \
                           -e POSTGRES_USERNAME=rawls-test \
                           -e POSTGRES_PASSWORD=rawls-test \
-                          sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 \
+                          sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16 \
                           bash -c "git config --global --add safe.directory /working && sbt -J-Xmx2g -J-XX:+UseG1GC \"project pact4s\" clean coverage \"testOnly org.broadinstitute.dsde.rawls.provider.*\"  coverageReport"
 
   can-i-deploy: # The can-i-deploy job will run as a result of a Rawls PR. It reports the pact verification statuses on all deployed environments.

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -328,7 +328,7 @@ jobs:
                           -e POSTGRES_READ_URL=localhost:5432 \
                           -e POSTGRES_USERNAME=rawls-test \
                           -e POSTGRES_PASSWORD=rawls-test \
-                          sbtscala/scala-sbt:eclipse-temurin-17.0.14_7_1.10.11_2.13.16 \
+                          sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 \
                           bash -c "git config --global --add safe.directory /working && sbt -J-Xmx2g -J-XX:+UseG1GC \"project pact4s\" clean coverage \"testOnly org.broadinstitute.dsde.rawls.provider.*\"  coverageReport"
 
   can-i-deploy: # The can-i-deploy job will run as a result of a Rawls PR. It reports the pact verification statuses on all deployed environments.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: Replace build script with multi-stage Dockerfile that builds its own JAR
-# FROM sbtscala/scala-sbt:eclipse-temurin-17.0.14_7_1.10.11_2.13.16 as jar-builder
+# FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 as jar-builder
 # ...build JAR...
 # FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 # COPY --from=jar-builder ./rawls*.jar /rawls

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: Replace build script with multi-stage Dockerfile that builds its own JAR
-# FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 as jar-builder
+# FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16 as jar-builder
 # ...build JAR...
 # FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 # COPY --from=jar-builder ./rawls*.jar /rawls

--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM sbtscala/scala-sbt:eclipse-temurin-17.0.14_7_1.10.11_2.13.16
+FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16
 
 COPY src /app/src
 COPY test.sh /app

--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16
+FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16
 
 COPY src /app/src
 COPY test.sh /app

--- a/automation/project/build.properties
+++ b/automation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.11.0
+sbt.version = 1.11.1

--- a/automation/project/build.properties
+++ b/automation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.11
+sbt.version = 1.11.0

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -99,7 +99,7 @@ function make_jar()
     # TODO: DOCKER_TAG hack until JAR build migrates to Dockerfile. Tell SBT to name the JAR
     # `rawls-assembly-local-SNAP.jar` instead of including the commit hash. Otherwise we get
     # an explosion of JARs that all get copied to the image; and which one runs is undefined.
-    DOCKER_RUN="$DOCKER_RUN -e DOCKER_TAG=local -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 /working/docker/clean_install.sh /working"
+    DOCKER_RUN="$DOCKER_RUN -e DOCKER_TAG=local -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16 /working/docker/clean_install.sh /working"
 
     JAR_CMD=$($DOCKER_RUN 1>&2)
     EXIT_CODE=$?
@@ -116,7 +116,7 @@ function artifactory_push()
     ARTIFACTORY_USERNAME=dsdejenkins
     ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN broadinstitute/dsde-toolbox vault read -field=password secret/dsp/accts/artifactory/dsdejenkins)
     echo "Publishing to artifactory..."
-    docker run --rm -e GIT_HASH=$GIT_HASH -v $PWD:/$PROJECT -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier -w="/$PROJECT" -e ARTIFACTORY_USERNAME=$ARTIFACTORY_USERNAME -e ARTIFACTORY_PASSWORD=$ARTIFACTORY_PASSWORD sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 /$PROJECT/core/src/bin/publishSnapshot.sh
+    docker run --rm -e GIT_HASH=$GIT_HASH -v $PWD:/$PROJECT -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier -w="/$PROJECT" -e ARTIFACTORY_USERNAME=$ARTIFACTORY_USERNAME -e ARTIFACTORY_PASSWORD=$ARTIFACTORY_PASSWORD sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16 /$PROJECT/core/src/bin/publishSnapshot.sh
 }
 
 function docker_cmd()

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -99,7 +99,7 @@ function make_jar()
     # TODO: DOCKER_TAG hack until JAR build migrates to Dockerfile. Tell SBT to name the JAR
     # `rawls-assembly-local-SNAP.jar` instead of including the commit hash. Otherwise we get
     # an explosion of JARs that all get copied to the image; and which one runs is undefined.
-    DOCKER_RUN="$DOCKER_RUN -e DOCKER_TAG=local -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier sbtscala/scala-sbt:eclipse-temurin-17.0.14_7_1.10.11_2.13.16 /working/docker/clean_install.sh /working"
+    DOCKER_RUN="$DOCKER_RUN -e DOCKER_TAG=local -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 /working/docker/clean_install.sh /working"
 
     JAR_CMD=$($DOCKER_RUN 1>&2)
     EXIT_CODE=$?
@@ -116,7 +116,7 @@ function artifactory_push()
     ARTIFACTORY_USERNAME=dsdejenkins
     ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN broadinstitute/dsde-toolbox vault read -field=password secret/dsp/accts/artifactory/dsdejenkins)
     echo "Publishing to artifactory..."
-    docker run --rm -e GIT_HASH=$GIT_HASH -v $PWD:/$PROJECT -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier -w="/$PROJECT" -e ARTIFACTORY_USERNAME=$ARTIFACTORY_USERNAME -e ARTIFACTORY_PASSWORD=$ARTIFACTORY_PASSWORD sbtscala/scala-sbt:eclipse-temurin-17.0.14_7_1.10.11_2.13.16 /$PROJECT/core/src/bin/publishSnapshot.sh
+    docker run --rm -e GIT_HASH=$GIT_HASH -v $PWD:/$PROJECT -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier -w="/$PROJECT" -e ARTIFACTORY_USERNAME=$ARTIFACTORY_USERNAME -e ARTIFACTORY_PASSWORD=$ARTIFACTORY_PASSWORD sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 /$PROJECT/core/src/bin/publishSnapshot.sh
 }
 
 function docker_cmd()

--- a/docker/build_jar.sh
+++ b/docker/build_jar.sh
@@ -6,7 +6,7 @@
 set -e
 
 # make jar.  cache sbt dependencies. capture output and stop db before returning.
-docker run --rm -e DOCKER_TAG -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier sbtscala/scala-sbt:eclipse-temurin-17.0.14_7_1.10.11_2.13.16 /working/docker/clean_install.sh /working
+docker run --rm -e DOCKER_TAG -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 /working/docker/clean_install.sh /working
 EXIT_CODE=$?
 
 if [ $EXIT_CODE != 0 ]; then

--- a/docker/build_jar.sh
+++ b/docker/build_jar.sh
@@ -6,7 +6,7 @@
 set -e
 
 # make jar.  cache sbt dependencies. capture output and stop db before returning.
-docker run --rm -e DOCKER_TAG -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 /working/docker/clean_install.sh /working
+docker run --rm -e DOCKER_TAG -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16 /working/docker/clean_install.sh /working
 EXIT_CODE=$?
 
 if [ $EXIT_CODE != 0 ]; then

--- a/local-dev/templates/docker-rsync-local-rawls.sh
+++ b/local-dev/templates/docker-rsync-local-rawls.sh
@@ -96,7 +96,7 @@ start_server () {
     -e JAVA_OPTS="$JAVA_OPTS" \
     -e GOOGLE_APPLICATION_CREDENTIALS='/etc/rawls-account.json' \
     -e GIT_HASH=$GIT_HASH \
-    sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 \
+    sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16 \
     bash -c "git config --global --add safe.directory /app && sbt clean \~reStart"
 
     docker cp config/rawls-account.pem rawls-sbt:/etc/rawls-account.pem

--- a/local-dev/templates/docker-rsync-local-rawls.sh
+++ b/local-dev/templates/docker-rsync-local-rawls.sh
@@ -96,7 +96,7 @@ start_server () {
     -e JAVA_OPTS="$JAVA_OPTS" \
     -e GOOGLE_APPLICATION_CREDENTIALS='/etc/rawls-account.json' \
     -e GIT_HASH=$GIT_HASH \
-    sbtscala/scala-sbt:eclipse-temurin-17.0.14_7_1.10.11_2.13.16 \
+    sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 \
     bash -c "git config --global --add safe.directory /app && sbt clean \~reStart"
 
     docker cp config/rawls-account.pem rawls-sbt:/etc/rawls-account.pem

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.11.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.0
+sbt.version=1.11.1


### PR DESCRIPTION
Ticket: CORE-69

Partially supersedes #3331. When updating `sbt`, we also need to update the `scala-sbt` docker images.
