### PR TITLE
CORE-462: dont fail Cromwell-on-Quicksilver

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -44,6 +44,7 @@ import org.broadinstitute.dsde.rawls.model.{
   Workspace
 }
 import org.broadinstitute.dsde.rawls.util.TracingUtils.{trace, traceDBIOWithParent}
+import slick.dbio.DBIO
 import slick.jdbc.ResultSetConcurrency.ReadOnly
 import slick.jdbc.{ResultSetConcurrency, ResultSetType}
 import slick.jdbc.TransactionIsolation.ReadCommitted
@@ -100,12 +101,12 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
     dataAccess: DataAccess,
     workspace: Workspace,
     updatedEntities: Seq[Entity]
-  ): ReadWriteAction[Traversable[Entity]] = ???
+  ): ReadWriteAction[Traversable[Entity]] = DBIO.successful(Seq()) // FIXME: implement this
 
   def listWorkflowEntities(dataAccess: DataAccess,
                            workspace: Workspace,
                            entityIds: Seq[Long]
-  ): ReadAction[Map[Long, Entity]] = ???
+  ): ReadAction[Map[Long, Entity]] = DBIO.successful(Map()) // FIXME: implement this
 
   override def copyEntities(sourceWorkspaceContext: Workspace,
                             destWorkspaceContext: Workspace,


### PR DESCRIPTION
Ticket: CORE-462

helpful for CORE-462 but does not complete that ticket.

When running a Cromwell submission on a Quicksilver-enabled workspace, don't throw errors during submission monitoring or writing outputs.

Note that this is just an interim PR to avoid errors. It does not implement output-writing. Outputs to data tables will still not be saved. This PR just avoids errors.