### PR TITLE
CORE-541: v2 serialization format for Quicksilver; remove ENTITY_REFS

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -142,4 +142,5 @@
     <include file="changesets/20250425_entity_json_serdes_format.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250428_entity_keys_update_trigger.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250514_use_names_in_entity_refs.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20250604_entity_views.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -142,5 +142,5 @@
     <include file="changesets/20250425_entity_json_serdes_format.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250428_entity_keys_update_trigger.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250514_use_names_in_entity_refs.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/20250604_entity_views.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20250604_entity_refs_view.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250604_entity_refs_view.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250604_entity_refs_view.xml
@@ -3,23 +3,9 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
 
-    <changeSet logicalFilePath="dummy" author="davidan" id="entity_refs_and_keys_views">
-        <!-- drop the triggers that populate ENTITY_KEYS -->
-        <sql stripComments="true" endDelimiter="~">
-        DROP TRIGGER IF EXISTS after_entity_insert ~
-        DROP TRIGGER IF EXISTS after_entity_update ~
-        </sql>
-
+    <changeSet logicalFilePath="dummy" author="davidan" id="entity_refs_view">
         <!-- drop the physical ENTITY_REFS and ENTITY_KEYS tables -->
         <dropTable tableName="ENTITY_REFS" />
-        <dropTable tableName="ENTITY_KEYS" />
-
-        <!-- create the ENTITY_KEYS view -->
-        <createView viewName="ENTITY_KEYS" replaceIfExists="true">
-            SELECT id, workspace_id, entity_type, JSON_KEYS(attributes, '$.attrs') as attribute_keys
-            FROM ENTITY
-            WHERE deleted = 0 and attributes is not null
-        </createView>
 
         <!-- create the ENTITY_REFS view -->
         <createView viewName="ENTITY_REFS" replaceIfExists="true">

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250604_entity_refs_view.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250604_entity_refs_view.xml
@@ -4,7 +4,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
 
     <changeSet logicalFilePath="dummy" author="davidan" id="entity_refs_view">
-        <!-- drop the physical ENTITY_REFS and ENTITY_KEYS tables -->
+        <!-- drop the physical ENTITY_REFS table -->
         <dropTable tableName="ENTITY_REFS" />
 
         <!-- create the ENTITY_REFS view -->
@@ -27,9 +27,6 @@
             ) AS refs_tbl
             WHERE deleted = 0 and attributes is not null
         </createView>
-
     </changeSet>
-
-
 
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250604_entity_views.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250604_entity_views.xml
@@ -23,26 +23,23 @@
 
         <!-- create the ENTITY_REFS view -->
         <createView viewName="ENTITY_REFS" replaceIfExists="true">
-            SELECT workspace_id,
+            SELECT distinct workspace_id,
                    id as from_entity_id,
                    entity_type as from_entity_type,
                    name as from_name,
                    from_attribute_name,
                    to_entity_type,
-                   to_name,
-                   is_scalar
+                   to_name
             FROM ENTITY
             JOIN JSON_TABLE(
                 attributes,
                 '$.refs[*]' COLUMNS (
                     from_attribute_name varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$.a',
 					to_entity_type varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$.t',
-		            to_name varchar(254) PATH '$.n',
-                    is_scalar boolean PATH '$.s'
+		            to_name varchar(254) PATH '$.n'
                  )
             ) AS refs_tbl
-            WHERE attributes is not null
-              AND deleted = 0
+            WHERE deleted = 0 and attributes is not null
         </createView>
 
     </changeSet>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250604_entity_views.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250604_entity_views.xml
@@ -3,7 +3,7 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
 
-    <changeSet logicalFilePath="dummy" author="davidan" id="entity_refs_and_keys_views" runOnChange="true">
+    <changeSet logicalFilePath="dummy" author="davidan" id="entity_refs_and_keys_views">
         <!-- drop the triggers that populate ENTITY_KEYS -->
         <sql stripComments="true" endDelimiter="~">
         DROP TRIGGER IF EXISTS after_entity_insert ~

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250604_entity_views.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250604_entity_views.xml
@@ -16,16 +16,9 @@
 
         <!-- create the ENTITY_KEYS view -->
         <createView viewName="ENTITY_KEYS" replaceIfExists="true">
-            SELECT id,
-                   workspace_id, entity_type,
-                   JSON_ARRAYAGG(attrName) as attribute_keys
-            FROM ENTITY AS outer_row
-            JOIN JSON_TABLE(
-                outer_row.attributes,
-                '$.attrs[*]' COLUMNS (attrName JSON PATH '$.a')
-            ) AS jt_outer
-            WHERE attributes is not null
-            GROUP BY id
+            SELECT id, workspace_id, entity_type, JSON_KEYS(attributes, '$.attrs') as attribute_keys
+            FROM ENTITY
+            WHERE deleted = 0 and attributes is not null
         </createView>
 
         <!-- create the ENTITY_REFS view -->
@@ -34,23 +27,22 @@
                    id as from_entity_id,
                    entity_type as from_entity_type,
                    name as from_name,
-                   JSON_UNQUOTE(attrs_array->'$.a') as from_attribute_name,
+                   from_attribute_name,
                    to_entity_type,
-                   to_name
-            FROM ENTITY AS e
+                   to_name,
+                   is_scalar
+            FROM ENTITY
             JOIN JSON_TABLE(
-                e.attributes,
-                '$.attrs[*]' COLUMNS (attrs_array JSON PATH '$')
-            ) AS attrs_tbl
-            JOIN JSON_TABLE(
-                attrs_tbl.attrs_array,
-                '$.r[*]' COLUMNS (
-		            to_entity_type varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$.t',
-		            to_name varchar(254) PATH '$.n'
-	            )
+                attributes,
+                '$.refs[*]' COLUMNS (
+                    from_attribute_name varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$.a',
+					to_entity_type varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$.t',
+		            to_name varchar(254) PATH '$.n',
+                    is_scalar boolean PATH '$.s'
+                 )
             ) AS refs_tbl
             WHERE attributes is not null
-                AND deleted = 0
+              AND deleted = 0
         </createView>
 
     </changeSet>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250604_entity_views.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250604_entity_views.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
+
+    <changeSet logicalFilePath="dummy" author="davidan" id="entity_refs_and_keys_views" runOnChange="true">
+        <!-- drop the triggers that populate ENTITY_KEYS -->
+        <sql stripComments="true" endDelimiter="~">
+        DROP TRIGGER IF EXISTS after_entity_insert ~
+        DROP TRIGGER IF EXISTS after_entity_update ~
+        </sql>
+
+        <!-- drop the physical ENTITY_REFS and ENTITY_KEYS tables -->
+        <dropTable tableName="ENTITY_REFS" />
+        <dropTable tableName="ENTITY_KEYS" />
+
+        <!-- create the ENTITY_KEYS view -->
+        <createView viewName="ENTITY_KEYS" replaceIfExists="true">
+            SELECT id,
+                   workspace_id, entity_type,
+                   JSON_ARRAYAGG(attrName) as attribute_keys
+            FROM ENTITY AS outer_row
+            JOIN JSON_TABLE(
+                outer_row.attributes,
+                '$.attrs[*]' COLUMNS (attrName JSON PATH '$.a')
+            ) AS jt_outer
+            WHERE attributes is not null
+            GROUP BY id
+        </createView>
+
+        <!-- create the ENTITY_REFS view -->
+        <createView viewName="ENTITY_REFS" replaceIfExists="true">
+            SELECT workspace_id,
+                   id as from_entity_id,
+                   entity_type as from_entity_type,
+                   name as from_name,
+                   JSON_UNQUOTE(attrs_array->'$.a') as from_attribute_name,
+                   to_entity_type,
+                   to_name
+            FROM ENTITY AS e
+            JOIN JSON_TABLE(
+                e.attributes,
+                '$.attrs[*]' COLUMNS (attrs_array JSON PATH '$')
+            ) AS attrs_tbl
+            JOIN JSON_TABLE(
+                attrs_tbl.attrs_array,
+                '$.r[*]' COLUMNS (
+		            to_entity_type varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$.t',
+		            to_name varchar(254) PATH '$.n'
+	            )
+            ) AS refs_tbl
+            WHERE attributes is not null
+                AND deleted = 0
+        </createView>
+
+    </changeSet>
+
+
+
+</databaseChangeLog>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -664,9 +664,11 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     //  individually for each value that needs to be changed. Since we control the serialization format of the
     //  refs array, and only perform the string replace inside that array, we avoid any problems with other
     //  user-supplied values.
+    val oldRef = s""""n": "$oldName", "t": "$entityType""""
+    val newRef = s""""n": "$newName", "t": "$entityType""""
     val updateReferencesInAttributesSql = sql"""update ENTITY
             set attributes = JSON_REPLACE(attributes, $slickRefsPath,
-              CAST(REPLACE(JSON_EXTRACT(attributes, $slickRefsPath), '"n": "#$oldName", "t": "#$entityType"', '"n": "#$newName", "t": "#$entityType"') as JSON))
+              CAST(REPLACE(JSON_EXTRACT(attributes, $slickRefsPath), $oldRef, $newRef) as JSON))
             where workspace_id = $workspaceId
             and deleted = 0
             and JSON_CONTAINS(attributes, JSON_OBJECT('n', $oldName, 't', $entityType), $slickRefsPath)""".asUpdate

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -25,6 +25,7 @@ import slick.sql.SqlStreamingAction
 import spray.json._
 
 import scala.concurrent.ExecutionContext
+import scala.util.Try
 
 trait CompactEntityComponent extends LazyLogging {
   this: DriverComponent =>
@@ -616,13 +617,21 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   //      methods in this section are used for building entity query functions
   // ====================================================================================================
 
+  // TODO: reusable function for '$.attrs[*]'
+  // TODO: search inside references too
   private def countEntitiesWithFilter(workspaceId: UUID,
                                       entityType: String,
                                       filter: SQLActionBuilder
   ): ReadWriteAction[Int] =
     concatSqlActions(
-      sql"select count(*) ",
-      fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
+      sql"""select count(*)
+            from ENTITY e,
+            JSON_TABLE(attributes, '$$.attrs[*]' COLUMNS (
+		      attr_name varchar(254) PATH '$$.a',
+              attr_value JSON PATH '$$.v'
+	          )
+	        ) as jt where e.workspace_id = $workspaceId and e.entity_type = $entityType and e.deleted = 0
+         """,
       filter
     ).as[Int].map(_.head)
 
@@ -630,15 +639,25 @@ class CompactEntityQuery(driverComponent: DriverComponent)
                                       entityType: String,
                                       entityQuery: EntityQuery,
                                       filter: SQLActionBuilder
-  ): SqlStreamingAction[Seq[Entity], Entity, Read] =
+  ): SqlStreamingAction[Seq[Entity], Entity, Read] = {
+
+    // sql" from ENTITY e where e.workspace_id = $workspaceId and e.entity_type = $entityType and e.deleted = 0"
+    val fromClause = sql""" from ENTITY e,
+                           JSON_TABLE(attributes, '$$.attrs[*]' COLUMNS (
+                            attr_name varchar(254) PATH '$$.a',
+                            attr_value JSON PATH '$$.v'
+                            )
+                           ) as jt where e.workspace_id = $workspaceId and e.entity_type = $entityType and e.deleted = 0"""
+
     concatSqlActions(
       selectEntityColumns,
       filteredAttributesColumn(entityQuery),
-      fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
+      fromClause,
       filter,
       orderBy(entityQuery),
       paginationClause(entityQuery)
     ).as[Entity]
+  }
 
   private val selectEntityColumns =
     sql"select name, entity_type, "
@@ -690,9 +709,18 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     )
   }
 
+  // TODO: SQL injection
+  // TODO: create a reusable helper function to generate searchCriteria
+  private def columnFilterCondition(columnFilter: EntityColumnFilter) = {
+    val aname = AttributeName.toDelimitedName(columnFilter.attributeName)
+    sql" and attr_name = $aname and CAST(JSON_UNQUOTE(attr_value) as CHAR) = ${columnFilter.term} "
+  }
+
+  /* v1 implementation:
   private def columnFilterCondition(columnFilter: EntityColumnFilter) =
     // CAST, JSON_UNQUOTE and JSON_EXTRACT are used to handle strings and numbers and do a case insensitive comparison
     sql" and CAST(e.attributes ->> ${slickAttributePath(columnFilter.attributeName)} AS CHAR) = ${columnFilter.term}"
+   */
 
   private def orderBy(entityQuery: EntityQuery): SQLActionBuilder =
     concatSqlActions(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -542,6 +542,34 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   }
 
   /**
+    * Rename an entity type, updating both the ENTITY table and embedded references in entity attributes.
+    *
+    * Returns the number of entities that were renamed.
+    *
+    * TODO: `execution plan: `
+    * TODO: also update the sort value in $.attrs for scalar references
+    */
+  def renameEntityType(workspaceId: UUID, oldType: String, newType: String): ReadWriteAction[Int] = {
+    // Update the entity type in the ENTITY table
+    // explain plan: index range scan on idx_entity_type_name
+    val updateEntityTypeSql =
+      sql"""update ENTITY set entity_type = $newType, record_version = record_version + 1
+            where workspace_id = $workspaceId and entity_type = $oldType and deleted = 0"""
+
+    val updateReferencesInAttributesSql = sql"""update ENTITY
+    set attributes = REPLACE(attributes, '"t": "#$oldType"', '"t": "#$newType"')
+    where workspace_id = $workspaceId
+    and deleted = 0
+    and JSON_CONTAINS(attributes, JSON_OBJECT('t', $oldType), '$$.refs')""".asUpdate
+
+    // Execute all updates in same transaction
+    for {
+      paths <- updateReferencesInAttributesSql
+      entityRowsUpdated <- updateEntityTypeSql.asUpdate
+    } yield entityRowsUpdated
+  }
+
+  /**
    * Rename an entity type, updating both the ENTITY table and embedded references in entity attributes.
    *
    * Returns the number of entities that were renamed.
@@ -549,7 +577,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * TODO: `execution plan: `
    * TODO: also update the sort value in $.attrs for scalar references
    */
-  def renameEntityType(workspaceId: UUID, oldType: String, newType: String): ReadWriteAction[Int] = {
+  def renameEntityTypeOLD(workspaceId: UUID, oldType: String, newType: String): ReadWriteAction[Int] = {
     // Update the entity type in the ENTITY table
     // explain plan: index range scan on idx_entity_type_name
     val updateEntityTypeSql =
@@ -572,22 +600,14 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     val attrRefRegex = """'\\$\\.refs[^.]+\\.t'"""
     val getReferencePathsInAttributesSql =
       sql"""
-        with entity_attrs as 
-          (select e.attributes
-          from ENTITY e
-          join ENTITY_REFS er on e.workspace_id = er.workspace_id and e.entity_type = er.from_entity_type and e.name = er.from_name
-          where er.workspace_id = $workspaceId
-          and er.to_entity_type = $oldType)
         select type_path
-        from entity_attrs e,
-        json_table(json_search(e.attributes, 'all', $oldType), '$$[*]' COLUMNS( type_path VARCHAR(100) PATH '$$' ERROR ON ERROR )) jt
-        where type_path REGEXP #$attrRefRegex
-        union
-        select json_unquote(json_search(e.attributes, 'all', $oldType))
-        from entity_attrs e
-        where json_type(json_search(e.attributes, 'all', $oldType)) != 'ARRAY'
-        and json_unquote(json_search(e.attributes, 'all', $oldType)) REGEXP #$attrRefRegex
+        from ENTITY e,
+        json_table(json_search(e.attributes, 'all', $oldType, null, '$$.refs[*].t'), '$$[*]' COLUMNS( type_path VARCHAR(100) PATH '$$' ERROR ON ERROR )) jt
+        where workspace_id = $workspaceId
+        and type_path REGEXP #$attrRefRegex
+        order by type_path desc
         """
+    // descending order is very important here; it optimizes how MySQL processes the JSON_REPLACE calls
 
     // TODO: `execution plan: `
     def updateReferencesInAttributesSql(paths: Seq[String]) = {
@@ -595,11 +615,10 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       concatSqlActions(
         sql"""
           update ENTITY e 
-          join ENTITY_REFS er on e.workspace_id = er.workspace_id and e.entity_type = er.from_entity_type and e.name = er.from_name
-          set e.attributes = JSON_REPLACE(e.attributes, 
+          set e.attributes = JSON_REPLACE(e.attributes,
         """,
         reduceSqlActionsWithDelim(replaceParamsSqls, sql","),
-        sql""") where er.workspace_id = $workspaceId and er.to_entity_type = $oldType"""
+        sql""") where e.workspace_id = $workspaceId and JSON_CONTAINS(e.attributes, $oldType, '$$.refs[*].t')"""
       )
     }
 
@@ -768,7 +787,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   /** look up the types&names of all entities referenced by the given entity */
   @VisibleForTesting
   def getReferencesFrom(workspaceId: UUID, from: EntityPointer): ReadAction[Seq[EntityPointer]] =
-    sql"""select to_entity_type, to_name
+    sql"""select distinct to_entity_type, to_name
          from ENTITY_REFS
          where workspace_id = $workspaceId
          and from_entity_type = ${from.entityType}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -65,7 +65,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     GetResult(r => CompactEntityVersionRecord(r.<<, r.<<, r.<<, r.<<))
 
   implicit val getKeysRecord: GetResult[KeysRecord] =
-    GetResult(r => KeysRecord(r.<<, r.<<, r.<<, r.<<, r.<<))
+    GetResult(r => KeysRecord(r.<<, r.<<, r.<<, r.<<))
 
   implicit val getEntityTypeAndAttributeKey: GetResult[EntityTypeAndAttributeKey] =
     GetResult(r => EntityTypeAndAttributeKey(r.<<, AttributeName.fromDelimitedName(r.<<)))
@@ -260,58 +260,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     countExisting(workspaceId, refs).map(count => count == refs.size)
 
   /**
-   * Delete all rows in ENTITY_REFS for the specified entities
-   *
-   * Returns the number of rows deleted
-   *
-   * `execution plan: Uses unq_from_to index. Extra: Using where`
-   */
-  def deleteAllReferencesFrom(workspaceId: UUID, fromRefs: Set[EntityPointer]): ReadWriteAction[Int] = {
-    val typeNameClauses = generateTypeNameSql(fromRefs, typeColumn = "from_entity_type", nameColumn = "from_name")
-
-    val baseSql =
-      sql"""delete from ENTITY_REFS
-        where workspace_id = $workspaceId
-        and ("""
-
-    concatSqlActions(baseSql, reduceSqlActionsWithDelim(typeNameClauses.toSeq, sql" or "), sql")").asUpdate
-  }
-
-  /**
-   * Delete all rows in ENTITY_REFS for all entities of the given type
-   *
-   * Returns the number of rows deleted
-   *
-   * `execution plan: Uses unq_from_to index. Extra: Using where`
-   */
-  def deleteAllReferencesFromType(workspaceId: UUID, fromType: String): ReadWriteAction[Int] =
-    sql"""delete from ENTITY_REFS where workspace_id = $workspaceId and from_entity_type = $fromType""".asUpdate
-
-  /**
-    * Insert references into ENTITY_REFS.
-    *
-    * Returns the number of rows upserted.
-    *
-    * `execution plan: multi-row insert`
-    */
-  def insertReferences(workspaceId: UUID, references: Set[RefMapping]): ReadWriteAction[Int] =
-    // short-circuit
-    if (references.isEmpty) {
-      DBIO.successful(0)
-    } else {
-      val baseSql =
-        sql"""insert into ENTITY_REFS(workspace_id, from_entity_type, from_name, to_entity_type, to_name) values """
-
-      val valuesSql = references.flatMap { refPointers =>
-        refPointers.to.map { toEntity =>
-          sql"($workspaceId, ${refPointers.from.entityType}, ${refPointers.from.entityName}, ${toEntity.entityType}, ${toEntity.entityName})"
-        }
-      }
-
-      concatSqlActions(baseSql, reduceSqlActionsWithDelim(valuesSql.toSeq)).asUpdate
-    }
-
-  /**
    * Get all entity attribute keys for a workspace.
    *
    * `execution plan: Index range scan; using where. Index: idx_entity_keys_workspace_and_entity_type.`
@@ -329,8 +277,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   def countEntitiesGroupedByType(workspaceId: UUID): ReadAction[Seq[EntityTypeAndCount]] =
     // ENTITY_KEYS should be smaller than ENTITY and already excludes deleted entities
     sql"""SELECT entity_type, COUNT(*)
-      FROM ENTITY_KEYS
-      WHERE workspace_id = $workspaceId
+      #$fromEntityWhereNotDeleted
+      AND workspace_id = $workspaceId
       GROUP BY entity_type;""".as[EntityTypeAndCount]
 
   /**
@@ -780,7 +728,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   // `execution plan: single row constant; fully indexed by primary key`
   @VisibleForTesting
   protected[slick] def getKeys(entityId: Long): ReadAction[Option[KeysRecord]] = {
-    val query = sql"""select id, workspace_id, entity_type, attribute_keys, last_updated
+    val query = sql"""select id, workspace_id, entity_type, attribute_keys
             from ENTITY_KEYS
             where id = $entityId;""".as[KeysRecord]
     uniqueResult(query)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -491,22 +491,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     // The best approach would be to add a custom MySQL function for JSON path replacement
     // For now, we'll do this in application code when accessing entities
 
-    // Update from_entity_type in ENTITY_REFS table
-    // explain plan: index range scan on unq_from_to
-    val updateFromReferencesSql =
-      sql"""update ENTITY_REFS
-            set from_entity_type = $newType
-            where workspace_id = $workspaceId
-            and from_entity_type = $oldType"""
-
-    // Update to_entity_type in ENTITY_REFS table
-    // explain plan: index range scan on unq_from_to
-    val updateToReferencesSql =
-      sql"""update ENTITY_REFS
-            set to_entity_type = $newType
-            where workspace_id = $workspaceId
-            and to_entity_type = $oldType"""
-
     // Get all paths in attributes that reference the old type
     // This is a bit tricky because the attributes column is JSON and we need to search for the old type
     // in all possible paths. We use JSON_SEARCH to find the paths and JSON_TABLE to extract them.
@@ -515,7 +499,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     // Uses ENTITY_REFS table to find the attributes that reference the old type so must be run before
     // the ENTITY_REFS table is updated.
     // explain plan: non-unique index scan on idx_entity_type_name and idx_to
-    val attrRefRegex = """'\\$\\.attrs\\.[^.]+\\.entityType'"""
+    val attrRefRegex = """'\\$\\.refs[^.]+\\.t'"""
     val getReferencePathsInAttributesSql =
       sql"""
         with entity_attrs as 
@@ -544,7 +528,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           join ENTITY_REFS er on e.workspace_id = er.workspace_id and e.entity_type = er.from_entity_type and e.name = er.from_name
           set e.attributes = JSON_REPLACE(e.attributes, 
         """,
-        reduceSqlActionsWithDelim(replaceParamsSqls.toSeq, sql","),
+        reduceSqlActionsWithDelim(replaceParamsSqls, sql","),
         sql""") where er.workspace_id = $workspaceId and er.to_entity_type = $oldType"""
       )
     }
@@ -556,12 +540,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         if (paths.isEmpty) {
           DBIO.successful(0)
         } else {
-          DBIO.seq(
-            updateReferencesInAttributesSql(paths).asUpdate,
-            updateToReferencesSql.asUpdate
-          )
+          updateReferencesInAttributesSql(paths).asUpdate
         }
-      _ <- updateFromReferencesSql.asUpdate
       entityRowsUpdated <- updateEntityTypeSql.asUpdate
     } yield entityRowsUpdated
   }
@@ -652,6 +632,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * Example sql produced:
    * JSON_OBJECT(
    *   'v', e.attributes -> '$.v',
+   *   'refs', e.attributes -> '$.refs',
    *   'attrs', JSON_OBJECT(
    *     ?, e.attributes -> ?,
    *     ?, e.attributes -> ?
@@ -666,6 +647,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         concatSqlActions(
           sql"""JSON_OBJECT(
                '#${CompactEntitySerialization.VERSION_KEY}', e.attributes -> '$$.#${CompactEntitySerialization.VERSION_KEY}',
+               '#${CompactEntitySerialization.REFS_KEY}', e.attributes -> '$$.#${CompactEntitySerialization.REFS_KEY}',
                '#${CompactEntitySerialization.ATTRS_KEY}', JSON_OBJECT(""",
           reduceSqlActionsWithDelim(fieldSqls.toSeq, sql","),
           sql"))"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -265,22 +265,22 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   /**
    * Get all entity attribute keys for a workspace.
    *
-   * TODO: `execution plan: `
+   * `execution plan: Index range scan; using where. Index: idx_entity_keys_workspace_and_entity_type.`
    */
   def listEntityKeys(workspaceId: UUID): ReadAction[Seq[EntityTypeAndAttributeKey]] =
     sql"""SELECT distinct entity_type, attribute_key
-      FROM ENTITY_KEYS , JSON_TABLE(CAST(attribute_keys as JSON), '$$[*]' COLUMNS(attribute_key VARCHAR(256) PATH '$$')) t
+      FROM ENTITY_KEYS , JSON_TABLE(attribute_keys, '$$[*]' COLUMNS(attribute_key VARCHAR(256) PATH '$$')) t
       where workspace_id=$workspaceId;""".as[EntityTypeAndAttributeKey]
 
   /**
    * Gets the count of entities in a workspace, grouped by entity type.
    *
-    * TODO: `execution plan: `
+   * `execution plan: Index range scan; using where. Index: idx_entity_keys_workspace_and_entity_type.`
    */
   def countEntitiesGroupedByType(workspaceId: UUID): ReadAction[Seq[EntityTypeAndCount]] =
     sql"""SELECT entity_type, COUNT(*)
-      #$fromEntityWhereNotDeleted
-      AND workspace_id = $workspaceId
+      FROM ENTITY_KEYS
+      WHERE workspace_id = $workspaceId
       GROUP BY entity_type;""".as[EntityTypeAndCount]
 
   /**
@@ -620,7 +620,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   /**
     * Determine if an attribute exists in any entity of the given type and workspace.
     *
-    * TODO: `execution plan: `
+    * `Using index condition; Using where. Index used: idx_entity_keys_workspace_and_entity_type`
     */
   def attributeExists(workspaceId: UUID, entityType: String, attributeName: AttributeName): ReadAction[Boolean] =
     sql"""select exists (select 1 from ENTITY_KEYS
@@ -746,10 +746,10 @@ class CompactEntityQuery(driverComponent: DriverComponent)
          and from_name = ${from.entityName}""".as[EntityPointer]
 
   // return the ENTITY_KEYS row for a given entity
-  // TODO: `execution plan: `
+  // `execution plan: single row constant; fully indexed by primary key`
   @VisibleForTesting
   protected[slick] def getKeys(entityId: Long): ReadAction[Option[KeysRecord]] = {
-    val query = sql"""select id, workspace_id, entity_type, attribute_keys
+    val query = sql"""select id, workspace_id, entity_type, attribute_keys, last_updated
             from ENTITY_KEYS
             where id = $entityId;""".as[KeysRecord]
     uniqueResult(query)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -263,20 +263,19 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   /**
    * Get all entity attribute keys for a workspace.
    *
-   * `execution plan: Index range scan; using where. Index: idx_entity_keys_workspace_and_entity_type.`
+   * TODO: `execution plan: `
    */
   def listEntityKeys(workspaceId: UUID): ReadAction[Seq[EntityTypeAndAttributeKey]] =
     sql"""SELECT distinct entity_type, attribute_key
-      FROM ENTITY_KEYS , JSON_TABLE(attribute_keys, '$$[*]' COLUMNS(attribute_key VARCHAR(256) PATH '$$')) t
+      FROM ENTITY_KEYS , JSON_TABLE(CAST(attribute_keys as JSON), '$$[*]' COLUMNS(attribute_key VARCHAR(256) PATH '$$')) t
       where workspace_id=$workspaceId;""".as[EntityTypeAndAttributeKey]
 
   /**
    * Gets the count of entities in a workspace, grouped by entity type.
    *
-   * `execution plan: Index range scan; using where. Index: idx_entity_keys_workspace_and_entity_type.`
+    * TODO: `execution plan: `
    */
   def countEntitiesGroupedByType(workspaceId: UUID): ReadAction[Seq[EntityTypeAndCount]] =
-    // ENTITY_KEYS should be smaller than ENTITY and already excludes deleted entities
     sql"""SELECT entity_type, COUNT(*)
       #$fromEntityWhereNotDeleted
       AND workspace_id = $workspaceId
@@ -284,7 +283,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
   /**
    * Soft-deletes the given entities: removes their attributes and sets deleted=1 and deletedDate=now
-   * Does not remove rows from ENTITY_REFS table
    *
    * `execution plan: Index range scan; using where, using temporary. Index: idx_entity_type_name.`
    */
@@ -307,7 +305,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
   /**
    * Soft-deletes all entities of the given type: removes their attributes and sets deleted=1 and deletedDate=now
-   * Does not remove rows from ENTITY_REFS table
    *
    * `execution plan: Index range scan; using where, using temporary. Index: idx_entity_type_name.`
    */
@@ -381,7 +378,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
   // Gets any entities that have references to the entities in the given list
   // Excludes entities that are in the list
-  // `execution plan: uses idx_to index. Extra: Using where; Using index` (I think this may also use unq_from_to in some cases)
+  // TODO: `execution plan: `
   def getReferencesTo(workspaceId: UUID, refs: Seq[EntityPointer]): ReadAction[Seq[EntityPointer]] = {
     val toNameClause = reduceSqlActionsWithDelim(
       generateTypeNameSql(refs.toSet, typeColumn = "to_entity_type", nameColumn = "to_name").toSeq,
@@ -404,7 +401,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
   // Gets entities that have references to any entities of the given type
   // Excludes entities with the same type
-  // `execution plan: Uses unq_from_to index. Extra: Using where`
+  // TODO: `execution plan: `
   def getReferencesToType(workspaceId: UUID, entityType: String): ReadAction[Seq[EntityPointer]] =
     sql"""select from_entity_type, from_name
          from ENTITY_REFS
@@ -476,11 +473,11 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     queryEntitiesWithFilter(workspaceId, entityType, entityQuery, sql"")
 
   /**
-   * Rename an entity type, updating both the ENTITY table and entity references in ENTITY_REFS.
+   * Rename an entity type, updating both the ENTITY table and embedded references in entity attributes.
    *
    * Returns the number of entities that were renamed.
    *
-   * `execution plan: multiple statements that update both ENTITY and ENTITY_REFS tables`
+   * TODO: `execution plan: `
    */
   def renameEntityType(workspaceId: UUID, oldType: String, newType: String): ReadWriteAction[Int] = {
     // Update the entity type in the ENTITY table
@@ -538,7 +535,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         and json_unquote(json_search(e.attributes, 'all', $oldType)) REGEXP #$attrRefRegex
         """
 
-    // explain plan: non-unique index scan on idx_entity_type_name and idx_to
+    // TODO: `execution plan: `
     def updateReferencesInAttributesSql(paths: Seq[String]) = {
       val replaceParamsSqls = paths.map(path => sql"$path, $newType")
       concatSqlActions(
@@ -602,7 +599,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   /**
     * Determine if an attribute exists in any entity of the given type and workspace.
     *
-    * `Using index condition; Using where. Index used: idx_entity_keys_workspace_and_entity_type`
+    * TODO: `execution plan: `
     */
   def attributeExists(workspaceId: UUID, entityType: String, attributeName: AttributeName): ReadAction[Boolean] =
     sql"""select exists (select 1 from ENTITY_KEYS
@@ -682,7 +679,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   private def filterTermsCondition(filterTerms: Seq[String], operator: FilterOperator) = {
     // note the lower casing for case insensitive search
     val filterClauses = filterTerms.map { filterTerm =>
-      sql"""JSON_SEARCH(lower(e.attributes -> '#${CompactEntitySerialization.slickQueryPath}'), 'one', ${'%' + filterTerm.toLowerCase + '%'})"""
+      sql"""JSON_SEARCH(lower(e.attributes -> '#${CompactEntitySerialization.slickAttrsPath}'), 'one', ${'%' + filterTerm.toLowerCase + '%'})"""
     }
     concatSqlActions(
       sql" and (",
@@ -693,7 +690,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
   private def columnFilterCondition(columnFilter: EntityColumnFilter) =
     // CAST, JSON_UNQUOTE and JSON_EXTRACT are used to handle strings and numbers and do a case insensitive comparison
-    sql" and CAST(e.attributes ->> ${slickQueryPath(columnFilter.attributeName)} AS CHAR) = ${columnFilter.term}"
+    sql" and CAST(e.attributes ->> ${slickAttributePath(columnFilter.attributeName)} AS CHAR) = ${columnFilter.term}"
 
   private def orderBy(entityQuery: EntityQuery): SQLActionBuilder =
     concatSqlActions(
@@ -704,7 +701,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           // the order of the columns here is also the sort precedence, list length first, then scalar value
           // Sorting on a list column should sort by the list size and sorting on a scalar column sorts on the column value.
           // If the column is a mixed type then all scalars will group together sorted by value then all the lists will follow sorted by size.
-          sql" e.attributes -> ${slickQueryPath(attr)}"
+          sql" e.attributes -> ${slickAttributePath(attr)}"
       },
       sql" #${SortDirections.toSql(entityQuery.sortDirection)}"
     )
@@ -726,7 +723,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
          and from_name = ${from.entityName}""".as[EntityPointer]
 
   // return the ENTITY_KEYS row for a given entity
-  // `execution plan: single row constant; fully indexed by primary key`
+  // TODO: `execution plan: `
   @VisibleForTesting
   protected[slick] def getKeys(entityId: Long): ReadAction[Option[KeysRecord]] = {
     val query = sql"""select id, workspace_id, entity_type, attribute_keys

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -478,6 +478,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    *
    * Returns the number of entities that were renamed.
    *
+   * TODO: use the simplified SQL from `renameEntityType`, using string-replace
+   *
    * TODO: `execution plan: `
    */
   def renameEntity(workspaceId: UUID, entityType: String, oldName: String, newName: String): ReadWriteAction[Int] = {
@@ -556,81 +558,27 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       sql"""update ENTITY set entity_type = $newType, record_version = record_version + 1
             where workspace_id = $workspaceId and entity_type = $oldType and deleted = 0"""
 
+    // Update all embedded references in the $.refs array.
+    // This is done via JSON_REPLACE(CAST(REPLACE(JSON_EXTRACT))). Explaining from the inside out:
+    //   - JSON_EXTRACT(attributes, '$$.refs') gets the refs array
+    //   - REPLACE(...) treats the refs array as a plain string, and replaces all occurrences of
+    //      the old type with the new type
+    //   - CAST(... as JSON) converts the modified string back to a JSON array
+    //   - JSON_REPLACE(...) replaces the original refs array with the modified one
+    // We use a string replace here because it is significantly more performant than calling JSON_REPLACE
+    //  individually for each value that needs to be changed. Since we control the serialization format of the
+    //  refs array, and only perform the string replace inside that array, we avoid any problems with other
+    //  user-supplied values.
     val updateReferencesInAttributesSql = sql"""update ENTITY
-    set attributes = REPLACE(attributes, '"t": "#$oldType"', '"t": "#$newType"')
-    where workspace_id = $workspaceId
-    and deleted = 0
-    and JSON_CONTAINS(attributes, JSON_OBJECT('t', $oldType), '$$.refs')""".asUpdate
+            set attributes = JSON_REPLACE(attributes, '$$.refs',
+              CAST(REPLACE(JSON_EXTRACT(attributes, '$$.refs'), '"t": "#$oldType"', '"t": "#$newType"') as JSON))
+            where workspace_id = $workspaceId
+            and deleted = 0
+            and JSON_CONTAINS(attributes, JSON_OBJECT('t', $oldType), '$$.refs')""".asUpdate
 
     // Execute all updates in same transaction
     for {
-      paths <- updateReferencesInAttributesSql
-      entityRowsUpdated <- updateEntityTypeSql.asUpdate
-    } yield entityRowsUpdated
-  }
-
-  /**
-   * Rename an entity type, updating both the ENTITY table and embedded references in entity attributes.
-   *
-   * Returns the number of entities that were renamed.
-   *
-   * TODO: `execution plan: `
-   * TODO: also update the sort value in $.attrs for scalar references
-   */
-  def renameEntityTypeOLD(workspaceId: UUID, oldType: String, newType: String): ReadWriteAction[Int] = {
-    // Update the entity type in the ENTITY table
-    // explain plan: index range scan on idx_entity_type_name
-    val updateEntityTypeSql =
-      sql"""update ENTITY set entity_type = $newType, record_version = record_version + 1
-            where workspace_id = $workspaceId and entity_type = $oldType and deleted = 0"""
-
-    // Update entity references in the attributes JSON column
-    // This requires a custom function that can do complex JSON updates which MySQL doesn't provide natively
-    // The best approach would be to add a custom MySQL function for JSON path replacement
-    // For now, we'll do this in application code when accessing entities
-
-    // Get all paths in attributes that reference the old type
-    // This is a bit tricky because the attributes column is JSON and we need to search for the old type
-    // in all possible paths. We use JSON_SEARCH to find the paths and JSON_TABLE to extract them.
-    // We also need to handle the case where the reference is singular or not in an array.
-    // Also exclude values in the json that match the old type but are not entity references.
-    // Uses ENTITY_REFS table to find the attributes that reference the old type so must be run before
-    // the ENTITY_REFS table is updated.
-    // explain plan: non-unique index scan on idx_entity_type_name and idx_to
-    val attrRefRegex = """'\\$\\.refs[^.]+\\.t'"""
-    val getReferencePathsInAttributesSql =
-      sql"""
-        select type_path
-        from ENTITY e,
-        json_table(json_search(e.attributes, 'all', $oldType, null, '$$.refs[*].t'), '$$[*]' COLUMNS( type_path VARCHAR(100) PATH '$$' ERROR ON ERROR )) jt
-        where workspace_id = $workspaceId
-        and type_path REGEXP #$attrRefRegex
-        order by type_path desc
-        """
-    // descending order is very important here; it optimizes how MySQL processes the JSON_REPLACE calls
-
-    // TODO: `execution plan: `
-    def updateReferencesInAttributesSql(paths: Seq[String]) = {
-      val replaceParamsSqls = paths.map(path => sql"$path, $newType")
-      concatSqlActions(
-        sql"""
-          update ENTITY e 
-          set e.attributes = JSON_REPLACE(e.attributes,
-        """,
-        reduceSqlActionsWithDelim(replaceParamsSqls, sql","),
-        sql""") where e.workspace_id = $workspaceId and JSON_CONTAINS(e.attributes, $oldType, '$$.refs[*].t')"""
-      )
-    }
-
-    // Execute all updates in same transaction
-    for {
-      paths <- getReferencePathsInAttributesSql.as[String]
-      _ <-
-        if (paths.isEmpty) {
-          DBIO.successful(0)
-        } else {
-          updateReferencesInAttributesSql(paths).asUpdate
-        }
+      _ <- updateReferencesInAttributesSql
       entityRowsUpdated <- updateEntityTypeSql.asUpdate
     } yield entityRowsUpdated
   }
@@ -638,6 +586,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   /**
     * Renames a single attribute across all entities of the given type and workspace.
     * This method assumes the old and new attribute names have already been validated!
+    *
+    * TODO: also update in $.refs
     *
     * `Using where. Index used: idx_entity_type_name`
     */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -68,7 +68,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     GetResult(r => CompactEntityVersionRecord(r.<<, r.<<, r.<<, r.<<))
 
   implicit val getKeysRecord: GetResult[KeysRecord] =
-    GetResult(r => KeysRecord(r.<<, r.<<, r.<<, r.<<))
+    GetResult(r => KeysRecord(r.<<, r.<<, r.<<, r.<<, r.<<))
 
   implicit val getEntityTypeAndAttributeKey: GetResult[EntityTypeAndAttributeKey] =
     GetResult(r => EntityTypeAndAttributeKey(r.<<, AttributeName.fromDelimitedName(r.<<)))
@@ -278,6 +278,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * `execution plan: Index range scan; using where. Index: idx_entity_keys_workspace_and_entity_type.`
    */
   def countEntitiesGroupedByType(workspaceId: UUID): ReadAction[Seq[EntityTypeAndCount]] =
+    // ENTITY_KEYS should be smaller than ENTITY and already excludes deleted entities
     sql"""SELECT entity_type, COUNT(*)
       FROM ENTITY_KEYS
       WHERE workspace_id = $workspaceId
@@ -487,11 +488,14 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     // validation ensures that oldName and newName are SQL-safe
     EntityUtils.validateEntityName(oldName)
     EntityUtils.validateEntityName(newName)
+    EntityUtils.validateEntityType(entityType)
     // Update the entity name in the ENTITY table
     // explain plan: index range scan on idx_entity_type_name
-    val updateEntityNameSql =
-      sql"""update ENTITY set name = $newName, record_version = record_version + 1
-            where workspace_id = $workspaceId and name = $oldName and deleted = 0"""
+    val updateEntityNameSql = sql"""update ENTITY set name = $newName, record_version = record_version + 1
+          where workspace_id = $workspaceId
+          and entity_type = $entityType
+          and name = $oldName
+          and deleted = 0"""
 
     // Update all embedded references in the $.refs array.
     // This is done via JSON_REPLACE(CAST(REPLACE(JSON_EXTRACT))). Explaining from the inside out:
@@ -505,11 +509,11 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     //  refs array, and only perform the string replace inside that array, we avoid any problems with other
     //  user-supplied values.
     val updateReferencesInAttributesSql = sql"""update ENTITY
-            set attributes = JSON_REPLACE(attributes, '$$.refs',
-              CAST(REPLACE(JSON_EXTRACT(attributes, '$$.refs'), '"n": "#$oldName"', '"n": "#$newName"') as JSON))
+            set attributes = JSON_REPLACE(attributes, $slickRefsPath,
+              CAST(REPLACE(JSON_EXTRACT(attributes, $slickRefsPath), '"n": "#$oldName"', "t": "#$entityType"'', '"n": "#$newName", "t": "#$entityType"') as JSON))
             where workspace_id = $workspaceId
             and deleted = 0
-            and JSON_CONTAINS(attributes, JSON_OBJECT('n', $oldName), '$$.refs')""".asUpdate
+            and JSON_CONTAINS(attributes, JSON_OBJECT('n', $oldName, 't', $entityType), $slickRefsPath)""".asUpdate
 
     // Update sortable values in the $.attrs object.
     //  1. search $.refs to find all reference whose target name is equal to $oldName
@@ -526,9 +530,10 @@ class CompactEntityQuery(driverComponent: DriverComponent)
             attrnames as (
               select paths.id,
                 JSON_EXTRACT(attributes, CONCAT(paths.path, '.a')) as attr,
-                JSON_EXTRACT(attributes, CONCAT(paths.path, '.s')) as is_scalar
+                JSON_EXTRACT(attributes, CONCAT(paths.path, '.s')) as is_scalar,
+                JSON_EXTRACT(attributes, CONCAT(paths.path, '.t')) as entity_type
               from ENTITY e join paths on e.id = paths.id
-              having is_scalar = true
+              having is_scalar = true and entity_type = $entityType
             )
           update ENTITY e
           join attrnames on e.id = attrnames.id
@@ -572,11 +577,11 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     //  refs array, and only perform the string replace inside that array, we avoid any problems with other
     //  user-supplied values.
     val updateReferencesInAttributesSql = sql"""update ENTITY
-            set attributes = JSON_REPLACE(attributes, '$$.refs',
-              CAST(REPLACE(JSON_EXTRACT(attributes, '$$.refs'), '"t": "#$oldType"', '"t": "#$newType"') as JSON))
+            set attributes = JSON_REPLACE(attributes, $slickRefsPath,
+              CAST(REPLACE(JSON_EXTRACT(attributes, $slickRefsPath), '"t": "#$oldType"', '"t": "#$newType"') as JSON))
             where workspace_id = $workspaceId
             and deleted = 0
-            and JSON_CONTAINS(attributes, JSON_OBJECT('t', $oldType), '$$.refs')""".asUpdate
+            and JSON_CONTAINS(attributes, JSON_OBJECT('t', $oldType), $slickRefsPath)""".asUpdate
 
     // Execute all updates in same transaction
     for {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.entities.EntityUtils
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
 
 import java.sql.Timestamp
@@ -478,67 +479,41 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    *
    * Returns the number of entities that were renamed.
    *
-   * TODO: use the simplified SQL from `renameEntityType`, using string-replace
+   * TODO: also update the sortable value in the '$.attrs' object for any scalar references to the entity being renamed
    *
    * TODO: `execution plan: `
    */
   def renameEntity(workspaceId: UUID, entityType: String, oldName: String, newName: String): ReadWriteAction[Int] = {
+    // validation ensures that oldName and newName are SQL-safe
+    EntityUtils.validateEntityName(oldName)
+    EntityUtils.validateEntityName(newName)
     // Update the entity name in the ENTITY table
     // explain plan: index range scan on idx_entity_type_name
-    val updateEntityNameSql = sql"""update ENTITY set name = $newName, record_version = record_version + 1
-          where workspace_id = $workspaceId
-          and entity_type = $entityType
-          and name = $oldName
-          and deleted = 0"""
+    val updateEntityNameSql =
+      sql"""update ENTITY set name = $newName, record_version = record_version + 1
+            where workspace_id = $workspaceId and name = $oldName and deleted = 0"""
 
-    // Get all paths in attributes that reference the old name
-    // explain plan: non-unique index scan on idx_entity_type_name and idx_to
-    val attrRefRegex =
-      s"'\\\\$$\\.${CompactEntitySerialization.REFS_KEY}[^.]+\\.t'"
+    // Update all embedded references in the $.refs array.
+    // This is done via JSON_REPLACE(CAST(REPLACE(JSON_EXTRACT))). Explaining from the inside out:
+    //   - JSON_EXTRACT(attributes, '$$.refs') gets the refs array
+    //   - REPLACE(...) treats the refs array as a plain string, and replaces all occurrences of
+    //      the old name with the new name
+    //   - CAST(... as JSON) converts the modified string back to a JSON array
+    //   - JSON_REPLACE(...) replaces the original refs array with the modified one
+    // We use a string replace here because it is significantly more performant than calling JSON_REPLACE
+    //  individually for each value that needs to be changed. Since we control the serialization format of the
+    //  refs array, and only perform the string replace inside that array, we avoid any problems with other
+    //  user-supplied values.
+    val updateReferencesInAttributesSql = sql"""update ENTITY
+            set attributes = JSON_REPLACE(attributes, '$$.refs',
+              CAST(REPLACE(JSON_EXTRACT(attributes, '$$.refs'), '"n": "#$oldName"', '"n": "#$newName"') as JSON))
+            where workspace_id = $workspaceId
+            and deleted = 0
+            and JSON_CONTAINS(attributes, JSON_OBJECT('n', $oldName), '$$.refs')""".asUpdate
 
-    val getReferencePathsInAttributesSql =
-      sql"""
-    with entity_attrs as
-      (select e.attributes
-      from ENTITY e
-      join ENTITY_REFS er on e.workspace_id = er.workspace_id and e.entity_type = er.from_entity_type and e.name = er.from_name
-      where er.workspace_id = $workspaceId
-      and er.to_name = $oldName)
-    select name_path
-    from entity_attrs e,
-    json_table(json_search(e.attributes, 'all', $oldName), '$$[*]' COLUMNS( name_path VARCHAR(100) PATH '$$' ERROR ON ERROR )) jt
-    where name_path REGEXP #$attrRefRegex
-    union
-    select json_unquote(json_search(e.attributes, 'all', $oldName))
-    from entity_attrs e
-    where json_type(json_search(e.attributes, 'all', $oldName)) != 'ARRAY'
-    and json_unquote(json_search(e.attributes, 'all', $oldName)) REGEXP #$attrRefRegex
-    """
-
-    // Update attributes with references to the old name
-    // explain plan: non-unique index scan on idx_entity_type_name and idx_to
-    def updateReferencesInAttributesSql(paths: Seq[String]) = {
-      val replaceParamsSqls = paths.map(path => sql"$path, $newName")
-      concatSqlActions(
-        sql"""
-      update ENTITY e
-      join ENTITY_REFS er on e.workspace_id = er.workspace_id and e.entity_type = er.from_entity_type and e.name = er.from_name
-      set e.attributes = JSON_REPLACE(e.attributes,
-    """,
-        reduceSqlActionsWithDelim(replaceParamsSqls.toSeq, sql","),
-        sql""") where er.workspace_id = $workspaceId and er.to_name = $oldName"""
-      )
-    }
-
-    // Execute all updates
+    // Execute all updates in same transaction
     for {
-      paths <- getReferencePathsInAttributesSql.as[String]
-      _ <-
-        if (paths.isEmpty) {
-          DBIO.successful(0)
-        } else {
-          updateReferencesInAttributesSql(paths).asUpdate
-        }
+      _ <- updateReferencesInAttributesSql
       entityRowsUpdated <- updateEntityNameSql.asUpdate
     } yield entityRowsUpdated
   }
@@ -549,9 +524,11 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     * Returns the number of entities that were renamed.
     *
     * TODO: `execution plan: `
-    * TODO: also update the sort value in $.attrs for scalar references
     */
   def renameEntityType(workspaceId: UUID, oldType: String, newType: String): ReadWriteAction[Int] = {
+    // validation ensures that oldType and newType are SQL-safe
+    EntityUtils.validateEntityType(oldType)
+    EntityUtils.validateEntityType(newType)
     // Update the entity type in the ENTITY table
     // explain plan: index range scan on idx_entity_type_name
     val updateEntityTypeSql =
@@ -722,7 +699,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           // the order of the columns here is also the sort precedence, list length first, then scalar value
           // Sorting on a list column should sort by the list size and sorting on a scalar column sorts on the column value.
           // If the column is a mixed type then all scalars will group together sorted by value then all the lists will follow sorted by size.
-          sql" e.attributes -> ${slickAttributePath(attr)}"
+          sql" JSON_LENGTH(e.attributes -> ${slickAttributePath(attr)}), e.attributes -> ${slickAttributePath(attr)}"
       },
       sql" #${SortDirections.toSql(entityQuery.sortDirection)}"
     )
@@ -737,7 +714,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   /** look up the types&names of all entities referenced by the given entity */
   @VisibleForTesting
   def getReferencesFrom(workspaceId: UUID, from: EntityPointer): ReadAction[Seq[EntityPointer]] =
-    sql"""select distinct to_entity_type, to_name
+    sql"""select to_entity_type, to_name
          from ENTITY_REFS
          where workspace_id = $workspaceId
          and from_entity_type = ${from.entityType}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -478,7 +478,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    *
    * Returns the number of entities that were renamed.
    *
-   * `execution plan: index range scan on idx_entity_type_name`
+   * TODO: `execution plan: `
    */
   def renameEntity(workspaceId: UUID, entityType: String, oldName: String, newName: String): ReadWriteAction[Int] = {
     // Update the entity name in the ENTITY table
@@ -489,28 +489,10 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           and name = $oldName
           and deleted = 0"""
 
-    // Update the entity from_name in the ENTITY_REFS table
-    // explain plan: index range scan on unq_from_to
-    val updateFromNameSql =
-      sql"""update ENTITY_REFS
-            set from_name = $newName
-            where workspace_id = $workspaceId
-            and from_entity_type = $entityType
-            and from_name = $oldName"""
-
-    // Update the entity to_name in the ENTITY_REFS table
-    // explain plan: index range scan on unq_from_to
-    val updateToNameSql =
-      sql"""update ENTITY_REFS
-            set to_name = $newName
-            where workspace_id = $workspaceId
-            and to_entity_type = $entityType
-            and to_name = $oldName"""
-
     // Get all paths in attributes that reference the old name
     // explain plan: non-unique index scan on idx_entity_type_name and idx_to
     val attrRefRegex =
-      s"'\\\\$$\\.${CompactEntitySerialization.ATTRS_KEY}\\.[^.]+\\.${AttributeFormat.ENTITY_NAME_KEY}'"
+      s"'\\\\$$\\.${CompactEntitySerialization.REFS_KEY}[^.]+\\.t'"
 
     val getReferencePathsInAttributesSql =
       sql"""
@@ -553,12 +535,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         if (paths.isEmpty) {
           DBIO.successful(0)
         } else {
-          DBIO.seq(
-            updateReferencesInAttributesSql(paths).asUpdate,
-            updateToNameSql.asUpdate
-          )
+          updateReferencesInAttributesSql(paths).asUpdate
         }
-      _ <- updateFromNameSql.asUpdate
       entityRowsUpdated <- updateEntityNameSql.asUpdate
     } yield entityRowsUpdated
   }
@@ -569,6 +547,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * Returns the number of entities that were renamed.
    *
    * TODO: `execution plan: `
+   * TODO: also update the sort value in $.attrs for scalar references
    */
   def renameEntityType(workspaceId: UUID, oldType: String, newType: String): ReadWriteAction[Int] = {
     // Update the entity type in the ENTITY table

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -379,7 +379,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
   // Gets any entities that have references to the entities in the given list
   // Excludes entities that are in the list
-  // TODO: `execution plan: `
+  // TODO CORE-541: `execution plan: `
   def getReferencesTo(workspaceId: UUID, refs: Seq[EntityPointer]): ReadAction[Seq[EntityPointer]] = {
     val toNameClause = reduceSqlActionsWithDelim(
       generateTypeNameSql(refs.toSet, typeColumn = "to_entity_type", nameColumn = "to_name").toSeq,
@@ -402,7 +402,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
   // Gets entities that have references to any entities of the given type
   // Excludes entities with the same type
-  // TODO: `execution plan: `
+  // TODO CORE-541: `execution plan: `
   def getReferencesToType(workspaceId: UUID, entityType: String): ReadAction[Seq[EntityPointer]] =
     sql"""select from_entity_type, from_name
          from ENTITY_REFS
@@ -478,9 +478,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    *
    * Returns the number of entities that were renamed.
    *
-   * TODO: also update the sortable value in the '$.attrs' object for any scalar references to the entity being renamed
-   *
-   * TODO: `execution plan: `
+   * TODO CORE-541: `execution plan: `
    */
   def renameEntity(workspaceId: UUID, entityType: String, oldName: String, newName: String): ReadWriteAction[Int] = {
     // validation ensures that entityType, oldName, and newName are SQL-safe
@@ -551,7 +549,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     *
     * Returns the number of entities that were renamed.
     *
-    * TODO: `execution plan: `
+    * TODO CORE-541: `execution plan: `
     */
   def renameEntityType(workspaceId: UUID, oldType: String, newType: String): ReadWriteAction[Int] = {
     // validation ensures that oldType and newType are SQL-safe
@@ -592,7 +590,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     * Renames a single attribute across all entities of the given type and workspace.
     * This method assumes the old and new attribute names have already been validated!
     *
-    * TODO: also update in $.refs
+    * TODO CORE-542: also update in $.refs
     *
     * `Using where. Index used: idx_entity_type_name`
     */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -379,7 +379,10 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
   // Gets any entities that have references to the entities in the given list
   // Excludes entities that are in the list
-  // TODO CORE-541: `execution plan: `
+  //
+  // `execution plan:
+  //    Using index condition (idx_entity_type_name); Using where; Using temporary on ENTITY
+  //    Table function: json_table; Using temporary; Using where for view.`
   def getReferencesTo(workspaceId: UUID, refs: Seq[EntityPointer]): ReadAction[Seq[EntityPointer]] = {
     val toNameClause = reduceSqlActionsWithDelim(
       generateTypeNameSql(refs.toSet, typeColumn = "to_entity_type", nameColumn = "to_name").toSeq,
@@ -402,7 +405,10 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
   // Gets entities that have references to any entities of the given type
   // Excludes entities with the same type
-  // TODO CORE-541: `execution plan: `
+  //
+  // `execution plan:
+  //    Using index condition (idx_entity_type_name); Using where; Using temporary on ENTITY
+  //    Table function: json_table; Using temporary; Using where for view.`
   def getReferencesToType(workspaceId: UUID, entityType: String): ReadAction[Seq[EntityPointer]] =
     sql"""select from_entity_type, from_name
          from ENTITY_REFS
@@ -478,7 +484,12 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    *
    * Returns the number of entities that were renamed.
    *
-   * TODO CORE-541: `execution plan: `
+   * execution plans:
+   *    updateEntityNameSql: index range scan on idx_entity_type_name
+   *    updateReferencesInAttributesSql: index range scan on idx_entity_type_name
+   *    updateSortValues: ugly. the two CTEs are materialized and the query does full table scans against those.
+   *      The initial "where workspace_id=?" on the first CTE uses the idx_entity_type_name index, and the following
+   *      full table scans are against only the materialized temp tables with rows matching the workspace id.
    */
   def renameEntity(workspaceId: UUID, entityType: String, oldName: String, newName: String): ReadWriteAction[Int] = {
     // validation ensures that entityType, oldName, and newName are SQL-safe
@@ -512,16 +523,17 @@ class CompactEntityQuery(driverComponent: DriverComponent)
             and JSON_CONTAINS(attributes, JSON_OBJECT('n', $oldName, 't', $entityType), $slickRefsPath)""".asUpdate
 
     // Update sortable values in the $.attrs object.
-    //  1. search $.refs to find all reference whose target name is equal to $oldName
+    //  1. search $.refs to find all scalar references to the target type/name
     //  2. extract the attribute name and isScalar boolean for each of those references
-    //  3. filter to those references where isScalar is true
+    //  3. re-filter to those references where isScalar is true and entityType matches; this prevents false positives from JSON_SEARCH
     //  4. update the specific entity/attribute name combinations
     val updateSortValues =
       sql"""with paths as(
               select id,
               REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldName, null, '$$.refs')), '.n', '') as path
               from ENTITY
-              having path is not null
+              where workspace_id = $workspaceId
+              and JSON_CONTAINS(attributes, JSON_OBJECT('n', $oldName, 't', $entityType, 'z', true), $slickRefsPath)
             ),
             attrnames as (
               select paths.id,
@@ -549,7 +561,9 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     *
     * Returns the number of entities that were renamed.
     *
-    * TODO CORE-541: `execution plan: `
+    * execution plan:
+    *     updateEntityTypeSql: index range scan on idx_entity_type_name
+    *     updateReferencesInAttributesSql: index range scan on idx_entity_type_name
     */
   def renameEntityType(workspaceId: UUID, oldType: String, newType: String): ReadWriteAction[Int] = {
     // validation ensures that oldType and newType are SQL-safe

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -10,7 +10,6 @@ import java.util.{Date, UUID}
 import org.broadinstitute.dsde.rawls.model.FilterOperators.FilterOperator
 import org.broadinstitute.dsde.rawls.model.{
   Attributable,
-  AttributeFormat,
   AttributeName,
   AttributeRename,
   Entity,
@@ -27,7 +26,6 @@ import slick.sql.SqlStreamingAction
 import spray.json._
 
 import scala.concurrent.ExecutionContext
-import scala.util.Try
 
 trait CompactEntityComponent extends LazyLogging {
   this: DriverComponent =>
@@ -485,7 +483,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * TODO: `execution plan: `
    */
   def renameEntity(workspaceId: UUID, entityType: String, oldName: String, newName: String): ReadWriteAction[Int] = {
-    // validation ensures that oldName and newName are SQL-safe
+    // validation ensures that entityType, oldName, and newName are SQL-safe
     EntityUtils.validateEntityName(oldName)
     EntityUtils.validateEntityName(newName)
     EntityUtils.validateEntityType(entityType)
@@ -510,7 +508,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     //  user-supplied values.
     val updateReferencesInAttributesSql = sql"""update ENTITY
             set attributes = JSON_REPLACE(attributes, $slickRefsPath,
-              CAST(REPLACE(JSON_EXTRACT(attributes, $slickRefsPath), '"n": "#$oldName"', "t": "#$entityType"'', '"n": "#$newName", "t": "#$entityType"') as JSON))
+              CAST(REPLACE(JSON_EXTRACT(attributes, $slickRefsPath), '"n": "#$oldName", "t": "#$entityType"', '"n": "#$newName", "t": "#$entityType"') as JSON))
             where workspace_id = $workspaceId
             and deleted = 0
             and JSON_CONTAINS(attributes, JSON_OBJECT('n', $oldName, 't', $entityType), $slickRefsPath)""".asUpdate
@@ -530,7 +528,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
             attrnames as (
               select paths.id,
                 JSON_EXTRACT(attributes, CONCAT(paths.path, '.a')) as attr,
-                JSON_EXTRACT(attributes, CONCAT(paths.path, '.s')) as is_scalar,
+                JSON_EXTRACT(attributes, CONCAT(paths.path, '.z')) as is_scalar,
                 JSON_EXTRACT(attributes, CONCAT(paths.path, '.t')) as entity_type
               from ENTITY e join paths on e.id = paths.id
               having is_scalar = true and entity_type = $entityType
@@ -540,7 +538,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           set e.attributes = JSON_REPLACE(e.attributes, CONCAT('$$.attrs.', attrnames.attr), $newName) where e.id = attrnames.id;
          """.asUpdate
 
-    // Execute all updates in same transaction
+    // Execute all updates
     for {
       _ <- updateSortValues
       _ <- updateReferencesInAttributesSql

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -269,7 +269,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
     val allCopies = DBIO.sequence(chunks map copyChunkOfEntitiesOrAllEntities)
 
-    allCopies.map { copyActionResults: Iterator[Int] => copyActionResults.sum}
+    allCopies.map { copyActionResults: Iterator[Int] => copyActionResults.sum }
   }
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -617,21 +617,13 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   //      methods in this section are used for building entity query functions
   // ====================================================================================================
 
-  // TODO: reusable function for '$.attrs[*]'
-  // TODO: search inside references too
   private def countEntitiesWithFilter(workspaceId: UUID,
                                       entityType: String,
                                       filter: SQLActionBuilder
   ): ReadWriteAction[Int] =
     concatSqlActions(
-      sql"""select count(*)
-            from ENTITY e,
-            JSON_TABLE(attributes, '$$.attrs[*]' COLUMNS (
-		      attr_name varchar(254) PATH '$$.a',
-              attr_value JSON PATH '$$.v'
-	          )
-	        ) as jt where e.workspace_id = $workspaceId and e.entity_type = $entityType and e.deleted = 0
-         """,
+      sql"select count(*) ",
+      fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
       filter
     ).as[Int].map(_.head)
 
@@ -639,25 +631,15 @@ class CompactEntityQuery(driverComponent: DriverComponent)
                                       entityType: String,
                                       entityQuery: EntityQuery,
                                       filter: SQLActionBuilder
-  ): SqlStreamingAction[Seq[Entity], Entity, Read] = {
-
-    // sql" from ENTITY e where e.workspace_id = $workspaceId and e.entity_type = $entityType and e.deleted = 0"
-    val fromClause = sql""" from ENTITY e,
-                           JSON_TABLE(attributes, '$$.attrs[*]' COLUMNS (
-                            attr_name varchar(254) PATH '$$.a',
-                            attr_value JSON PATH '$$.v'
-                            )
-                           ) as jt where e.workspace_id = $workspaceId and e.entity_type = $entityType and e.deleted = 0"""
-
+  ): SqlStreamingAction[Seq[Entity], Entity, Read] =
     concatSqlActions(
       selectEntityColumns,
       filteredAttributesColumn(entityQuery),
-      fromClause,
+      fromActiveEntitiesOfTypeInWorkspace(workspaceId, entityType),
       filter,
       orderBy(entityQuery),
       paginationClause(entityQuery)
     ).as[Entity]
-  }
 
   private val selectEntityColumns =
     sql"select name, entity_type, "
@@ -700,7 +682,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   private def filterTermsCondition(filterTerms: Seq[String], operator: FilterOperator) = {
     // note the lower casing for case insensitive search
     val filterClauses = filterTerms.map { filterTerm =>
-      sql"""JSON_SEARCH(lower(e.attributes -> '#${CompactEntitySerialization.slickAttrsPath}'), 'one', ${'%' + filterTerm.toLowerCase + '%'})"""
+      sql"""JSON_SEARCH(lower(e.attributes -> '#${CompactEntitySerialization.slickQueryPath}'), 'one', ${'%' + filterTerm.toLowerCase + '%'})"""
     }
     concatSqlActions(
       sql" and (",
@@ -709,18 +691,9 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     )
   }
 
-  // TODO: SQL injection
-  // TODO: create a reusable helper function to generate searchCriteria
-  private def columnFilterCondition(columnFilter: EntityColumnFilter) = {
-    val aname = AttributeName.toDelimitedName(columnFilter.attributeName)
-    sql" and attr_name = $aname and CAST(JSON_UNQUOTE(attr_value) as CHAR) = ${columnFilter.term} "
-  }
-
-  /* v1 implementation:
   private def columnFilterCondition(columnFilter: EntityColumnFilter) =
     // CAST, JSON_UNQUOTE and JSON_EXTRACT are used to handle strings and numbers and do a case insensitive comparison
-    sql" and CAST(e.attributes ->> ${slickAttributePath(columnFilter.attributeName)} AS CHAR) = ${columnFilter.term}"
-   */
+    sql" and CAST(e.attributes ->> ${slickQueryPath(columnFilter.attributeName)} AS CHAR) = ${columnFilter.term}"
 
   private def orderBy(entityQuery: EntityQuery): SQLActionBuilder =
     concatSqlActions(
@@ -731,7 +704,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           // the order of the columns here is also the sort precedence, list length first, then scalar value
           // Sorting on a list column should sort by the list size and sorting on a scalar column sorts on the column value.
           // If the column is a mixed type then all scalars will group together sorted by value then all the lists will follow sorted by size.
-          sql" JSON_LENGTH(e.attributes -> ${slickAttributePath(attr)}), e.attributes -> ${slickAttributePath(attr)}"
+          sql" e.attributes -> ${slickQueryPath(attr)}"
       },
       sql" #${SortDirections.toSql(entityQuery.sortDirection)}"
     )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -511,8 +511,34 @@ class CompactEntityQuery(driverComponent: DriverComponent)
             and deleted = 0
             and JSON_CONTAINS(attributes, JSON_OBJECT('n', $oldName), '$$.refs')""".asUpdate
 
+    // Update sortable values in the $.attrs object.
+    //  1. search $.refs to find all reference whose target name is equal to $oldName
+    //  2. extract the attribute name and isScalar boolean for each of those references
+    //  3. filter to those references where isScalar is true
+    //  4. update the specific entity/attribute name combinations
+    val updateSortValues =
+      sql"""with paths as(
+              select id,
+              REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldName, null, '$$.refs')), '.n', '') as path
+              from ENTITY
+              having path is not null
+            ),
+            attrnames as (
+              select paths.id,
+                JSON_EXTRACT(attributes, CONCAT(paths.path, '.a')) as attr,
+                JSON_EXTRACT(attributes, CONCAT(paths.path, '.s')) as is_scalar
+              from ENTITY e join paths on e.id = paths.id
+              having is_scalar = true
+            )
+          update ENTITY e
+          join attrnames on e.id = attrnames.id
+          set e.attributes = JSON_REPLACE(e.attributes, CONCAT('$$.attrs.', attrnames.attr), $newName) where e.id = attrnames.id;
+         """.asUpdate
+
+
     // Execute all updates in same transaction
     for {
+      _ <- updateSortValues
       _ <- updateReferencesInAttributesSql
       entityRowsUpdated <- updateEntityNameSql.asUpdate
     } yield entityRowsUpdated

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -535,7 +535,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           set e.attributes = JSON_REPLACE(e.attributes, CONCAT('$$.attrs.', attrnames.attr), $newName) where e.id = attrnames.id;
          """.asUpdate
 
-
     // Execute all updates in same transaction
     for {
       _ <- updateSortValues

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
@@ -58,7 +58,7 @@ case class CompactEntityVersionRecord(id: Long, name: String, entityType: String
 /**
   * model class for rows in the ENTITY_KEYS table
   */
-case class KeysRecord(id: Long, workspaceId: UUID, entityType: String, attributeKeys: String)
+case class KeysRecord(id: Long, workspaceId: UUID, entityType: String, attributeKeys: String, lastUpdated: Timestamp)
 
 /**
   * model class for rows in the ENTITY_REFS table

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
@@ -58,7 +58,7 @@ case class CompactEntityVersionRecord(id: Long, name: String, entityType: String
 /**
   * model class for rows in the ENTITY_KEYS table
   */
-case class KeysRecord(id: Long, workspaceId: UUID, entityType: String, attributeKeys: String, lastUpdated: Timestamp)
+case class KeysRecord(id: Long, workspaceId: UUID, entityType: String, attributeKeys: String)
 
 /**
   * model class for rows in the ENTITY_REFS table

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
@@ -4,6 +4,8 @@ import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
 import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeName, Entity, EntityPointer}
+import spray.json.DefaultJsonProtocol.{jsonFormat3, jsonFormat4}
+import spray.json.RootJsonFormat
 
 import java.sql.Timestamp
 import java.util.UUID
@@ -63,7 +65,14 @@ case class KeysRecord(id: Long, workspaceId: UUID, entityType: String, attribute
 /**
   * model class for rows in the ENTITY_REFS table
   */
-case class RefPointerRecord(fromId: Long, toId: Long)
+case class RefPointerRecord(workspaceId: UUID,
+                            fromEntityId: Long,
+                            fromEntityType: String,
+                            fromName: String,
+                            fromAttribute: String,
+                            toEntityType: String,
+                            toName: String
+)
 
 /** all reference pointers from one entity to all its reference targets */
 case class RefMapping(from: EntityPointer, to: Set[EntityPointer])

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntitySlickComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntitySlickComponent.scala
@@ -44,9 +44,10 @@ trait CompactEntitySlickComponent {
     def workspaceId = column[UUID]("workspace_id")
     def entityType = column[String]("entity_type")
     def attributeKeys = column[String]("attribute_keys")
+    def lastUpdated = column[Timestamp]("last_updated")
 
     def * =
-      (id, workspaceId, entityType, attributeKeys) <> (KeysRecord.tupled, KeysRecord.unapply)
+      (id, workspaceId, entityType, attributeKeys, lastUpdated) <> (KeysRecord.tupled, KeysRecord.unapply)
   }
 
   /** high-level Slick query object for ENTITY */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntitySlickComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntitySlickComponent.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
+import org.broadinstitute.dsde.rawls.model.AttributeName
 import slick.jdbc.MySQLProfile.api._
 
 import java.sql.Timestamp
@@ -31,11 +32,19 @@ trait CompactEntitySlickComponent {
 
   /** high-level Slick table for ENTITY_REFS */
   class CompactEntityRefTable(tag: Tag) extends Table[RefPointerRecord](tag, "ENTITY_REFS") {
-    def fromId = column[Long]("from_id")
-    def toId = column[Long]("to_id")
+    def workspaceId = column[UUID]("workspace_id")
+    def fromEntityId: Rep[Long] = column[Long]("from_entity_id")
+    def fromEntityType = column[String]("from_entity_type")
+    def fromName = column[String]("from_name")
+    def fromAttributeName = column[String]("from_attribute_name")
+    def toEntityType = column[String]("to_entity_type")
+    def toName = column[String]("to_name")
 
     def * =
-      (fromId, toId) <> (RefPointerRecord.tupled, RefPointerRecord.unapply)
+      (workspaceId, fromEntityId, fromEntityType, fromName, fromAttributeName, toEntityType, toName) <> (
+        RefPointerRecord.tupled,
+        RefPointerRecord.unapply
+      )
   }
 
   /** high-level Slick table for ENTITY_KEYS */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntitySlickComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntitySlickComponent.scala
@@ -44,10 +44,9 @@ trait CompactEntitySlickComponent {
     def workspaceId = column[UUID]("workspace_id")
     def entityType = column[String]("entity_type")
     def attributeKeys = column[String]("attribute_keys")
-    def lastUpdated = column[Timestamp]("last_updated")
 
     def * =
-      (id, workspaceId, entityType, attributeKeys, lastUpdated) <> (KeysRecord.tupled, KeysRecord.unapply)
+      (id, workspaceId, entityType, attributeKeys) <> (KeysRecord.tupled, KeysRecord.unapply)
   }
 
   /** high-level Slick query object for ENTITY */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
@@ -65,7 +65,6 @@ trait DataAccess
     }.toSeq
 
     DBIO.sequence(shardDeletes) andThen // FK to entity
-      TableQuery[CompactEntityKeysTable].delete andThen // FK to entity
       TableQuery[WorkspaceAttributeTable].delete andThen // FK to entity, workspace
       TableQuery[SubmissionAttributeTable].delete andThen // FK to entity, submissionvalidation
       TableQuery[MethodConfigurationInputTable].delete andThen // FK to MC
@@ -88,8 +87,7 @@ trait DataAccess
       TableQuery[PendingBucketDeletionTable].delete andThen
       TableQuery[EntityAttributeTempTable].delete andThen
       TableQuery[WorkspaceAttributeTempTable].delete andThen
-      TableQuery[ExprEvalScratch].delete andThen
-      TableQuery[CompactEntityRefTable].delete
+      TableQuery[ExprEvalScratch].delete
   }
 
   def sqlDBStatus() =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
@@ -65,6 +65,7 @@ trait DataAccess
     }.toSeq
 
     DBIO.sequence(shardDeletes) andThen // FK to entity
+      TableQuery[CompactEntityKeysTable].delete andThen // FK to entity
       TableQuery[WorkspaceAttributeTable].delete andThen // FK to entity, workspace
       TableQuery[SubmissionAttributeTable].delete andThen // FK to entity, submissionvalidation
       TableQuery[MethodConfigurationInputTable].delete andThen // FK to MC

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -148,9 +148,6 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
           throw new RawlsConcurrentModificationException(
             s"Detected concurrent modifications to entity ${savedEntityRecord.toPointer}."
           )
-
-        // save all references from this entity to other entities
-        // _ <- repository.queries.insertReferences(workspaceId, refs)
       } yield savedEntityRecord.toEntity
     }
     // fire-and-forget an update to the workspace's last-modified date; no need to wait for it to complete

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -150,7 +150,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
           )
 
         // save all references from this entity to other entities
-        _ <- repository.queries.insertReferences(workspaceId, refs)
+        // _ <- repository.queries.insertReferences(workspaceId, refs)
       } yield savedEntityRecord.toEntity
     }
     // fire-and-forget an update to the workspace's last-modified date; no need to wait for it to complete
@@ -168,8 +168,6 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         _ = if (referencingEntities.nonEmpty) {
           throw new DeleteEntitiesConflictException(referencingEntities.map(_.toAttributeEntityReference).toSet)
         }
-        // remove all references from these entities
-        _ <- repository.queries.deleteAllReferencesFrom(workspaceId, pointers.toSet)
         // hard-delete everything we can
         _ <- repository.queries.deleteEntities(workspaceId, pointers)
         // soft-delete (i.e. hide) everything that could not be hard-deleted
@@ -186,8 +184,6 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         _ = if (referencingEntities.nonEmpty) {
           throw new DeleteEntitiesOfTypeConflictException(referencingEntities.size)
         }
-        // remove all references from these entities
-        _ <- repository.queries.deleteAllReferencesFromType(workspaceId, entityType)
         // hard-delete everything we can
         _ <- repository.queries.deleteEntitiesOfType(workspaceId, entityType)
         // soft-delete (i.e. hide) everything that could not be hard-deleted

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -101,12 +101,12 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
     dataAccess: DataAccess,
     workspace: Workspace,
     updatedEntities: Seq[Entity]
-  ): ReadWriteAction[Traversable[Entity]] = DBIO.successful(Seq()) // FIXME: implement this
+  ): ReadWriteAction[Traversable[Entity]] = DBIO.successful(Seq()) // TODO CORE-483: implement this
 
   def listWorkflowEntities(dataAccess: DataAccess,
                            workspace: Workspace,
                            entityIds: Seq[Long]
-  ): ReadAction[Map[Long, Entity]] = DBIO.successful(Map()) // FIXME: implement this
+  ): ReadAction[Map[Long, Entity]] = DBIO.successful(Map()) // TODO CORE-483: implement this
 
   override def copyEntities(sourceWorkspaceContext: Workspace,
                             destWorkspaceContext: Workspace,
@@ -417,7 +417,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
     val newName = renameInfo.newName
 
     // Perform the rename in a transaction
-    val renameFuture = repository.dataSource.inTransaction { dataAccess =>
+    val renameFuture = repository.dataSource.inTransaction { _ =>
       for {
         // First check if the old entity type exists
         entityTypeCount <- repository.queries.countEntities(workspaceId, oldName)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.dsde.rawls.entities.compact
 
+import autovalue.shaded.com.google.common.annotations.VisibleForTesting
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.slick.CompactEntityAttributeListSerializer
 import org.broadinstitute.dsde.rawls.entities.exceptions.CompactEntityDeserializationException
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
@@ -30,7 +32,7 @@ object CompactEntitySerialization extends CompactEntitySerialization
 /**
   * Methods to serialize attributes to/deserialize attributes from the database
   */
-trait CompactEntitySerialization {
+trait CompactEntitySerialization extends LazyLogging {
 
   // defines how list attributes are translated to/from JSON
   implicit val attributeFormat: AttributeFormat = new AttributeFormat with CompactEntityAttributeListSerializer
@@ -48,17 +50,17 @@ trait CompactEntitySerialization {
 
   // translate a AttributeMap into a JsValue suitable for persisting into the db
   def toSql(attributes: AttributeMap): JsObject = {
-    // v1 serialization format:
-    // val attrsJson = attributes.toJson
-
     // translate references and reference lists into sortable values;
     // the references themselves are stored in a separate "refs" key
     val jsonAttrs: AttributeMap = attributes.map { case (name, value) =>
       val normalizedValue = value match {
         case AttributeEntityReferenceList(l) if l.isEmpty => AttributeEntityReferenceEmptyList
-        case AttributeEntityReferenceList(l)              => AttributeNumber(l.size)
-        case AttributeEntityReference(_, entityName)      => AttributeString(entityName)
-        case x                                            => x
+        // TODO: should AttributeEntityReferenceList(l) return
+        //  AttributeValueList(l.map(r => AttributeString(r.entityName))) instead? That would allow for filtering,
+        //  at the cost of additional duplication.
+        case AttributeEntityReferenceList(l)         => AttributeNumber(l.size)
+        case AttributeEntityReference(_, entityName) => AttributeString(entityName)
+        case x                                       => x
       }
       name -> normalizedValue
     }
@@ -71,12 +73,12 @@ trait CompactEntitySerialization {
             SqlEntityReference(a = AttributeName.toDelimitedName(name),
                                n = ref.entityName,
                                t = ref.entityType,
-                               s = Some(true)
+                               z = Some(true)
             )
           )
         case (name, refList: AttributeEntityReferenceList) =>
           refList.list.map(r =>
-            SqlEntityReference(a = AttributeName.toDelimitedName(name), n = r.entityName, t = r.entityType, s = None)
+            SqlEntityReference(a = AttributeName.toDelimitedName(name), n = r.entityName, t = r.entityType, z = None)
           )
       }
       .flatten
@@ -186,7 +188,7 @@ trait CompactEntitySerialization {
             "attrs": {
               "attrName1": "Hello world",
               "attrName2": "targetName1", // used for sorting/filtering
-              "attrName3": 2,             // used for sorting/filtering
+              "attrName3": 2,             // used for sorting
               "attrName4": 123,
             },
             "refs": [
@@ -208,15 +210,21 @@ trait CompactEntitySerialization {
           baseAttrs.contains(AttributeName.fromDelimitedName(attributeName))
         }
         val refAttrs: AttributeMap = filteredGroupedRefs.map { case (attributeName, refSeq) =>
-          val aname = AttributeName.fromDelimitedName(attributeName)
+          val attrName = AttributeName.fromDelimitedName(attributeName)
           val attr: Attribute = if (refSeq.isEmpty) {
             AttributeValueEmptyList // no references, so this is an empty list
-          } else if (refSeq.head.s.contains(true)) {
+          } else if (refSeq.head.z.contains(true)) {
+            if (refSeq.size > 1) {
+              logger.warn(
+                s"Found ${refSeq.size} ref entries for attribute $attributeName, but expected a scalar." +
+                  " Using only the first of those entries."
+              )
+            }
             refSeq.head.toAttributeEntityReference // single scalar reference
           } else {
             AttributeEntityReferenceList(refSeq.map(_.toAttributeEntityReference)) // multiple references
           }
-          aname -> attr
+          attrName -> attr
         }
 
         // layer the references on top of the base attribute map
@@ -229,11 +237,14 @@ trait CompactEntitySerialization {
     }
 
   // SQL representation of an entity reference. We use single-character field names to save space in the database.
+  // Note also that MySQL stores keys alphabetically. The order of keys is important for functionality like
+  // rename-entity which manipulates the string representation of the JSON and expects e.g. "n" and "t" in a
+  // specific order and next to each other.
   case class SqlEntityReference(
     a: String, // delimited attribute name (namespace:)name
     n: String, // target entity name
     t: String, // target entity type
-    s: Option[Boolean] // true if this reference is a scalar; false or None if it is a list
+    z: Option[Boolean] // true if this reference is a scalar; false or None if it is a list
   ) {
     def toAttributeEntityReference: AttributeEntityReference =
       AttributeEntityReference(entityType = t, entityName = n)
@@ -241,4 +252,10 @@ trait CompactEntitySerialization {
 
   implicit val sqlEntityReferenceFormat: RootJsonFormat[SqlEntityReference] = jsonFormat4(SqlEntityReference)
 
+  // Representation of the raw serialization format for entities in the db, without the post-processing
+  // performed by `deserialize()`. Used by tests to verify functionality.
+  @VisibleForTesting
+  case class SqlEntityData(v: Int, attrs: AttributeMap, refs: Seq[SqlEntityReference])
+
+  implicit val sqlEntityDataFormat: RootJsonFormat[SqlEntityData] = jsonFormat3(SqlEntityData)
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
@@ -41,7 +41,7 @@ trait CompactEntitySerialization {
   // on the `ENTITY` database table
   val ATTRS_KEY: String = "attrs"
   // json key for the "query" values, used for sorting and filtering in entityQuery
-  val QUERY_KEY: String = "q"
+  val REFS_KEY: String = "refs"
 
   // the current serialization version
   val CURRENT_VERSION: Int = 2
@@ -51,51 +51,80 @@ trait CompactEntitySerialization {
     // v1 serialization format:
     // val attrsJson = attributes.toJson
     // v2 serialization format:
-    val sqlAttrs: Vector[SqlAttribute] = attributes.map { case (name, value) =>
-      SqlAttribute(
-        a = toDelimitedName(name),
-        v = value match {
-          case _: AttributeValue                                           => Some(value.toJson)
-          case _: AttributeValueList                                       => Some(value.toJson)
-          case AttributeValueEmptyList | AttributeEntityReferenceEmptyList => Some(JsArray.empty)
-          case _                                                           => None
-        },
-        r = value match {
-          case ref: AttributeEntityReference =>
-            Some(Seq(SqlEntityReference(n = ref.entityName, t = ref.entityType)))
-          case refList: AttributeEntityReferenceList =>
-            Some(refList.list.map(r => SqlEntityReference(n = r.entityName, t = r.entityType)))
-          case _ => None
-        },
-        s = value match {
-          case _: AttributeEntityReference => Some(true)
-          case _                           => None
-        }
-      )
-    }.toVector
-    val attrsJson = JsArray(sqlAttrs.map(_.toJson))
+//    val sqlAttrs: Vector[SqlAttribute] = attributes.map { case (name, value) =>
+//      SqlAttribute(
+//        a = toDelimitedName(name),
+//        v = value match {
+//          case _: AttributeValue                                           => Some(value.toJson)
+//          case _: AttributeValueList                                       => Some(value.toJson)
+//          case AttributeValueEmptyList | AttributeEntityReferenceEmptyList => Some(JsArray.empty)
+//          case _                                                           => None
+//        },
+//        r = value match {
+//          case ref: AttributeEntityReference =>
+//            Some(Seq(SqlEntityReference(n = ref.entityName, t = ref.entityType)))
+//          case refList: AttributeEntityReferenceList =>
+//            Some(refList.list.map(r => SqlEntityReference(n = r.entityName, t = r.entityType)))
+//          case _ => None
+//        },
+//        s = value match {
+//          case _: AttributeEntityReference => Some(true)
+//          case _                           => None
+//        }
+//      )
+//    }.toVector
+//    val attrsJson = JsArray(sqlAttrs.map(_.toJson))
+//
+//    val queryAttrs: Map[String, JsValue] = attributes.map { case (name, value) =>
+//      val aname = AttributeName.toDelimitedName(name)
+//      val jsval: JsValue = value match {
+//        case AttributeString(s)                      => JsString(s.take(500)) // TODO: what limit should we set?
+//        case AttributeNumber(n)                      => JsNumber(n)
+//        case AttributeBoolean(b)                     => JsBoolean(b)
+//        case AttributeValueList(l)                   => JsNumber(l.size)
+//        case AttributeEntityReferenceList(l)         => JsNumber(l.size)
+//        case AttributeEntityReference(_, entityName) => JsString(entityName)
+//        case AttributeValueRawJson(js)               => js
+//        case AttributeValueEmptyList | AttributeEntityReferenceEmptyList => JsNumber(0) // or should we use Int.max?
+//        case AttributeNull                                               => JsNull
+//      }
+//      aname -> jsval
+//    }
 
-    val queryAttrs: Map[String, JsValue] = attributes.map { case (name, value) =>
-      val aname = AttributeName.toDelimitedName(name)
-      val jsval: JsValue = value match {
-        case AttributeString(s)                      => JsString(s.take(500)) // TODO: what limit should we set?
-        case AttributeNumber(n)                      => JsNumber(n)
-        case AttributeBoolean(b)                     => JsBoolean(b)
-        case AttributeValueList(l)                   => JsNumber(l.size)
-        case AttributeEntityReferenceList(l)         => JsNumber(l.size)
-        case AttributeEntityReference(_, entityName) => JsString(entityName)
-        case AttributeValueRawJson(js)               => js
-        case AttributeValueEmptyList | AttributeEntityReferenceEmptyList => JsNumber(0) // or should we use Int.max?
-        case AttributeNull                                               => JsNull
+    // translate references and reference lists into sortable values;
+    // the references themselves are stored in a separate "refs" key
+    val jsonAttrs: AttributeMap = attributes.map { case (name, value) =>
+      val normalizedValue = value match {
+        case AttributeEntityReferenceList(l)         => AttributeNumber(l.size)
+        case AttributeEntityReference(_, entityName) => AttributeString(entityName)
+        case x                                       => x
       }
-      aname -> jsval
+      name -> normalizedValue
     }
+
+    val refObjects: Vector[SqlEntityReference] = attributes
+      .collect {
+        case (name, ref: AttributeEntityReference) =>
+          Seq(
+            SqlEntityReference(a = AttributeName.toDelimitedName(name),
+                               n = ref.entityName,
+                               t = ref.entityType,
+                               s = Some(true)
+            )
+          )
+        case (name, refList: AttributeEntityReferenceList) =>
+          refList.list.map(r =>
+            SqlEntityReference(a = AttributeName.toDelimitedName(name), n = r.entityName, t = r.entityType, s = None)
+          )
+      }
+      .flatten
+      .toVector
 
     JsObject(
       Map(
         VERSION_KEY -> JsNumber(CURRENT_VERSION),
-        ATTRS_KEY -> attrsJson,
-        QUERY_KEY -> JsObject(queryAttrs)
+        ATTRS_KEY -> jsonAttrs.toJson,
+        REFS_KEY -> JsArray(refObjects.map(_.toJson))
       )
     )
   }
@@ -110,13 +139,11 @@ trait CompactEntitySerialization {
         )
     }
 
-  val slickAttrsPath: String = s"$$.${ATTRS_KEY}"
+  val slickAttrsPath: String = s"$$.$ATTRS_KEY"
   def slickAttributePath(attributeName: String): String = s"""${slickAttrsPath}."${attributeName}""""
   def slickAttributePath(attributeName: AttributeName): String = slickAttributePath(toDelimitedName(attributeName))
 
-  val slickQueryPath: String = s"$$.${QUERY_KEY}"
-  def slickQueryPath(attributeName: String): String = s"""${slickQueryPath}."${attributeName}""""
-  def slickQueryPath(attributeName: AttributeName): String = slickQueryPath(toDelimitedName(attributeName))
+  val slickRefsPath: String = s"$$.$REFS_KEY"
 
   // retrieve the version number from the database's JSON
   private def getVersion(jso: JsObject): Int =
@@ -133,17 +160,32 @@ trait CompactEntitySerialization {
     }
 
   // retrieve the attributes packet from the database's JSON
-  private def getAttrs(jso: JsObject): JsArray =
+  private def getAttrs(jso: JsObject): JsObject =
     jso.fields.get(ATTRS_KEY) match {
-      case Some(jsa: JsArray) => jsa
+      case Some(jso: JsObject) => jso
       case None =>
         throw new CompactEntityDeserializationException(
-          s"wanted an attributes array; found none"
+          s"wanted an attributes object; found none"
         )
       // version could not be determined
       case Some(otherJsValue) =>
         throw new CompactEntityDeserializationException(
-          s"wanted an attributes array; found a ${otherJsValue.getClass.getName}"
+          s"wanted an attributes object; found a ${otherJsValue.getClass.getName}"
+        )
+    }
+
+  // retrieve the references packet from the database's JSON
+  private def getReferences(jso: JsObject): JsArray =
+    jso.fields.get(REFS_KEY) match {
+      case Some(jsa: JsArray) => jsa
+      case None =>
+        throw new CompactEntityDeserializationException(
+          s"wanted an references array; found none"
+        )
+      // version could not be determined
+      case Some(otherJsValue) =>
+        throw new CompactEntityDeserializationException(
+          s"wanted an references array; found a ${otherJsValue.getClass.getName}"
         )
     }
 
@@ -175,20 +217,47 @@ trait CompactEntitySerialization {
        */
       case 1 => getAttrs(jso).convertTo[AttributeMap]
 
-      /*  version 2 stores attributes in a normalized array
+      /*  version 2 stores references normalized and replaced with sortable/filterable values in the main
+            "attrs" object.
           {
             "v": 2,
-            "attrs": [
-                {"a": "hello", "v": "world"},
-                {"a": "refs", "r": [
-                    {"n": "1", "t": "test"},
-                    {"n": "2", "t": "test"}
-                ]}
+            "attrs": {
+              "attrName1": "Hello world",
+              "attrName2": "targetName1", // used for sorting/filtering
+              "attrName3": 2,             // used for sorting/filtering
+              "attrName4": 123,
+            },
+            "refs": [
+              {"a": "attrName2", "t": "targetType", "n": "targetName1", "s": true},
+              {"a": "attrName3", "t": "targetType", "n": "targetName1"},
+              {"a": "attrName3", "t": "targetType", "n": "targetName2"}
             ]
           }
        */
       case 2 =>
-        getAttrs(jso).convertTo[Seq[SqlAttribute]].map(_.toPair).toMap
+        val baseAttrs = getAttrs(jso).convertTo[AttributeMap]
+
+        val refs = getReferences(jso).convertTo[Seq[SqlEntityReference]]
+        val groupedRefs: Map[String, Seq[SqlEntityReference]] = refs.groupMap(_.a)(identity)
+        // for
+
+
+
+
+        val refAttrs: AttributeMap = groupedRefs.map { case (attributeName, refSeq) =>
+          val aname = AttributeName.fromDelimitedName(attributeName)
+          val attr: Attribute = if (refSeq.isEmpty) {
+            AttributeValueEmptyList // no references, so this is an empty list
+          } else if (refSeq.head.s.contains(true)) {
+            refSeq.head.toAttributeEntityReference // single scalar reference
+          } else {
+            AttributeEntityReferenceList(refSeq.map(_.toAttributeEntityReference)) // multiple references
+          }
+          aname -> attr
+        }.toMap
+
+        // layer references on top of the attribute map
+        baseAttrs ++ refAttrs
 
       case x =>
         throw new CompactEntityDeserializationException(
@@ -197,36 +266,15 @@ trait CompactEntitySerialization {
     }
 
   case class SqlEntityReference(
-    n: String, // entity name
-    t: String // entity type
+    a: String, // delimited attribute name (namespace:)name
+    n: String, // target entity name
+    t: String, // target entity type
+    s: Option[Boolean] // true if this reference is a scalar; false or None if it is a list
   ) {
     def toAttributeEntityReference: AttributeEntityReference =
       AttributeEntityReference(entityType = t, entityName = n)
   }
 
-  case class SqlAttribute(
-    a: String, // delimited attribute name (namespace:)name
-    v: Option[JsValue], // non-reference value; can be string, number, boolean, null, raw JSON, or array of any of those
-    r: Option[Seq[SqlEntityReference]], // references to other entities
-    s: Option[Boolean] // true if this reference is a scalar; false or None if it is a list
-  ) {
-    def toPair: (AttributeName, Attribute) = {
-      val name = AttributeName.fromDelimitedName(a)
-      val value = (v, r) match {
-        case (Some(value), None) => value.convertTo[Attribute]
-        case (None, Some(sqlRefs)) =>
-          if (s.getOrElse(false)) {
-            sqlRefs.head.toAttributeEntityReference
-          } else {
-            AttributeEntityReferenceList(sqlRefs.map(_.toAttributeEntityReference))
-          }
-        case _ => throw new RuntimeException("Unexpected combination of value and references in SqlAttribute")
-      }
-      (name, value)
-    }
-  }
-
-  implicit val sqlEntityReferenceFormat: RootJsonFormat[SqlEntityReference] = jsonFormat2(SqlEntityReference)
-  implicit val sqlAttributeFormat: RootJsonFormat[SqlAttribute] = jsonFormat4(SqlAttribute)
+  implicit val sqlEntityReferenceFormat: RootJsonFormat[SqlEntityReference] = jsonFormat4(SqlEntityReference)
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
@@ -50,46 +50,6 @@ trait CompactEntitySerialization {
   def toSql(attributes: AttributeMap): JsObject = {
     // v1 serialization format:
     // val attrsJson = attributes.toJson
-    // v2 serialization format:
-//    val sqlAttrs: Vector[SqlAttribute] = attributes.map { case (name, value) =>
-//      SqlAttribute(
-//        a = toDelimitedName(name),
-//        v = value match {
-//          case _: AttributeValue                                           => Some(value.toJson)
-//          case _: AttributeValueList                                       => Some(value.toJson)
-//          case AttributeValueEmptyList | AttributeEntityReferenceEmptyList => Some(JsArray.empty)
-//          case _                                                           => None
-//        },
-//        r = value match {
-//          case ref: AttributeEntityReference =>
-//            Some(Seq(SqlEntityReference(n = ref.entityName, t = ref.entityType)))
-//          case refList: AttributeEntityReferenceList =>
-//            Some(refList.list.map(r => SqlEntityReference(n = r.entityName, t = r.entityType)))
-//          case _ => None
-//        },
-//        s = value match {
-//          case _: AttributeEntityReference => Some(true)
-//          case _                           => None
-//        }
-//      )
-//    }.toVector
-//    val attrsJson = JsArray(sqlAttrs.map(_.toJson))
-//
-//    val queryAttrs: Map[String, JsValue] = attributes.map { case (name, value) =>
-//      val aname = AttributeName.toDelimitedName(name)
-//      val jsval: JsValue = value match {
-//        case AttributeString(s)                      => JsString(s.take(500)) // TODO: what limit should we set?
-//        case AttributeNumber(n)                      => JsNumber(n)
-//        case AttributeBoolean(b)                     => JsBoolean(b)
-//        case AttributeValueList(l)                   => JsNumber(l.size)
-//        case AttributeEntityReferenceList(l)         => JsNumber(l.size)
-//        case AttributeEntityReference(_, entityName) => JsString(entityName)
-//        case AttributeValueRawJson(js)               => js
-//        case AttributeValueEmptyList | AttributeEntityReferenceEmptyList => JsNumber(0) // or should we use Int.max?
-//        case AttributeNull                                               => JsNull
-//      }
-//      aname -> jsval
-//    }
 
     // translate references and reference lists into sortable values;
     // the references themselves are stored in a separate "refs" key
@@ -102,6 +62,7 @@ trait CompactEntitySerialization {
       name -> normalizedValue
     }
 
+    // collect all references and translate them to SqlEntityReference objects
     val refObjects: Vector[SqlEntityReference] = attributes
       .collect {
         case (name, ref: AttributeEntityReference) =>
@@ -235,15 +196,16 @@ trait CompactEntitySerialization {
           }
        */
       case 2 =>
+        // extract the base attributes from the JSON
         val baseAttrs = getAttrs(jso).convertTo[AttributeMap]
 
+        // extract the references from the JSON
         val refs = getReferences(jso).convertTo[Seq[SqlEntityReference]]
         val groupedRefs: Map[String, Seq[SqlEntityReference]] = refs.groupMap(_.a)(identity)
         // discard any references that do not have a matching base attribute
         val filteredGroupedRefs: Map[String, Seq[SqlEntityReference]] = groupedRefs.filter { case (attributeName, _) =>
           baseAttrs.contains(AttributeName.fromDelimitedName(attributeName))
         }
-
         val refAttrs: AttributeMap = filteredGroupedRefs.map { case (attributeName, refSeq) =>
           val aname = AttributeName.fromDelimitedName(attributeName)
           val attr: Attribute = if (refSeq.isEmpty) {
@@ -254,9 +216,9 @@ trait CompactEntitySerialization {
             AttributeEntityReferenceList(refSeq.map(_.toAttributeEntityReference)) // multiple references
           }
           aname -> attr
-        }.toMap
+        }
 
-        // layer references on top of the attribute map
+        // layer the references on top of the base attribute map
         baseAttrs ++ refAttrs
 
       case x =>
@@ -265,6 +227,7 @@ trait CompactEntitySerialization {
         )
     }
 
+  // SQL representation of an entity reference. We use single-character field names to save space in the database.
   case class SqlEntityReference(
     a: String, // delimited attribute name (namespace:)name
     n: String, // target entity name

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
@@ -4,8 +4,18 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.CompactEntityAttributeList
 import org.broadinstitute.dsde.rawls.entities.exceptions.CompactEntityDeserializationException
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
-import org.broadinstitute.dsde.rawls.model.{AttributeFormat, AttributeName}
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
+import org.broadinstitute.dsde.rawls.model.{
+  Attribute,
+  AttributeEntityReference,
+  AttributeEntityReferenceEmptyList,
+  AttributeEntityReferenceList,
+  AttributeFormat,
+  AttributeName,
+  AttributeValue,
+  AttributeValueEmptyList,
+  AttributeValueList
+}
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
@@ -27,16 +37,44 @@ trait CompactEntitySerialization {
   val ATTRS_KEY: String = "attrs"
 
   // the current serialization version
-  val CURRENT_VERSION: Int = 1
+  val CURRENT_VERSION: Int = 2
 
   // translate a AttributeMap into a JsValue suitable for persisting into the db
-  def toSql(attributes: AttributeMap): JsObject =
+  def toSql(attributes: AttributeMap): JsObject = {
+    // v1 serialization format:
+    // val attrsJson = attributes.toJson
+    // v2 serialization format:
+    val sqlAttrs: Vector[SqlAttribute] = attributes.map { case (name, value) =>
+      SqlAttribute(
+        a = toDelimitedName(name),
+        v = value match {
+          case _: AttributeValue                                           => Some(value.toJson)
+          case _: AttributeValueList                                       => Some(value.toJson)
+          case AttributeValueEmptyList | AttributeEntityReferenceEmptyList => Some(JsArray.empty)
+          case _                                                           => None
+        },
+        r = value match {
+          case ref: AttributeEntityReference =>
+            Some(Seq(SqlEntityReference(n = ref.entityName, t = ref.entityType)))
+          case refList: AttributeEntityReferenceList =>
+            Some(refList.list.map(r => SqlEntityReference(n = r.entityName, t = r.entityType)))
+          case _ => None
+        },
+        s = value match {
+          case _: AttributeEntityReference => Some(true)
+          case _                           => None
+        }
+      )
+    }.toVector
+    val attrsJson = JsArray(sqlAttrs.map(_.toJson))
+
     JsObject(
       Map(
         VERSION_KEY -> JsNumber(CURRENT_VERSION),
-        ATTRS_KEY -> attributes.toJson
+        ATTRS_KEY -> attrsJson
       )
     )
+  }
 
   // translate a SQL column value back into an AttributeMap
   def fromSql(attributes: Option[String]): AttributeMap =
@@ -67,17 +105,17 @@ trait CompactEntitySerialization {
     }
 
   // retrieve the attributes packet from the database's JSON
-  private def getAttrs(jso: JsObject): JsObject =
+  private def getAttrs(jso: JsObject): JsArray =
     jso.fields.get(ATTRS_KEY) match {
-      case Some(jso: JsObject) => jso
+      case Some(jsa: JsArray) => jsa
       case None =>
         throw new CompactEntityDeserializationException(
-          s"wanted an attributes sub-object; found none"
+          s"wanted an attributes array; found none"
         )
       // version could not be determined
       case Some(otherJsValue) =>
         throw new CompactEntityDeserializationException(
-          s"wanted an attributes sub-object; found a ${otherJsValue.getClass.getName}"
+          s"wanted an attributes array; found a ${otherJsValue.getClass.getName}"
         )
     }
 
@@ -109,10 +147,58 @@ trait CompactEntitySerialization {
        */
       case 1 => getAttrs(jso).convertTo[AttributeMap]
 
+      /*  version 2 stores attributes in a normalized array
+          {
+            "v": 2,
+            "attrs": [
+                {"a": "hello", "v": "world"},
+                {"a": "refs", "r": [
+                    {"n": "1", "t": "test"},
+                    {"n": "2", "t": "test"}
+                ]}
+            ]
+          }
+       */
+      case 2 =>
+        getAttrs(jso).convertTo[Seq[SqlAttribute]].map(_.toPair).toMap
+
       case x =>
         throw new CompactEntityDeserializationException(
           s"found unexpected version number: $x"
         )
     }
+
+  case class SqlEntityReference(
+    n: String, // entity name
+    t: String // entity type
+  ) {
+    def toAttributeEntityReference: AttributeEntityReference =
+      AttributeEntityReference(entityType = t, entityName = n)
+  }
+
+  case class SqlAttribute(
+    a: String, // delimited attribute name (namespace:)name
+    v: Option[JsValue], // non-reference value; can be string, number, boolean, null, raw JSON, or array of any of those
+    r: Option[Seq[SqlEntityReference]], // references to other entities
+    s: Option[Boolean] // true if this reference is a scalar; false or None if it is a list
+  ) {
+    def toPair: (AttributeName, Attribute) = {
+      val name = AttributeName.fromDelimitedName(a)
+      val value = (v, r) match {
+        case (Some(value), None) => value.convertTo[Attribute]
+        case (None, Some(sqlRefs)) =>
+          if (s.getOrElse(false)) {
+            sqlRefs.head.toAttributeEntityReference
+          } else {
+            AttributeEntityReferenceList(sqlRefs.map(_.toAttributeEntityReference))
+          }
+        case _ => throw new RuntimeException("Unexpected combination of value and references in SqlAttribute")
+      }
+      (name, value)
+    }
+  }
+
+  implicit val sqlEntityReferenceFormat: RootJsonFormat[SqlEntityReference] = jsonFormat2(SqlEntityReference)
+  implicit val sqlAttributeFormat: RootJsonFormat[SqlAttribute] = jsonFormat4(SqlAttribute)
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
@@ -7,14 +7,19 @@ import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model.{
   Attribute,
+  AttributeBoolean,
   AttributeEntityReference,
   AttributeEntityReferenceEmptyList,
   AttributeEntityReferenceList,
   AttributeFormat,
   AttributeName,
+  AttributeNull,
+  AttributeNumber,
+  AttributeString,
   AttributeValue,
   AttributeValueEmptyList,
-  AttributeValueList
+  AttributeValueList,
+  AttributeValueRawJson
 }
 import spray.json.DefaultJsonProtocol._
 import spray.json._
@@ -35,6 +40,8 @@ trait CompactEntitySerialization {
   // json key for the attributes content. If this ever changes, make sure to also change the triggers
   // on the `ENTITY` database table
   val ATTRS_KEY: String = "attrs"
+  // json key for the "query" values, used for sorting and filtering in entityQuery
+  val QUERY_KEY: String = "q"
 
   // the current serialization version
   val CURRENT_VERSION: Int = 2
@@ -68,10 +75,27 @@ trait CompactEntitySerialization {
     }.toVector
     val attrsJson = JsArray(sqlAttrs.map(_.toJson))
 
+    val queryAttrs: Map[String, JsValue] = attributes.map { case (name, value) =>
+      val aname = AttributeName.toDelimitedName(name)
+      val jsval: JsValue = value match {
+        case AttributeString(s)                      => JsString(s.take(500)) // TODO: what limit should we set?
+        case AttributeNumber(n)                      => JsNumber(n)
+        case AttributeBoolean(b)                     => JsBoolean(b)
+        case AttributeValueList(l)                   => JsNumber(l.size)
+        case AttributeEntityReferenceList(l)         => JsNumber(l.size)
+        case AttributeEntityReference(_, entityName) => JsString(entityName)
+        case AttributeValueRawJson(js)               => js
+        case AttributeValueEmptyList | AttributeEntityReferenceEmptyList => JsNumber(0) // or should we use Int.max?
+        case AttributeNull                                               => JsNull
+      }
+      aname -> jsval
+    }
+
     JsObject(
       Map(
         VERSION_KEY -> JsNumber(CURRENT_VERSION),
-        ATTRS_KEY -> attrsJson
+        ATTRS_KEY -> attrsJson,
+        QUERY_KEY -> JsObject(queryAttrs)
       )
     )
   }
@@ -89,6 +113,10 @@ trait CompactEntitySerialization {
   val slickAttrsPath: String = s"$$.${ATTRS_KEY}"
   def slickAttributePath(attributeName: String): String = s"""${slickAttrsPath}."${attributeName}""""
   def slickAttributePath(attributeName: AttributeName): String = slickAttributePath(toDelimitedName(attributeName))
+
+  val slickQueryPath: String = s"$$.${QUERY_KEY}"
+  def slickQueryPath(attributeName: String): String = s"""${slickQueryPath}."${attributeName}""""
+  def slickQueryPath(attributeName: AttributeName): String = slickQueryPath(toDelimitedName(attributeName))
 
   // retrieve the version number from the database's JSON
   private def getVersion(jso: JsObject): Int =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
@@ -55,9 +55,10 @@ trait CompactEntitySerialization {
     // the references themselves are stored in a separate "refs" key
     val jsonAttrs: AttributeMap = attributes.map { case (name, value) =>
       val normalizedValue = value match {
-        case AttributeEntityReferenceList(l)         => AttributeNumber(l.size)
-        case AttributeEntityReference(_, entityName) => AttributeString(entityName)
-        case x                                       => x
+        case AttributeEntityReferenceList(l) if l.isEmpty => AttributeEntityReferenceEmptyList
+        case AttributeEntityReferenceList(l)              => AttributeNumber(l.size)
+        case AttributeEntityReference(_, entityName)      => AttributeString(entityName)
+        case x                                            => x
       }
       name -> normalizedValue
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerialization.scala
@@ -180,12 +180,12 @@ trait CompactEntitySerialization {
       case Some(jsa: JsArray) => jsa
       case None =>
         throw new CompactEntityDeserializationException(
-          s"wanted an references array; found none"
+          s"wanted a references array; found none"
         )
       // version could not be determined
       case Some(otherJsValue) =>
         throw new CompactEntityDeserializationException(
-          s"wanted an references array; found a ${otherJsValue.getClass.getName}"
+          s"wanted a references array; found a ${otherJsValue.getClass.getName}"
         )
     }
 
@@ -239,12 +239,12 @@ trait CompactEntitySerialization {
 
         val refs = getReferences(jso).convertTo[Seq[SqlEntityReference]]
         val groupedRefs: Map[String, Seq[SqlEntityReference]] = refs.groupMap(_.a)(identity)
-        // for
+        // discard any references that do not have a matching base attribute
+        val filteredGroupedRefs: Map[String, Seq[SqlEntityReference]] = groupedRefs.filter { case (attributeName, _) =>
+          baseAttrs.contains(AttributeName.fromDelimitedName(attributeName))
+        }
 
-
-
-
-        val refAttrs: AttributeMap = groupedRefs.map { case (attributeName, refSeq) =>
+        val refAttrs: AttributeMap = filteredGroupedRefs.map { case (attributeName, refSeq) =>
           val aname = AttributeName.fromDelimitedName(attributeName)
           val attr: Attribute = if (refSeq.isEmpty) {
             AttributeValueEmptyList // no references, so this is an empty list

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -227,12 +227,12 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
       _ = if (!allExist)
         throw new EntityReferenceNotFoundException("Some entity references do not exist")
 
-      _ <- repository.queries.deleteAllReferencesFrom(workspaceId, batch.map(_.toPointer).toSet)
-      _ <-
-        if (allReferences.nonEmpty)
-          repository.queries.insertReferences(workspaceId, allReferences)
-        else
-          DBIO.successful(0)
+//      _ <- repository.queries.deleteAllReferencesFrom(workspaceId, batch.map(_.toPointer).toSet)
+//      _ <-
+//        if (allReferences.nonEmpty)
+//          repository.queries.insertReferences(workspaceId, allReferences)
+//        else
+//          DBIO.successful(0)
     } yield entitiesCreated
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -227,12 +227,6 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
       _ = if (!allExist)
         throw new EntityReferenceNotFoundException("Some entity references do not exist")
 
-//      _ <- repository.queries.deleteAllReferencesFrom(workspaceId, batch.map(_.toPointer).toSet)
-//      _ <-
-//        if (allReferences.nonEmpty)
-//          repository.queries.insertReferences(workspaceId, allReferences)
-//        else
-//          DBIO.successful(0)
     } yield entitiesCreated
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -2239,21 +2239,35 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     // Define references to form a recursive structure
     val entity4 = Entity("entityName4", "entityType1", Map())
-    val entity3 = Entity("entityName3", "entityType1", Map(
-      AttributeName.withDefaultNS("ref1") -> AttributeEntityReference(entity4.entityType, entity4.name)
-    ))
-    val entity2 = Entity("entityName2", "entityType1", Map(
-      AttributeName.withDefaultNS("ref1") -> AttributeEntityReference(entity4.entityType, entity4.name)
-    ))
-    val entity1 = Entity("entityName1", "entityType1", Map(
-      AttributeName.withDefaultNS("ref") -> AttributeEntityReferenceList(Seq(
-        AttributeEntityReference(entity2.entityType, entity2.name),
-        AttributeEntityReference(entity3.entityType, entity3.name)
-    ))))
+    val entity3 =
+      Entity("entityName3",
+             "entityType1",
+             Map(
+               AttributeName.withDefaultNS("ref1") -> AttributeEntityReference(entity4.entityType, entity4.name)
+             )
+      )
+    val entity2 =
+      Entity("entityName2",
+             "entityType1",
+             Map(
+               AttributeName.withDefaultNS("ref1") -> AttributeEntityReference(entity4.entityType, entity4.name)
+             )
+      )
+    val entity1 = Entity(
+      "entityName1",
+      "entityType1",
+      Map(
+        AttributeName.withDefaultNS("ref") -> AttributeEntityReferenceList(
+          Seq(
+            AttributeEntityReference(entity2.entityType, entity2.name),
+            AttributeEntityReference(entity3.entityType, entity3.name)
+          )
+        )
+      )
+    )
 
     // insert all entities
     insertAndGetAll(Seq(entity4, entity3, entity2, entity1))
-
 
     // Perform the recursive query
     val recursiveReferences = runAndWait(q.recursiveGetEntityReferences(workspaceId, Set(entity1.toPointer)))
@@ -2276,12 +2290,16 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     insertAndGetAll(Seq(entity1, entity2))
 
     // Update the entities to contain a cycle
-    val entity1Update = entity1.copy(attributes = Map(
-      AttributeName.withDefaultNS("ref") -> AttributeEntityReference(entity2.entityType, entity2.name)
-    ))
-    val entity2Update = entity2.copy(attributes = Map(
-      AttributeName.withDefaultNS("ref") -> AttributeEntityReference(entity1.entityType, entity1.name)
-    ))
+    val entity1Update = entity1.copy(attributes =
+      Map(
+        AttributeName.withDefaultNS("ref") -> AttributeEntityReference(entity2.entityType, entity2.name)
+      )
+    )
+    val entity2Update = entity2.copy(attributes =
+      Map(
+        AttributeName.withDefaultNS("ref") -> AttributeEntityReference(entity1.entityType, entity1.name)
+      )
+    )
     runAndWait(q.batchCreateEntities(workspaceId, Seq(entity1Update, entity2Update), insertOnly = false))
 
     // Perform the recursive query

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -2093,9 +2093,6 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     // Insert all entities
     insertAndGetAll(Seq(targetEntity1, sourceEntity1, sourceEntity2, sourceEntity3))
 
-    // these references does not exist in the attributes but makes the underlying rename query think so
-    // TODO FIXME
-
     // Execute renameEntityType and verify the result
     val newTargetType = "newTargetType"
     runAndWait(q.renameEntityType(wsid, targetType, newTargetType)) shouldBe 1
@@ -2132,8 +2129,6 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     // Insert all entities
     insertAndGetAll(Seq(targetEntity1, sourceEntity1))
 
-    // TODO FIXME
-
     // Execute renameEntityType, this time on sourceType which has no references
     val newSourceType = "newSourceType"
     val result = runAndWait(q.renameEntityType(wsid, sourceType, newSourceType))
@@ -2154,7 +2149,6 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     )
   }
 
-  // TODO: times out. Is there a bug?
   it should "handle a list with 10000 entity references efficiently" in withMinimalTestDatabase { _ =>
     // Create target entity type that will be renamed
     val targetType = "largeRefTargetType"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.{
   Attributable,
+  AttributeBoolean,
   AttributeEntityReference,
   AttributeEntityReferenceList,
   AttributeName,
@@ -1087,7 +1088,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
   private val columnFilterCases = List(
     (AttributeNumber(42), "42"),
     (AttributeString("foo"), "foo"),
-    (AttributeString("fOo"), "foO") // case sensitivity check
+    (AttributeString("fOo"), "foO"), // case sensitivity check
+    (AttributeBoolean(true), "TRUE")
   )
 
   behavior of "countEntitiesWithColumnFilter"
@@ -1920,7 +1922,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     )
   }
 
-  it should "handle a list with 10000 entity references efficiently" in withMinimalTestDatabase { _ =>
+  it should "handle a list with 10000 entity references efficiently" ignore withMinimalTestDatabase { _ =>
     // Create target entity type that will be renamed
     val targetType = "largeRefTargetType"
     val targetEntity = Entity("targetEntity", targetType, Map())

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -201,7 +201,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val savedEntity = insertAndGet(entity)
     // get the keys
     val actual = runAndWait(q.getKeys(savedEntity.id))
-    actual shouldBe empty
+    actual should not be empty
+    actual.get.attributeKeys shouldBe "[]"
   }
 
   it should "save keys for an entity with attributes" in withMinimalTestDatabase { _ =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -984,7 +984,25 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val pointers1 = RefMapping(source1, Set(target1, target2))
     val pointers2 = RefMapping(source2, Set(target3, target4, target5))
     val pointers3 = RefMapping(source3, Set(target1, target3, target6))
-    // insert rows TODO FIXME
+    // insert rows
+    val allTargets: Seq[Entity] = Seq(target1, target2, target3, target4, target5, target6).map { targetPointer =>
+      Entity(targetPointer.entityName, targetPointer.entityType, Map())
+    }
+    insertAndGetAll(allTargets)
+    val allSources: Seq[Entity] = Seq(pointers1, pointers2, pointers3).map { refMapping =>
+      Entity(
+        refMapping.from.entityName,
+        refMapping.from.entityType,
+        Map(
+          AttributeName.withDefaultNS("refs") -> AttributeEntityReferenceList(
+            refMapping.to.map { target =>
+              AttributeEntityReference(target.entityType, target.entityName)
+            }.toSeq
+          )
+        )
+      )
+    }
+    insertAndGetAll(allSources)
 
     runAndWait(q.getReferencesFrom(wsid, source1)) should contain theSameElementsAs pointers1.to
     runAndWait(q.getReferencesFrom(wsid, source2)) should contain theSameElementsAs pointers2.to
@@ -999,7 +1017,6 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     // target2 is referenced by source1; target6 is referenced by source3
     runAndWait(q.getReferencesTo(wsid, Seq(target2, target6))) should contain theSameElementsAs Seq(source1, source3)
-
   }
 
   it should "not find entities in other workspaces" in withMinimalTestDatabase { _ =>
@@ -1746,14 +1763,6 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     // Insert all entities
     insertAndGetAll(Seq(targetEntity1, targetEntity2, sourceEntity1, sourceEntity2, sourceEntity3))
-
-    val refMappings = Set(
-      RefMapping(sourceEntity1.toPointer, Set(targetEntity1.toPointer, targetEntity2.toPointer)),
-      RefMapping(sourceEntity2.toPointer, Set(targetEntity2.toPointer)),
-      RefMapping(sourceEntity3.toPointer, Set(targetEntity1.toPointer))
-    )
-
-    // TODO FIXME
 
     // Execute renameEntityType and verify the result
     val newTargetType = "newTargetType"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -264,17 +264,41 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
   behavior of "getReferencesFrom"
 
   it should "insert and delete all" in withMinimalTestDatabase { _ =>
-    // the entity doing the referencing: the "source"
-    val from = EntityPointer("fromType", "fromName")
     // entities being referenced: the "targets"
-    val tos: Seq[EntityPointer] = Range(1, 5) map (idx => EntityPointer("toType", s"toName$idx"))
+    val target1 = Entity(s"toName1", "toType", Map())
+    val target2 = Entity(s"toName2", "toType", Map())
+    val target3 = Entity(s"toName3", "toType", Map())
+    val target4 = Entity(s"toName4", "toType", Map())
+    val target5 = Entity(s"toName5", "toType", Map())
 
-    // source should have no rows in ENTITY_REFS table
-    runAndWait(q.getReferencesFrom(wsid, from)) shouldBe empty
-    // insert rows
-    runAndWait(q.getReferencesFrom(wsid, from)) should contain theSameElementsAs tos
-    // delete rows
-    runAndWait(q.getReferencesFrom(wsid, from)) shouldBe empty
+    val allTargets = Seq(target1, target2, target3, target4, target5)
+
+    // the entity doing the referencing: the "source"
+    val targetRefs = allTargets.map { target =>
+      AttributeEntityReference(target.entityType, target.name)
+    }
+    val sourceEntity = Entity("fromName",
+                              "fromType",
+                              Map(
+                                AttributeName.withDefaultNS("refs") -> AttributeEntityReferenceList(targetRefs)
+                              )
+    )
+
+    // insert targets
+    allTargets.foreach { target =>
+      insertAndGet(target)
+    }
+
+    // source should have no rows in ENTITY_REFS table b/c we haven't inserted it yet
+    runAndWait(q.getReferencesFrom(wsid, sourceEntity.toPointer)) shouldBe empty
+    // insert the source
+    insertAndGet(sourceEntity)
+    runAndWait(q.getReferencesFrom(wsid, sourceEntity.toPointer)) should contain theSameElementsAs allTargets.map(
+      _.toPointer
+    )
+    // delete the source
+    runAndWait(q.deleteEntities(wsid, Seq(sourceEntity.toPointer)))
+    runAndWait(q.getReferencesFrom(wsid, sourceEntity.toPointer)) shouldBe empty
   }
 
   it should "insert for multiple source entities" in withMinimalTestDatabase { _ =>
@@ -291,6 +315,35 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     // sources should have no rows in ENTITY_REFS table
     runAndWait(q.getReferencesFrom(wsid, from1)) shouldBe empty
     runAndWait(q.getReferencesFrom(wsid, from2)) shouldBe empty
+
+    // insert targets
+    (tos1 ++ tos2).toSet[EntityPointer].foreach { targetPointer =>
+      insertAndGet(Entity(targetPointer.entityName, targetPointer.entityType, Map()))
+    }
+    // insert from1 with references of tos1
+    val tos1Refs = tos1.map { target =>
+      AttributeEntityReference(target.entityType, target.entityName)
+    }
+    insertAndGet(
+      Entity(from1.entityName,
+             from1.entityType,
+             Map(
+               AttributeName.withDefaultNS("refs") -> AttributeEntityReferenceList(tos1Refs)
+             )
+      )
+    )
+    // insert from2 with references of tos2
+    val tos2Refs = tos2.map { target =>
+      AttributeEntityReference(target.entityType, target.entityName)
+    }
+    insertAndGet(
+      Entity(from2.entityName,
+             from2.entityType,
+             Map(
+               AttributeName.withDefaultNS("refs") -> AttributeEntityReferenceList(tos2Refs)
+             )
+      )
+    )
 
     runAndWait(q.getReferencesFrom(wsid, from1)) should contain theSameElementsAs tos1
     runAndWait(q.getReferencesFrom(wsid, from2)) should contain theSameElementsAs tos2

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -1027,35 +1027,81 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val source2 = EntityPointer("sourceType", "source2")
 
     // referenced/target entities
-    val target1 = EntityPointer("targetType", "targetName1")
+    val target1 = Entity("targetName1", "targetType", Map())
 
-    val pointers1 = RefMapping(source1, Set(target1))
-    val pointers2 = RefMapping(source2, Set(target1))
-    // insert rows for workspace 1
-    // TODO FIXME
-    // insert rows for workspace 2
-    // TODO FIXME
+    // insert rows for workspace 1: source1 has a reference to target1, source2 does not
+    insertAndGetAll(
+      Seq(
+        target1,
+        Entity(
+          source1.entityName,
+          source1.entityType,
+          Map(
+            AttributeName.withDefaultNS("refs") -> AttributeEntityReferenceList(
+              Seq(AttributeEntityReference("targetType", "targetName1"))
+            )
+          )
+        ),
+        Entity(source2.entityName, source2.entityType, Map())
+      ),
+      wsid
+    )
 
-    runAndWait(q.getReferencesTo(wsid, Seq(target1))) should contain theSameElementsAs Seq(pointers1.from)
-    runAndWait(q.getReferencesTo(wsid2, Seq(target1))) should contain theSameElementsAs Seq(pointers2.from)
+    // insert rows for workspace 2: source2 has a reference to target1, source1 does not
+    insertAndGetAll(
+      Seq(
+        target1,
+        Entity(
+          source1.entityName,
+          source1.entityType,
+          Map(
+          )
+        ),
+        Entity(
+          source2.entityName,
+          source2.entityType,
+          Map(
+            AttributeName.withDefaultNS("refs") -> AttributeEntityReferenceList(
+              Seq(AttributeEntityReference("targetType", "targetName1"))
+            )
+          )
+        )
+      ),
+      wsid2
+    )
+
+    runAndWait(q.getReferencesTo(wsid, Seq(target1.toPointer))) should contain theSameElementsAs Seq(source1)
+    runAndWait(q.getReferencesTo(wsid2, Seq(target1.toPointer))) should contain theSameElementsAs Seq(source2)
   }
 
   it should "exclude entities included in the search" in withMinimalTestDatabase { _ =>
     // define entities
-    val entity1 = EntityPointer("entityType", "name1")
-    val entity2 = EntityPointer("entityType", "name2")
-    val entity3 = EntityPointer("entityType", "name3")
-
     // entity2 references entity1; entity3 references both entity1 and entity2
-    val pointers1 = RefMapping(entity2, Set(entity1))
-    val pointers2 = RefMapping(entity3, Set(entity1, entity2))
+    val entity1 = Entity("name1", "entityType", Map())
+    val entity2 =
+      Entity("name2",
+             "entityType",
+             Map(
+               AttributeName.withDefaultNS("ref1") -> AttributeEntityReference(entity1.entityType, entity1.name)
+             )
+      )
+    val entity3 = Entity(
+      "name3",
+      "entityType",
+      Map(
+        AttributeName.withDefaultNS("ref1") -> AttributeEntityReference(entity1.entityType, entity1.name),
+        AttributeName.withDefaultNS("ref2") -> AttributeEntityReference(entity2.entityType, entity2.name)
+      )
+    )
 
-    // TODO FIXME
+    insertAndGetAll(Seq(entity1, entity2, entity3))
 
     // asking for references to entity1 and entity2 should exclude entity2 because entity2 is in the search criteria,
     //  even though entity2 references entity1
-    val expected = Set(entity3)
-    runAndWait(q.getReferencesTo(wsid, Seq(entity1, entity2))).toSet should contain theSameElementsAs expected
+    val expected = Set(entity3.toPointer)
+    runAndWait(
+      q.getReferencesTo(wsid, Seq(entity1.toPointer, entity2.toPointer))
+    ).toSet should contain theSameElementsAs expected
 
   }
 
@@ -1078,7 +1124,27 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val pointers2 = RefMapping(source2, Set(target2))
     val pointers3 = RefMapping(source3, Set(target1))
 
-    // TODO FIXME
+    // insert targets
+    insertAndGetAll(
+      Seq(target1, target2, target3).map { targetPointer =>
+        Entity(targetPointer.entityName, targetPointer.entityType, Map())
+      }
+    )
+    // insert sources and their references to the targets
+    val sourcesWithReferences = Seq(pointers1, pointers2, pointers3).map { refMapping =>
+      Entity(
+        refMapping.from.entityName,
+        refMapping.from.entityType,
+        Map(
+          AttributeName.withDefaultNS("refs") -> AttributeEntityReferenceList(
+            refMapping.to.map { target =>
+              AttributeEntityReference(target.entityType, target.entityName)
+            }.toSeq
+          )
+        )
+      )
+    }
+    insertAndGetAll(sourcesWithReferences)
 
     val expected = Set(source2, source3)
     runAndWait(q.getReferencesToType(wsid, targetType1)) should contain theSameElementsAs expected
@@ -1086,20 +1152,30 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
   it should "not return source entities of the same type" in withMinimalTestDatabase { _ =>
     // define entities
-    val entity1 = EntityPointer("entityTypeA", "name1")
-    val entity2 = EntityPointer("entityTypeA", "name2")
-    val entity3 = EntityPointer("entityTypeB", "name3")
-
     // entity2 references entity1; entity3 references both entity1 and entity2
-    val pointers1 = RefMapping(entity2, Set(entity1))
-    val pointers2 = RefMapping(entity3, Set(entity1, entity2))
+    // entity3 has a different entity type
+    val entity1 = Entity("name1", "entityTypeA", Map())
+    val entity2 =
+      Entity("name2",
+             "entityTypeA",
+             Map(
+               AttributeName.withDefaultNS("ref1") -> AttributeEntityReference(entity1.entityType, entity1.name)
+             )
+      )
+    val entity3 = Entity(
+      "name3",
+      "entityTypeB",
+      Map(
+        AttributeName.withDefaultNS("ref1") -> AttributeEntityReference(entity1.entityType, entity1.name),
+        AttributeName.withDefaultNS("ref2") -> AttributeEntityReference(entity2.entityType, entity2.name)
+      )
+    )
 
-    // insert rows
-    // TODO FIXME
+    insertAndGetAll(Seq(entity1, entity2, entity3))
 
     // asking for references to entity1 should exclude entity2 because entity2 is of the same type,
     //  even though entity2 references entity1
-    runAndWait(q.getReferencesToType(wsid, "entityTypeA")).toSet should contain theSameElementsAs Set(entity3)
+    runAndWait(q.getReferencesToType(wsid, "entityTypeA")).toSet should contain theSameElementsAs Set(entity3.toPointer)
 
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -1753,7 +1753,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       RefMapping(sourceEntity1.toPointer, Set(originalEntity.toPointer)),
       RefMapping(sourceEntity2.toPointer, Set(originalEntity.toPointer))
     )
-    runAndWait(q.insertReferences(wsid, refMappings))
+    // TODO FIXME
 
     // Verify references to the original entity before rename
     runAndWait(q.getReferencesTo(wsid, Seq(originalEntity.toPointer))) should contain theSameElementsAs Seq(
@@ -1999,7 +1999,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     )
   }
 
-  it should "handle a list with 10000 entity references efficiently" ignore withMinimalTestDatabase { _ =>
+  // TODO: times out. Is there a bug?
+  it should "handle a list with 10000 entity references efficiently" in withMinimalTestDatabase { _ =>
     // Create target entity type that will be renamed
     val targetType = "largeRefTargetType"
     val targetEntity = Entity("targetEntity", targetType, Map())
@@ -2019,10 +2020,6 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     // Insert entities
     insertAndGet(targetEntity)
     insertAndGet(sourceEntity)
-
-    // Insert references - we need 1000 identical references
-    val refMapping = RefMapping(sourceEntity.toPointer, Set(targetEntity.toPointer))
-    // TODO FIXME
 
     // Execute renameEntityType and verify the result
     val newTargetType = "newLargeRefTargetType"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -200,8 +200,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val savedEntity = insertAndGet(entity)
     // get the keys
     val actual = runAndWait(q.getKeys(savedEntity.id))
-    actual should not be empty
-    actual.get.attributeKeys shouldBe "[]"
+    actual shouldBe empty
   }
 
   it should "save keys for an entity with attributes" in withMinimalTestDatabase { _ =>
@@ -262,7 +261,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     runAndWait(q.existsAll(wsid, refs)) shouldBe false
   }
 
-  behavior of "insertReferences, getReferencesFrom, deleteAllReferencesFrom"
+  behavior of "getReferencesFrom"
 
   it should "insert and delete all" in withMinimalTestDatabase { _ =>
     // the entity doing the referencing: the "source"
@@ -273,10 +272,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     // source should have no rows in ENTITY_REFS table
     runAndWait(q.getReferencesFrom(wsid, from)) shouldBe empty
     // insert rows
-    runAndWait(q.insertReferences(wsid, Set(RefMapping(from, tos.toSet)))) shouldBe tos.size
     runAndWait(q.getReferencesFrom(wsid, from)) should contain theSameElementsAs tos
     // delete rows
-    runAndWait(q.deleteAllReferencesFrom(wsid, Set(from))) shouldBe tos.size
     runAndWait(q.getReferencesFrom(wsid, from)) shouldBe empty
   }
 
@@ -294,115 +291,9 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     // sources should have no rows in ENTITY_REFS table
     runAndWait(q.getReferencesFrom(wsid, from1)) shouldBe empty
     runAndWait(q.getReferencesFrom(wsid, from2)) shouldBe empty
-    // insert
-    runAndWait(
-      q.insertReferences(wsid, Set(RefMapping(from1, tos1.toSet), RefMapping(from2, tos2.toSet)))
-    ) shouldBe tos1.size + tos2.size
+
     runAndWait(q.getReferencesFrom(wsid, from1)) should contain theSameElementsAs tos1
     runAndWait(q.getReferencesFrom(wsid, from2)) should contain theSameElementsAs tos2
-  }
-
-  it should "delete references for multiple entities" in withMinimalTestDatabase { _ =>
-    // the entities doing the referencing: the "sources"
-    val from1 = EntityPointer("fromType", "fromName1")
-    val from2 = EntityPointer("fromType", "fromName2")
-    val from3 = EntityPointer("fromType", "fromName3")
-    // referenced/target entities
-    val target1 = EntityPointer("targetType", "targetName1")
-    val target2 = EntityPointer("targetType", "targetName2")
-    val target3 = EntityPointer("targetType", "targetName3")
-    val target4 = EntityPointer("targetType", "targetName4")
-    val target5 = EntityPointer("targetType", "targetName5")
-    val target6 = EntityPointer("targetType", "targetName6")
-
-    // source should have no rows in ENTITY_REFS table
-    runAndWait(q.getReferencesFrom(wsid, from1)) shouldBe empty
-    runAndWait(q.getReferencesFrom(wsid, from2)) shouldBe empty
-    runAndWait(q.getReferencesFrom(wsid, from3)) shouldBe empty
-
-    // references to insert
-    val pointers1 = RefMapping(from1, Set(target1, target2))
-    val pointers2 = RefMapping(from2, Set(target2, target3, target4))
-    val pointers3 = RefMapping(from3, Set(target4, target5, target6))
-
-    // insert rows
-    runAndWait(
-      q.insertReferences(wsid, Set(pointers1, pointers2, pointers3))
-    ) shouldBe (pointers1.to.size + pointers2.to.size + pointers3.to.size)
-    runAndWait(q.getReferencesFrom(wsid, from1)) should contain theSameElementsAs pointers1.to
-    runAndWait(q.getReferencesFrom(wsid, from2)) should contain theSameElementsAs pointers2.to
-    runAndWait(q.getReferencesFrom(wsid, from3)) should contain theSameElementsAs pointers3.to
-    // delete rows
-    runAndWait(
-      q.deleteAllReferencesFrom(wsid, Set(from1, from2, from3))
-    ) shouldBe (pointers1.to.size + pointers2.to.size + pointers3.to.size)
-    runAndWait(q.getReferencesFrom(wsid, from1)) shouldBe empty
-    runAndWait(q.getReferencesFrom(wsid, from2)) shouldBe empty
-    runAndWait(q.getReferencesFrom(wsid, from3)) shouldBe empty
-  }
-
-  it should "only delete references in the given workspace" in withMinimalTestDatabase { _ =>
-    // the entities doing the referencing: the "sources"
-    val from1 = EntityPointer("fromType", "fromName1")
-    // referenced/target entities
-    val target1 = EntityPointer("targetType", "targetName1")
-    val target2 = EntityPointer("targetType", "targetName2")
-
-    val wsid2 = minimalTestData.workspace2.workspaceIdAsUUID
-
-    // Insert references into different workspaces. Note that both workspaces reuse the "from" entity type/name
-    runAndWait(
-      q.insertReferences(wsid, Set(RefMapping(from1, Set(target1))))
-    )
-    runAndWait(
-      q.insertReferences(wsid2, Set(RefMapping(from1, Set(target2))))
-    )
-    runAndWait(q.getReferencesFrom(wsid, from1)) should contain theSameElementsAs Set(target1)
-    runAndWait(q.getReferencesFrom(wsid2, from1)) should contain theSameElementsAs Set(target2)
-    // delete rows from workspace 1 only
-    runAndWait(q.deleteAllReferencesFrom(wsid, Set(from1))) shouldBe 1
-    runAndWait(q.getReferencesFrom(wsid, from1)) shouldBe empty
-    runAndWait(q.getReferencesFrom(wsid2, from1)) should contain theSameElementsAs Set(target2)
-  }
-
-  behavior of "deleteAllReferencesFromType"
-
-  it should "only delete references for the given type" in withMinimalTestDatabase { _ =>
-    // referencing/source entities
-    val sourceType1 = "source1"
-    val sourceType2 = "source2"
-    val source1 = EntityPointer(sourceType1, "source1") // source1 and source2 have the same type
-    val source2 = EntityPointer(sourceType1, "source2")
-    val source3 = EntityPointer(sourceType2, "source3") // source3 has a different type
-
-    // referenced/target entities
-    val target1 = EntityPointer("targetType", "targetName1")
-    val target2 = EntityPointer("targetType", "targetName2")
-    val target3 = EntityPointer("targetType", "targetName3")
-    val target4 = EntityPointer("targetType", "targetName4")
-    val target5 = EntityPointer("targetType", "targetName5")
-    val target6 = EntityPointer("targetType", "targetName6")
-    // source should have no rows in ENTITY_REFS table
-    val pointers1 = RefMapping(source1, Set(target1, target2))
-    val pointers2 = RefMapping(source2, Set(target3, target4, target5))
-    val pointers3 = RefMapping(source3, Set(target1, target3, target6))
-    // insert rows
-    runAndWait(
-      q.insertReferences(wsid, Set(pointers1, pointers2, pointers3))
-    ) shouldBe (pointers1.to.size + pointers2.to.size + pointers3.to.size)
-    runAndWait(q.getReferencesFrom(wsid, source1)) should contain theSameElementsAs pointers1.to
-    runAndWait(q.getReferencesFrom(wsid, source2)) should contain theSameElementsAs pointers2.to
-    runAndWait(q.getReferencesFrom(wsid, source3)) should contain theSameElementsAs pointers3.to
-    // delete rows
-    runAndWait(
-      q.deleteAllReferencesFromType(
-        wsid,
-        sourceType1
-      )
-    ) shouldBe (pointers1.to.size + pointers2.to.size)
-    runAndWait(q.getReferencesFrom(wsid, source1)) shouldBe empty
-    runAndWait(q.getReferencesFrom(wsid, source2)) shouldBe empty
-    runAndWait(q.getReferencesFrom(wsid, source3)) should contain theSameElementsAs pointers3.to
   }
 
   behavior of "listEntityKeys"
@@ -1038,10 +929,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val pointers1 = RefMapping(source1, Set(target1, target2))
     val pointers2 = RefMapping(source2, Set(target3, target4, target5))
     val pointers3 = RefMapping(source3, Set(target1, target3, target6))
-    // insert rows
-    runAndWait(
-      q.insertReferences(wsid, Set(pointers1, pointers2, pointers3))
-    ) shouldBe (pointers1.to.size + pointers2.to.size + pointers3.to.size)
+    // insert rows TODO FIXME
+
     runAndWait(q.getReferencesFrom(wsid, source1)) should contain theSameElementsAs pointers1.to
     runAndWait(q.getReferencesFrom(wsid, source2)) should contain theSameElementsAs pointers2.to
     runAndWait(q.getReferencesFrom(wsid, source3)) should contain theSameElementsAs pointers3.to
@@ -1071,9 +960,9 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val pointers1 = RefMapping(source1, Set(target1))
     val pointers2 = RefMapping(source2, Set(target1))
     // insert rows for workspace 1
-    runAndWait(q.insertReferences(wsid, Set(pointers1))) shouldBe pointers1.to.size
+    // TODO FIXME
     // insert rows for workspace 2
-    runAndWait(q.insertReferences(wsid2, Set(pointers2))) shouldBe pointers2.to.size
+    // TODO FIXME
 
     runAndWait(q.getReferencesTo(wsid, Seq(target1))) should contain theSameElementsAs Seq(pointers1.from)
     runAndWait(q.getReferencesTo(wsid2, Seq(target1))) should contain theSameElementsAs Seq(pointers2.from)
@@ -1089,7 +978,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val pointers1 = RefMapping(entity2, Set(entity1))
     val pointers2 = RefMapping(entity3, Set(entity1, entity2))
 
-    runAndWait(q.insertReferences(wsid, Set(pointers1, pointers2))) shouldBe pointers1.to.size + pointers2.to.size
+    // TODO FIXME
 
     // asking for references to entity1 and entity2 should exclude entity2 because entity2 is in the search criteria,
     //  even though entity2 references entity1
@@ -1117,9 +1006,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val pointers2 = RefMapping(source2, Set(target2))
     val pointers3 = RefMapping(source3, Set(target1))
 
-    runAndWait(
-      q.insertReferences(wsid, Set(pointers1, pointers2, pointers3))
-    ) shouldBe pointers1.to.size + pointers2.to.size + pointers3.to.size
+    // TODO FIXME
 
     val expected = Set(source2, source3)
     runAndWait(q.getReferencesToType(wsid, targetType1)) should contain theSameElementsAs expected
@@ -1136,9 +1023,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val pointers2 = RefMapping(entity3, Set(entity1, entity2))
 
     // insert rows
-    runAndWait(
-      q.insertReferences(wsid, Set(pointers1, pointers2))
-    ) shouldBe pointers1.to.size + pointers2.to.size
+    // TODO FIXME
 
     // asking for references to entity1 should exclude entity2 because entity2 is of the same type,
     //  even though entity2 references entity1
@@ -1812,7 +1697,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       RefMapping(sourceEntity3.toPointer, Set(targetEntity1.toPointer))
     )
 
-    runAndWait(q.insertReferences(wsid, refMappings))
+    // TODO FIXME
 
     // Execute renameEntityType and verify the result
     val newTargetType = "newTargetType"
@@ -1922,16 +1807,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     insertAndGetAll(Seq(targetEntity1, sourceEntity1, sourceEntity2, sourceEntity3))
 
     // these references does not exist in the attributes but makes the underlying rename query think so
-    runAndWait(
-      q.insertReferences(
-        wsid,
-        Set(
-          RefMapping(sourceEntity1.toPointer, Set(targetEntity1.toPointer)),
-          RefMapping(sourceEntity2.toPointer, Set(targetEntity1.toPointer)),
-          RefMapping(sourceEntity3.toPointer, Set(targetEntity1.toPointer))
-        )
-      )
-    )
+    // TODO FIXME
 
     // Execute renameEntityType and verify the result
     val newTargetType = "newTargetType"
@@ -1969,13 +1845,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     // Insert all entities
     insertAndGetAll(Seq(targetEntity1, sourceEntity1))
 
-    runAndWait(
-      q.insertReferences(wsid,
-                         Set(
-                           RefMapping(sourceEntity1.toPointer, Set(targetEntity1.toPointer))
-                         )
-      )
-    )
+    // TODO FIXME
 
     // Execute renameEntityType, this time on sourceType which has no references
     val newSourceType = "newSourceType"
@@ -2020,7 +1890,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     // Insert references - we need 1000 identical references
     val refMapping = RefMapping(sourceEntity.toPointer, Set(targetEntity.toPointer))
-    runAndWait(q.insertReferences(wsid, Set(refMapping)))
+    // TODO FIXME
 
     // Execute renameEntityType and verify the result
     val newTargetType = "newLargeRefTargetType"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
+import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
+import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization.SqlEntityData
 import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.{
   Attributable,
@@ -1825,12 +1827,6 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     )
     insertAndGetAll(Seq(sourceEntity1, sourceEntity2))
 
-    val refMappings = Set(
-      RefMapping(sourceEntity1.toPointer, Set(originalEntity.toPointer)),
-      RefMapping(sourceEntity2.toPointer, Set(originalEntity.toPointer))
-    )
-    // TODO FIXME
-
     // Verify references to the original entity before rename
     runAndWait(q.getReferencesTo(wsid, Seq(originalEntity.toPointer))) should contain theSameElementsAs Seq(
       sourceEntity1.toPointer,
@@ -1863,6 +1859,89 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       sourceEntity1.toPointer,
       sourceEntity2.toPointer
     )
+  }
+
+  it should "rename in both $.attrs and $.refs when updating references" in withMinimalTestDatabase { _ =>
+    // Create the original entity
+    val entityType = "testType"
+    val originalEntity = Entity("originalName", entityType, Map())
+    insertAndGet(originalEntity)
+
+    // Create source entities referencing the original entity
+    val sourceEntity1 = Entity(
+      "sourceEntity1",
+      "sourceType",
+      Map(
+        AttributeName.withDefaultNS("refList") -> AttributeEntityReferenceList(
+          Seq(originalEntity.toReference)
+        )
+      )
+    )
+    val sourceEntity2 = Entity(
+      "sourceEntity2",
+      "sourceType",
+      Map(
+        AttributeName.withDefaultNS("ref") -> originalEntity.toReference
+      )
+    )
+    insertAndGetAll(Seq(sourceEntity1, sourceEntity2))
+
+    // Rename the entity
+    val newName = "newName"
+    runAndWait(q.renameEntity(wsid, entityType, originalEntity.name, newName)) shouldBe 1
+
+    // Verify the entity was renamed
+    val renamedEntity = runAndWait(q.getEntity(wsid, entityType, newName)).get.toEntity
+    renamedEntity.name shouldBe newName
+
+    // verify that "originalName" is now "newName" in $.attrs for sourceEntity2
+    val source2 = runAndWait(q.getEntity(wsid, "sourceType", "sourceEntity2"))
+    source2 should not be empty
+    source2.get.attributes should not be empty
+    val rawData2 =
+      source2.get.attributes.get.parseJson.convertTo[SqlEntityData](CompactEntitySerialization.sqlEntityDataFormat)
+    rawData2.attrs(AttributeName.withDefaultNS("ref")) shouldBe AttributeString("newName")
+
+    // N.B. sourceEntity1 has a reference list, so it doesn't get the rename in $.attrs
+    // verify that $.attrs for sourceEntity1 is still `1`
+    val source1 = runAndWait(q.getEntity(wsid, "sourceType", "sourceEntity1"))
+    source1 should not be empty
+    source1.get.attributes should not be empty
+    val rawData1 =
+      source1.get.attributes.get.parseJson.convertTo[SqlEntityData](CompactEntitySerialization.sqlEntityDataFormat)
+    rawData1.attrs(AttributeName.withDefaultNS("refList")) shouldBe AttributeNumber(1)
+
+  }
+
+  it should "respect entity type when renaming" in withMinimalTestDatabase { _ =>
+    // Create the original entity
+    val entityType = "testType"
+    val originalEntity = Entity("originalName", entityType, Map())
+    insertAndGet(originalEntity)
+
+    // Create another entity with the same name but a different type
+    val otherEntityType = s"$entityType-other"
+    val otherEntity = Entity(originalEntity.name, otherEntityType, Map())
+    insertAndGet(otherEntity)
+
+    // Rename the entity
+    val newName = "newName"
+    runAndWait(q.renameEntity(wsid, entityType, originalEntity.name, newName)) shouldBe 1
+
+    // Verify the entity was renamed
+    val renamedEntity = runAndWait(q.getEntity(wsid, entityType, newName)).get.toEntity
+    renamedEntity.name shouldBe newName
+
+    // Verify the old name no longer exists
+    runAndWait(q.getEntity(wsid, entityType, originalEntity.name)) shouldBe None
+
+    // Verify the other entity still exists
+    val otherEntityLookup = runAndWait(q.getEntity(wsid, otherEntity.entityType, otherEntity.name)).get.toEntity
+    otherEntityLookup shouldBe otherEntity
+
+    // Verify nothing exists at the other entity's type plus the new name
+    val otherEntityRenamedLookup = runAndWait(q.getEntity(wsid, otherEntity.entityType, newName))
+    otherEntityRenamedLookup shouldBe None
   }
 
   behavior of "renameEntityType"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -141,7 +141,8 @@ class EntityServiceCompactMigrationSpec
 
   behavior of "Compact Entity Migration"
   testWorkspaces.foreach { case (workspace, expectedCount) =>
-    it should s"migrate to compact entities for workspace ${workspace.toWorkspaceName}" in withTestDataServices {
+    // TODO CORE-543: re-enable tests
+    it should s"migrate to compact entities for workspace ${workspace.toWorkspaceName}" ignore withTestDataServices {
       apiService =>
         // entity data is already loaded into legacy tables via withTestDataServices
 
@@ -191,7 +192,8 @@ class EntityServiceCompactMigrationSpec
     }
   }
 
-  it should s"migrate to compact entities with various attribute data types" in withTestDataServices { apiService =>
+  // TODO CORE-543: re-enable test
+  it should s"migrate to compact entities with various attribute data types" ignore withTestDataServices { apiService =>
     val workspace = testData.workspace // has some entities we can use to test references
 
     // various attribute types to ensure migration works for all of them

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -206,7 +206,7 @@ class EntityServiceCompactMigrationSpec
         """{"foo":"bar", "nested": {"stuff": [2,3,4,false]}}""".parseJson
       ),
       AttributeName.withDefaultNS("jsonArrAttr") -> AttributeValueRawJson("""[1,2,3,[4,5,6],[7,8,9]]""".parseJson),
-      /* TODO CORE-473: this migrates as an AttributeString, not AttributeValueRawJson. Does it matter?
+      /* This migrates as an AttributeString, not AttributeValueRawJson. We are ok with that.
       AttributeName.withDefaultNS("jsonStrAttr") -> AttributeValueRawJson(
         """"this is a string parsed as json"""".parseJson
       ),
@@ -218,7 +218,7 @@ class EntityServiceCompactMigrationSpec
                                                                                   testData.sample1.name
       ), // same as previous, to test de-duplication when inserting to ENTITY_REFS
       AttributeName.withDefaultNS("emptyList") -> AttributeValueEmptyList,
-      // TODO CORE-473: this migrates as an AttributeValueEmptyList. Does it matter? Both result in `[]`
+      // This migrates as an AttributeValueEmptyList. We are ok with that; both result in `[]`
       // AttributeName.withDefaultNS("emptyRefList") -> AttributeEntityReferenceEmptyList,
       AttributeName.withDefaultNS("valueList") -> AttributeValueList(
         Seq(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -95,8 +95,6 @@ class CompactEntityProviderSpec
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.getEntities(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityVersions(any(), any())).thenReturn(DBIO.successful(Seq()))
-    when(mockQuery.deleteAllReferencesFrom(any(), any())).thenReturn(DBIO.successful(-1))
-    when(mockQuery.insertReferences(any(), any())).thenReturn(DBIO.successful(-1))
 
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
@@ -111,8 +109,6 @@ class CompactEntityProviderSpec
 
     // should have called one batch-insert to write the entities
     verify(mockQuery, times(1)).batchCreateEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), any())
-    // entities have no references, so it should skip insertReferences
-    verify(mockQuery, never()).insertReferences(any(), any())
   }
 
   it should "issue multiple insert statements when given large batches" in {
@@ -121,8 +117,6 @@ class CompactEntityProviderSpec
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.getEntities(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityVersions(any(), any())).thenReturn(DBIO.successful(Seq()))
-    when(mockQuery.deleteAllReferencesFrom(any(), any())).thenReturn(DBIO.successful(-1))
-    when(mockQuery.insertReferences(any(), any())).thenReturn(DBIO.successful(-1))
 
     val config = CompactEntityProviderConfig(batchUpsertBatchSize = 25) // pretty small to force batching
 
@@ -146,9 +140,6 @@ class CompactEntityProviderSpec
     // should have called batchCreateEntities multiple times to write the entities
     verify(mockQuery, Mockito.atLeast(2))
       .batchCreateEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), any())
-    // entities have no references, so it should skip insertReferences
-    verify(mockQuery, never()).insertReferences(any(), any())
-
   }
 
   it should "ask to insert references" in {
@@ -157,8 +148,6 @@ class CompactEntityProviderSpec
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.getEntities(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityVersions(any(), any())).thenReturn(DBIO.successful(Seq()))
-    when(mockQuery.deleteAllReferencesFrom(any(), any())).thenReturn(DBIO.successful(-1))
-    when(mockQuery.insertReferences(any(), any())).thenReturn(DBIO.successful(-1))
 
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
@@ -193,14 +182,6 @@ class CompactEntityProviderSpec
 
     // should have called one batch-insert to write the entities
     verify(mockQuery, times(1)).batchCreateEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), any())
-    // entities found references, so should ask to upsert those.
-    // given the mock response defined above, we expect references from name2->targetName and name3->targetName
-    verify(mockQuery, times(1)).insertReferences(defaultWorkspace.workspaceIdAsUUID,
-                                                 Set(
-                                                   RefMapping(ref2, Set(refTarget)),
-                                                   RefMapping(ref3, Set(refTarget))
-                                                 )
-    )
   }
 
   "copyEntities" should "have tests" is pending
@@ -226,8 +207,6 @@ class CompactEntityProviderSpec
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(None)) // first request finds nothing
       .thenReturn(DBIO.successful(Some(createdEntityRec))) // second request finds the entity we saved
-    when(mockQuery.insertReferences(any(), any()))
-      .thenReturn(DBIO.successful(0))
 
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
@@ -242,7 +221,6 @@ class CompactEntityProviderSpec
                                           entityToCreate.entityType,
                                           entityToCreate.name
     )
-    verify(mockQuery, times(1)).insertReferences(defaultWorkspace.workspaceIdAsUUID, Set())
   }
 
   it should "persist an entity with simple attributes" in {
@@ -269,8 +247,6 @@ class CompactEntityProviderSpec
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(None)) // first request finds nothing
       .thenReturn(DBIO.successful(Some(createdEntityRec))) // second request finds the entity we saved
-    when(mockQuery.insertReferences(any(), any()))
-      .thenReturn(DBIO.successful(0))
 
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
@@ -285,7 +261,6 @@ class CompactEntityProviderSpec
                                           entityToCreate.entityType,
                                           entityToCreate.name
     )
-    verify(mockQuery, times(1)).insertReferences(defaultWorkspace.workspaceIdAsUUID, Set())
   }
 
   it should "persist an entity with references" in {
@@ -323,8 +298,6 @@ class CompactEntityProviderSpec
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(None)) // first request finds nothing
       .thenReturn(DBIO.successful(Some(createdEntityRec))) // second request finds the entity we saved
-    when(mockQuery.insertReferences(any(), any()))
-      .thenReturn(DBIO.successful(2))
 
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
@@ -346,22 +319,6 @@ class CompactEntityProviderSpec
                                           entityToCreate.entityType,
                                           entityToCreate.name
     )
-    verify(mockQuery, never()).deleteAllReferencesFrom(any(), any())
-
-    verify(mockQuery, times(1)).insertReferences(
-      defaultWorkspace.workspaceIdAsUUID,
-      Set(
-        RefMapping(
-          entityToCreate.toPointer,
-          Set(
-            EntityPointer("referencedType", "referencedName0"),
-            EntityPointer("referencedType", "referencedName1"),
-            EntityPointer("referencedType", "referencedName2")
-          )
-        )
-      )
-    )
-
   }
 
   it should "throw EntityReferenceNotFoundException if this entity's references are missing" in {
@@ -408,8 +365,6 @@ class CompactEntityProviderSpec
                                           entityToCreate.entityType,
                                           entityToCreate.name
     )
-    verify(mockQuery, never()).deleteAllReferencesFrom(any(), any())
-    verify(mockQuery, never()).insertReferences(any(), any())
   }
 
   it should "throw RawlsExceptionWithErrorReport if this type & name already exists" in {
@@ -444,8 +399,6 @@ class CompactEntityProviderSpec
 
     verify(mockQuery, never()).existsAll(defaultWorkspace.workspaceIdAsUUID, Set())
     verify(mockQuery, never()).createEntity(defaultWorkspace.workspaceIdAsUUID, entityToCreate)
-    verify(mockQuery, never()).deleteAllReferencesFrom(any(), any())
-    verify(mockQuery, never()).insertReferences(any(), any())
   }
 
   private val illegalEntities = Map(
@@ -474,8 +427,6 @@ class CompactEntityProviderSpec
       verify(mockQuery, never()).getEntity(any(), any(), any())
       verify(mockQuery, never()).existsAll(any(), any())
       verify(mockQuery, never()).createEntity(any(), any())
-      verify(mockQuery, never()).deleteAllReferencesFrom(any(), any())
-      verify(mockQuery, never()).insertReferences(any(), any())
     }
   }
 
@@ -518,7 +469,6 @@ class CompactEntityProviderSpec
 
     val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
     when(mockQuery.getReferencesTo(any(), any())).thenReturn(DBIO.successful(Seq()))
-    when(mockQuery.deleteAllReferencesFrom(any(), any())).thenReturn(DBIO.successful(1))
     when(mockQuery.deleteEntities(any(), any())).thenReturn(DBIO.successful(0))
     when(
       mockQuery.getEntity(any[UUID],
@@ -543,9 +493,6 @@ class CompactEntityProviderSpec
 
     verify(mockQuery, times(1)).getReferencesTo(defaultWorkspace.workspaceIdAsUUID,
                                                 Seq(entity1.toPointer, entity2.toPointer)
-    )
-    verify(mockQuery, times(1)).deleteAllReferencesFrom(defaultWorkspace.workspaceIdAsUUID,
-                                                        Set(entity1.toPointer, entity2.toPointer)
     )
     verify(mockQuery, times(1)).batchHide(defaultWorkspace.workspaceIdAsUUID, Seq(entity1.toPointer, entity2.toPointer))
   }
@@ -595,7 +542,6 @@ class CompactEntityProviderSpec
 
     val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
     when(mockQuery.getReferencesTo(any(), any())).thenReturn(DBIO.successful(Seq(referencingEntity.toPointer)))
-    when(mockQuery.deleteAllReferencesFrom(any(), any())).thenReturn(DBIO.successful(1))
     when(
       mockQuery.getEntity(any[UUID],
                           ArgumentMatchers.eq(createdEntityRec1.entityType),
@@ -620,9 +566,6 @@ class CompactEntityProviderSpec
     }
     result shouldBe a[DeleteEntitiesConflictException]
 
-    verify(mockQuery, never()).deleteAllReferencesFrom(defaultWorkspace.workspaceIdAsUUID,
-                                                       Set(entity1.toPointer, entity2.toPointer)
-    )
     verify(mockQuery, never()).batchHide(defaultWorkspace.workspaceIdAsUUID, Seq(entity1.toPointer, entity2.toPointer))
   }
 
@@ -633,7 +576,6 @@ class CompactEntityProviderSpec
 
     val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
     when(mockQuery.getReferencesToType(any(), any())).thenReturn(DBIO.successful(Seq()))
-    when(mockQuery.deleteAllReferencesFromType(any(), any())).thenReturn(DBIO.successful(1))
     when(mockQuery.deleteEntitiesOfType(any(), any())).thenReturn(DBIO.successful(0))
     when(mockQuery.batchHideType(any(), any())).thenReturn(DBIO.successful(1))
 
@@ -643,7 +585,6 @@ class CompactEntityProviderSpec
     Await.result(provider.deleteEntitiesOfType(entityType, defaultRequestContext), atMost)
 
     verify(mockQuery, times(1)).getReferencesToType(defaultWorkspace.workspaceIdAsUUID, entityType)
-    verify(mockQuery, times(1)).deleteAllReferencesFromType(defaultWorkspace.workspaceIdAsUUID, entityType)
     verify(mockQuery, times(1)).batchHideType(defaultWorkspace.workspaceIdAsUUID, entityType)
   }
 
@@ -666,7 +607,6 @@ class CompactEntityProviderSpec
 
     val mockQuery = mock[slickDataSource.dataAccess.compactEntityQuery.type]
     when(mockQuery.getReferencesToType(any(), any())).thenReturn(DBIO.successful(Seq(referencingEntity.toPointer)))
-    when(mockQuery.deleteAllReferencesFromType(any(), any())).thenReturn(DBIO.successful(1))
     when(mockQuery.batchHideType(any(), any())).thenReturn(DBIO.successful(1))
 
     // provider using mocks
@@ -679,7 +619,6 @@ class CompactEntityProviderSpec
     result shouldBe a[DeleteEntitiesOfTypeConflictException]
 
     verify(mockQuery, times(1)).getReferencesToType(defaultWorkspace.workspaceIdAsUUID, entity1.entityType)
-    verify(mockQuery, never()).deleteAllReferencesFromType(defaultWorkspace.workspaceIdAsUUID, entity1.entityType)
     verify(mockQuery, never()).batchHideType(defaultWorkspace.workspaceIdAsUUID, entity1.entityType)
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
@@ -1,7 +1,14 @@
 package org.broadinstitute.dsde.rawls.entities.compact
 
 import org.broadinstitute.dsde.rawls.entities.exceptions.CompactEntityDeserializationException
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeNumber, AttributeString, Entity}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  AttributeEntityReferenceList,
+  AttributeName,
+  AttributeNumber,
+  AttributeString,
+  Entity
+}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import spray.json.{JsArray, JsNumber, JsObject}
@@ -45,7 +52,7 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
       val serialized = toSql(entity.attributes)
       val actual = serialized.fields.get(ATTRS_KEY)
       actual should not be empty
-      actual.get shouldBe a[JsArray]
+      actual.get shouldBe a[JsObject]
       // this intentionally does not test the details of how the AttributeMap is serialized; that is done elsewhere.
       // this only tests that the serialized AttributeMap is a sub-object located in an "attrs" key
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
@@ -1,17 +1,10 @@
 package org.broadinstitute.dsde.rawls.entities.compact
 
 import org.broadinstitute.dsde.rawls.entities.exceptions.CompactEntityDeserializationException
-import org.broadinstitute.dsde.rawls.model.{
-  AttributeEntityReference,
-  AttributeEntityReferenceList,
-  AttributeName,
-  AttributeNumber,
-  AttributeString,
-  Entity
-}
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeEntityReferenceList, AttributeName, AttributeNumber, AttributeString, Entity}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import spray.json.{JsNumber, JsObject}
+import spray.json.{JsArray, JsNumber, JsObject}
 
 class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with CompactEntitySerialization {
 
@@ -52,7 +45,7 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
       val serialized = toSql(entity.attributes)
       val actual = serialized.fields.get(ATTRS_KEY)
       actual should not be empty
-      actual.get shouldBe a[JsObject]
+      actual.get shouldBe a[JsArray]
       // this intentionally does not test the details of how the AttributeMap is serialized; that is done elsewhere.
       // this only tests that the serialized AttributeMap is a sub-object located in an "attrs" key
     }
@@ -96,7 +89,7 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
 
   it should "throw if the version number is out of range" in {
     val input =
-      """{ "v": 2, "attrs": {} }"""
+      """{ "v": 3, "attrs": {} }"""
     intercept[CompactEntityDeserializationException] {
       fromSql(Option(input))
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
@@ -2,11 +2,13 @@ package org.broadinstitute.dsde.rawls.entities.compact
 
 import org.broadinstitute.dsde.rawls.entities.exceptions.CompactEntityDeserializationException
 import org.broadinstitute.dsde.rawls.model.{
+  AttributeBoolean,
   AttributeEntityReference,
   AttributeEntityReferenceList,
   AttributeName,
   AttributeNumber,
   AttributeString,
+  AttributeValueList,
   Entity
 }
 import org.scalatest.flatspec.AnyFlatSpec
@@ -56,6 +58,29 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
       // this intentionally does not test the details of how the AttributeMap is serialized; that is done elsewhere.
       // this only tests that the serialized AttributeMap is a sub-object located in an "attrs" key
     }
+  }
+
+  behavior of "v2-specific serialization"
+
+  it should "serialize references into a normalized array with sortable values in attrs" in {
+    // shorthand for attrs
+    val singleref = AttributeName.withDefaultNS("singleref")
+    val reflist = AttributeName.withDefaultNS("reflist")
+
+    val serialized = toSql(refsEntity.attributes)
+    val actual = serialized.convertTo[SqlEntityData]
+
+    // check refs array
+    actual.refs should contain theSameElementsInOrderAs Seq(
+      SqlEntityReference(a = "singleref", t = "targetType", n = "targetName1", z = Some(true)),
+      SqlEntityReference(a = "reflist", t = "targetType", n = "targetName2", z = None),
+      SqlEntityReference(a = "reflist", t = "targetType", n = "targetName3", z = None)
+    )
+
+    actual.attrs.keys should contain(singleref)
+    actual.attrs(singleref) shouldBe AttributeString("targetName1")
+    actual.attrs.keys should contain(reflist)
+    actual.attrs(reflist) shouldBe AttributeNumber(2)
   }
 
   behavior of "Attribute deserialization"
@@ -110,9 +135,54 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
     }
   }
 
+  behavior of "v2-specific deserialization"
+
+  it should "deserialize with no references" in {
+    val input =
+      """{ "v": 2,
+         "attrs": {"hello": "world", "mynum": 42, "somelist": [true, false] },
+         "refs": []
+       }"""
+
+    val expected = Map(
+      AttributeName.fromDelimitedName("hello") -> AttributeString("world"),
+      AttributeName.fromDelimitedName("mynum") -> AttributeNumber(42),
+      AttributeName.fromDelimitedName("somelist") -> AttributeValueList(
+        Seq(AttributeBoolean(true), AttributeBoolean(false))
+      )
+    )
+
+    val actual = fromSql(Option(input))
+    actual shouldBe expected
+  }
+
+  it should "deserialize with references" in {
+    val input =
+      """{ "v": 2,
+           "attrs": {"hello": "world", "reflist": 1, "refscalar": "targetName2"},
+           "refs": [
+             {"a": "reflist", "n": "targetName1", "t": "targetType"},
+             {"a": "refscalar", "n": "targetName2", "t": "targetType", "z": true}
+           ]
+         }"""
+
+    val expected = Map(
+      AttributeName.fromDelimitedName("hello") -> AttributeString("world"),
+      AttributeName.fromDelimitedName("reflist") -> AttributeEntityReferenceList(
+        Seq(
+          AttributeEntityReference("targetType", "targetName1")
+        )
+      ),
+      AttributeName.fromDelimitedName("refscalar") -> AttributeEntityReference("targetType", "targetName2")
+    )
+
+    val actual = fromSql(Option(input))
+    actual shouldBe expected
+  }
+
   it should "throw if the attributes sub-object is missing" in {
     val input =
-      """{ "v": 1, "incorrect-key-for-attrs": {} }"""
+      """{ "v": 2, "incorrect-key-for-attrs": {}, "refs": [] }"""
     intercept[CompactEntityDeserializationException] {
       fromSql(Option(input))
     }
@@ -120,7 +190,23 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
 
   it should "throw if the attributes sub-object is an unexpected data type" in {
     val input =
-      """{ "v": 1, "attrs": false }"""
+      """{ "v": 2, "attrs": false, "refs": [] }"""
+    intercept[CompactEntityDeserializationException] {
+      fromSql(Option(input))
+    }
+  }
+
+  it should "throw if the references sub-object is missing" in {
+    val input =
+      """{ "v": 2, "attrs": {}, "incorrect-key-for-refs": [] }"""
+    intercept[CompactEntityDeserializationException] {
+      fromSql(Option(input))
+    }
+  }
+
+  it should "throw if the references sub-object is an unexpected data type" in {
+    val input =
+      """{ "v": 2, "attrs": {}, "refs": false }"""
     intercept[CompactEntityDeserializationException] {
       fromSql(Option(input))
     }


### PR DESCRIPTION
* restructure the serialization format for the `ENTITY.attributes` column
* drop the ENTITY_REFS table; replace it with a view against `ENTITY.attributes`
* delete all methods that wrote to ENTITY_REFS

The expectation for this PR is that:
* working with entity references will be more stable and have less risk of getting out of sync due to data duplication
* batchUpsert/batchUpdate will be somewhat faster/lighter because they do not have to manage the ENTITY_REFS table
* delete-entities and delete-entity-type will be somewhat slower because they now read references from a less-optimized view instead of a physical indexed table


TODOs:
- [x] assess if this helps deleteEntityAttributes (it should; delete both from `$.attrs` and `$.refs` and we're done)
- [x] fix tests which previously relied on inserting into ENTITY_REFS
- [x] renameEntity is failing a test
- [x] renameEntityType and renameEntity SQL may be optimized. These use joins between ENTITY and ENTITY_REFS, but ENTITY_REFS is now a view on ENTITY so we might be able to do better.
- [x] Unit tests for rename-entity and sorting
- [x] figure out the problem in timeouts on the `10000 entity references efficiently` test
- [x] Unit tests for serialization
- [x] Check new execution plans
- [x] Initial perf testing for delete-entities and delete-entity-type

For future tickets:
- [ ] rename attribute needs to also update `$.refs`; this needs unit tests. CORE-542
- [ ] migration updates and re-enable migration tests. CORE-543
- [ ] investigate performance improvements for delete-entities and delete-entity-type. CORE-544
- [ ] expression evaluation updates CORE-462
- [ ] entityQuery, when specifying columns to return, may be possible to optimize. Currently it returns all references and may discard some/many of those. (CORE-545)

