### PR TITLE
[CORE-521] Fix incorrect cost reporting for submissions with running workflows

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceImpl.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceImpl.scala
@@ -52,30 +52,16 @@ class SubmissionCostServiceImpl(defaultTableName: String,
       Future.successful(Map.empty[String, Float])
     } else {
       for {
-        // try looking up the workflows via the submission ID.
-        // this makes for a smaller query string (though no faster).
-        submissionCosts <- executeSubmissionCostsQuery(
-          submissionId,
+        // Lookup-only costs for the requested workflow IDs
+        workflowCosts <- executeWorkflowCostsQuery(
+          workflowIds,
           googleProjectId,
           submissionDate,
           terminalStatusDate,
           tableName,
           datePartitionColumn
         )
-        // if that doesn't return anything, fall back to
-        fallbackCosts <-
-          if (submissionCosts.size() == 0)
-            executeWorkflowCostsQuery(
-              workflowIds,
-              googleProjectId,
-              submissionDate,
-              terminalStatusDate,
-              tableName,
-              datePartitionColumn
-            )
-          else
-            Future.successful(submissionCosts)
-      } yield extractCostResults(fallbackCosts)
+      } yield extractCostResults(workflowCosts)
     }
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-521

Fixes a bug where Rawls reports actual cost instead of estimated cost when:

- Some workflows are still running (should report estimated cost)
- Those running workflows already have actual cost in BigQuery
- At least one workflow is terminated and over 24 hours old

Now, if any workflows are still running, Rawls will correctly report estimated cost, regardless of what's in BigQuery.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
