### PR TITLE
CORE-500 deleteAzureWorkspace admin api

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -925,6 +925,45 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/WorkspaceAdminResponse'
+  /api/admin/workspaces/{workspaceNamespace}/{workspaceName}/deleteAzureWorkspace:
+    delete:
+      tags:
+        - admin
+        - workspaces
+      summary: Delete an Azure workspace
+      description: Delete a workspace of type MC calling Sam to delete the workspace resource and descendants, and removing all records from the Rawls database
+      operationId: adminDeleteAzureWorkspace
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
+      responses:
+        204:
+          description: Workspace successfully deleted
+        400:
+          description: Workspace is not an MC workspace
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: You must be an admin to delete an MC workspace
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Workspace not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+
   /api/admin/workspaces/{workspaceNamespace}/{workspaceName}/flags:
     get:
       tags:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -194,7 +194,16 @@ trait AdminApiService extends UserInfoDirectives {
                     }
                   }
                 }
-            }
+            } ~
+              path("deleteAzureWorkspace") {
+                delete {
+                  complete {
+                    workspaceAdminServiceConstructor(ctx)
+                      .adminDeleteMcWorkspace(WorkspaceName(workspaceNamespace, workspaceName))
+                      .map(_ => StatusCodes.NoContent)
+                  }
+                }
+              }
           } ~
             path(Segment) { workspaceId =>
               get {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
@@ -12,13 +12,16 @@ import org.broadinstitute.dsde.rawls.model.{
   ErrorReportSource,
   RawlsRequestContext,
   SamResourceTypeAdminActions,
+  SamResourceTypeName,
   SamResourceTypeNames,
+  SamWorkspacePolicyNames,
   Workspace,
   WorkspaceAdminResponse,
   WorkspaceAttributeSpecs,
   WorkspaceDetails,
   WorkspaceFeatureFlag,
-  WorkspaceName
+  WorkspaceName,
+  WorkspaceType
 }
 import org.broadinstitute.dsde.rawls.util._
 
@@ -107,6 +110,60 @@ class WorkspaceAdminService(
       settings
     )
 
+  /**
+   * Admin endpoint to delete a workspace of type MC
+   */
+  def adminDeleteMcWorkspace(workspaceName: WorkspaceName): Future[Unit] =
+    asFCAdmin {
+      for {
+        // Get workspace to verify it's an MC workspace and to get its ID
+        workspaceOpt <- workspaceRepository.getWorkspace(workspaceName)
+        workspace = workspaceOpt.getOrElse(throw NoSuchWorkspaceException(workspaceName))
+        _ = if (workspace.workspaceType != WorkspaceType.McWorkspace) {
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.BadRequest, s"Workspace ${workspaceName} is not an MC workspace")
+          )
+        }
+
+        // Add the current caller to the workspace owner policy to ensure they have sufficient permissions
+        _ <- samDAO.admin.addUserToPolicy(
+          SamResourceTypeNames.workspace,
+          workspace.workspaceId,
+          SamWorkspacePolicyNames.owner,
+          ctx.userInfo.userEmail.value,
+          ctx
+        )
+
+        _ <- recursivelyDeleteSamResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
+        _ <- workspaceRepository.deleteWorkspace(workspaceName)
+      } yield ()
+    }
+
+  /**
+   * Recursively delete a SAM resource and all its children
+   * @param resourceTypeName the resource type
+   * @param resourceId the resource ID
+   * @param ctx the request context
+   * @return Future[Unit]
+   */
+  private[workspace] def recursivelyDeleteSamResource(resourceTypeName: SamResourceTypeName,
+                                                      resourceId: String,
+                                                      ctx: RawlsRequestContext
+  ): Future[Unit] =
+    for {
+      // Get all child resources
+      children <- samDAO.listResourceChildren(resourceTypeName, resourceId, ctx)
+
+      // Recursively delete each child resource
+      _ <- Future.traverse(children) { child =>
+        recursivelyDeleteSamResource(SamResourceTypeName(child.resourceTypeName), child.resourceId, ctx)
+      }
+
+      // Delete the resource itself
+      _ <- samDAO.deleteResource(resourceTypeName, resourceId, ctx)
+      _ = logger.info(s"Successfully deleted SAM resource $resourceTypeName/$resourceId")
+    } yield ()
+
   // moved out of WorkspaceSupport because the only usage was in this file,
   // and it has raw datasource/dataAccess usage, which is being refactored out of WorkspaceSupport
   private def withWorkspaceContext[T](workspaceName: WorkspaceName,
@@ -117,5 +174,4 @@ class WorkspaceAdminService(
       case None            => throw NoSuchWorkspaceException(workspaceName)
       case Some(workspace) => op(workspace)
     }
-
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
@@ -7,24 +7,30 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsRequestContext,
   RawlsUserEmail,
   RawlsUserSubjectId,
+  SamFullyQualifiedResourceId,
   SamResourceTypeAdminActions,
+  SamResourceTypeName,
   SamResourceTypeNames,
+  SamWorkspacePolicyNames,
   UserInfo,
   Workspace,
   WorkspaceAdminResponse,
-  WorkspaceDetails
+  WorkspaceDetails,
+  WorkspaceName,
+  WorkspaceType
 }
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport}
 import org.joda.time.DateTime
-import org.mockito.{ArgumentMatchers, Mockito}
-import org.mockito.Mockito.{when, RETURNS_SMART_NULLS}
+import org.mockito.{ArgumentCaptor, ArgumentMatchers, Mockito}
+import org.mockito.Mockito.{times, verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.matchers.should.Matchers.{be, convertToAnyShouldWrapper}
 
 import java.util.UUID
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
+import scala.jdk.CollectionConverters._
 
 class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
 
@@ -141,5 +147,264 @@ class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
     intercept[NoSuchWorkspaceException] {
       Await.result(service.getWorkspaceById(workspaceId), Duration.Inf)
     }
+  }
+
+  "adminDeleteMcWorkspace" should "delete an MC workspace if the user is an admin" in {
+    val workspaceName = WorkspaceName("test-namespace", "test-name")
+    val workspaceWithMcType = workspace.copy(workspaceType = WorkspaceType.McWorkspace)
+    val userEmail = defaultRequestContext.userInfo.userEmail.value
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspace(workspaceName)).thenReturn(Future.successful(Option(workspaceWithMcType)))
+    when(workspaceRepository.deleteWorkspace(workspaceName)).thenReturn(Future.successful(true))
+
+    val gcsDAO = mock[GoogleServicesDAO]
+    when(gcsDAO.isAdmin(ArgumentMatchers.any())).thenReturn(Future.successful(true))
+
+    val samAdminDAO = mock[SamAdminDAO]
+    when(
+      samAdminDAO.addUserToPolicy(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceWithMcType.workspaceId),
+        ArgumentMatchers.eq(SamWorkspacePolicyNames.owner),
+        ArgumentMatchers.eq(userEmail),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(()))
+
+    val samDAO = mock[SamDAO]
+    when(samDAO.admin).thenReturn(samAdminDAO)
+    when(
+      samDAO.listResourceChildren(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceWithMcType.workspaceId),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(List.empty))
+    when(
+      samDAO.deleteResource(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceWithMcType.workspaceId),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(()))
+
+    val service = workspaceAdminServiceConstructor(
+      samDAO = samDAO,
+      workspaceRepository = workspaceRepository,
+      gcsDAO = gcsDAO
+    )
+
+    Await.result(service.adminDeleteMcWorkspace(workspaceName), Duration.Inf)
+
+    // Verify user was added to the owner policy
+    verify(samAdminDAO).addUserToPolicy(
+      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+      ArgumentMatchers.eq(workspaceWithMcType.workspaceId),
+      ArgumentMatchers.eq(SamWorkspacePolicyNames.owner),
+      ArgumentMatchers.eq(userEmail),
+      ArgumentMatchers.any()
+    )
+
+    // Verify deletion steps
+    verify(workspaceRepository).deleteWorkspace(workspaceName)
+    verify(samDAO).deleteResource(
+      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+      ArgumentMatchers.eq(workspaceWithMcType.workspaceId),
+      ArgumentMatchers.any()
+    )
+  }
+
+  it should "throw if the workspace is not an MC workspace" in {
+    val workspaceName = WorkspaceName("test-namespace", "test-name")
+    val workspaceWithRawlsType = workspace.copy(workspaceType = WorkspaceType.RawlsWorkspace)
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspace(workspaceName)).thenReturn(Future.successful(Option(workspaceWithRawlsType)))
+
+    val gcsDAO = mock[GoogleServicesDAO]
+    when(gcsDAO.isAdmin(ArgumentMatchers.any())).thenReturn(Future.successful(true))
+
+    val service = workspaceAdminServiceConstructor(
+      workspaceRepository = workspaceRepository,
+      gcsDAO = gcsDAO
+    )
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(service.adminDeleteMcWorkspace(workspaceName), Duration.Inf)
+    }
+
+    exception.errorReport.statusCode shouldEqual Some(StatusCodes.BadRequest)
+  }
+
+  it should "throw if the workspace does not exist" in {
+    val workspaceName = WorkspaceName("test-namespace", "test-name")
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspace(workspaceName)).thenReturn(Future.successful(None))
+
+    val gcsDAO = mock[GoogleServicesDAO]
+    when(gcsDAO.isAdmin(ArgumentMatchers.any())).thenReturn(Future.successful(true))
+
+    val service = workspaceAdminServiceConstructor(
+      workspaceRepository = workspaceRepository,
+      gcsDAO = gcsDAO
+    )
+
+    intercept[NoSuchWorkspaceException] {
+      Await.result(service.adminDeleteMcWorkspace(workspaceName), Duration.Inf)
+    }
+  }
+
+  it should "throw if the user is not an admin" in {
+    val workspaceName = WorkspaceName("test-namespace", "test-name")
+
+    val gcsDAO = mock[GoogleServicesDAO]
+    when(gcsDAO.isAdmin(ArgumentMatchers.any())).thenReturn(Future.successful(false))
+
+    val service = workspaceAdminServiceConstructor(gcsDAO = gcsDAO)
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(service.adminDeleteMcWorkspace(workspaceName), Duration.Inf)
+    }
+
+    exception.errorReport.statusCode shouldEqual Some(StatusCodes.Forbidden)
+  }
+
+  "recursivelyDeleteSamResource" should "delete a resource and its children recursively" in {
+    // Create a mock SamDAO with resource children
+    val resourceTypeName = SamResourceTypeNames.workspace
+    val resourceId = UUID.randomUUID().toString
+
+    // Use SamFullyQualifiedResourceId instead of custom case class
+    val childResource1 = SamFullyQualifiedResourceId("child-id-1", "child-type-1")
+    val childResource2 = SamFullyQualifiedResourceId("child-id-2", "child-type-2")
+    val grandchildResource = SamFullyQualifiedResourceId("grandchild-id", "grandchild-type")
+
+    val samDAO = mock[SamDAO]
+
+    // Mock the first level of children
+    when(
+      samDAO.listResourceChildren(
+        ArgumentMatchers.eq(resourceTypeName),
+        ArgumentMatchers.eq(resourceId),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(List(childResource1, childResource2)))
+
+    // Mock the second level (grandchildren) - first child has a child, second child doesn't
+    when(
+      samDAO.listResourceChildren(
+        ArgumentMatchers.eq(SamResourceTypeName(childResource1.resourceTypeName)),
+        ArgumentMatchers.eq(childResource1.resourceId),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(List(grandchildResource)))
+
+    when(
+      samDAO.listResourceChildren(
+        ArgumentMatchers.eq(SamResourceTypeName(childResource2.resourceTypeName)),
+        ArgumentMatchers.eq(childResource2.resourceId),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(List.empty))
+
+    // Mock the third level (no children)
+    when(
+      samDAO.listResourceChildren(
+        ArgumentMatchers.eq(SamResourceTypeName(grandchildResource.resourceTypeName)),
+        ArgumentMatchers.eq(grandchildResource.resourceId),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(List.empty))
+
+    // Mock all deleteResource calls to return success
+    when(
+      samDAO.deleteResource(
+        ArgumentMatchers.any(),
+        ArgumentMatchers.any(),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(()))
+
+    val service = workspaceAdminServiceConstructor(samDAO = samDAO)
+
+    // Call the method under test
+    Await.result(service.recursivelyDeleteSamResource(resourceTypeName, resourceId, defaultRequestContext),
+                 Duration.Inf
+    )
+
+    // Verify that deleteResource was called for all resources in the correct order (bottom-up)
+    // First verify the grandchild was deleted
+    verify(samDAO).deleteResource(
+      ArgumentMatchers.eq(SamResourceTypeName(grandchildResource.resourceTypeName)),
+      ArgumentMatchers.eq(grandchildResource.resourceId),
+      ArgumentMatchers.any()
+    )
+
+    // Then verify both children were deleted
+    verify(samDAO).deleteResource(
+      ArgumentMatchers.eq(SamResourceTypeName(childResource1.resourceTypeName)),
+      ArgumentMatchers.eq(childResource1.resourceId),
+      ArgumentMatchers.any()
+    )
+
+    verify(samDAO).deleteResource(
+      ArgumentMatchers.eq(SamResourceTypeName(childResource2.resourceTypeName)),
+      ArgumentMatchers.eq(childResource2.resourceId),
+      ArgumentMatchers.any()
+    )
+
+    // Finally verify the parent resource was deleted
+    verify(samDAO).deleteResource(
+      ArgumentMatchers.eq(resourceTypeName),
+      ArgumentMatchers.eq(resourceId),
+      ArgumentMatchers.any()
+    )
+  }
+
+  it should "handle empty child resources" in {
+    val resourceTypeName = SamResourceTypeNames.workspace
+    val resourceId = UUID.randomUUID().toString
+
+    val samDAO = mock[SamDAO]
+
+    // Mock no children
+    when(
+      samDAO.listResourceChildren(
+        ArgumentMatchers.eq(resourceTypeName),
+        ArgumentMatchers.eq(resourceId),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(List.empty))
+
+    // Mock deleteResource to return success
+    when(
+      samDAO.deleteResource(
+        ArgumentMatchers.any(),
+        ArgumentMatchers.any(),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(()))
+
+    val service = workspaceAdminServiceConstructor(samDAO = samDAO)
+
+    // Call the method under test
+    Await.result(service.recursivelyDeleteSamResource(resourceTypeName, resourceId, defaultRequestContext),
+                 Duration.Inf
+    )
+
+    // Verify that deleteResource was called only for the parent resource
+    verify(samDAO, times(1)).deleteResource(
+      ArgumentMatchers.any(),
+      ArgumentMatchers.any(),
+      ArgumentMatchers.any()
+    )
+
+    verify(samDAO).deleteResource(
+      ArgumentMatchers.eq(resourceTypeName),
+      ArgumentMatchers.eq(resourceId),
+      ArgumentMatchers.any()
+    )
   }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-500

Admin api that assigns the current user as owner of the workspace then recursively removes all sam resources then the rawls db entries. It is understood that Leonardo db records will be cleaned up directly in the database later when Azure related code is deleted (https://broadworkbench.atlassian.net/browse/AN-565).

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
