### PR TITLE
CORE-527 adminGetWorkspaceId

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1029,6 +1029,40 @@ paths:
         500:
           $ref: '#/components/responses/RawlsInternalError'
 
+  /api/admin/workspaces/{workspaceNamespace}/{workspaceName}/id:
+    get:
+      tags:
+        - admin
+        - workspaces
+      summary: get workspace ID by namespace and name
+      description: Returns the workspace ID for a workspace identified by namespace and name
+      operationId: adminGetWorkspaceId
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                type: string
+                description: The workspace ID
+        404:
+          description: Workspace not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: You must be an admin to get a workspace ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+
   /api/admin/bucketMigration/workspaces/{workspaceNamespace}/{workspaceName}:
     get:
       tags:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -204,7 +204,7 @@ trait AdminApiService extends UserInfoDirectives {
                       .map(_ => StatusCodes.NoContent)
                   }
                 }
-            } ~
+              } ~
               path("id") {
                 get {
                   complete {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -19,6 +19,7 @@ import org.broadinstitute.dsde.rawls.submissions.SubmissionsService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceAdminService
 import spray.json.DefaultJsonProtocol._
+import spray.json.JsString
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext
@@ -201,6 +202,18 @@ trait AdminApiService extends UserInfoDirectives {
                     workspaceAdminServiceConstructor(ctx)
                       .adminDeleteMcWorkspace(WorkspaceName(workspaceNamespace, workspaceName))
                       .map(_ => StatusCodes.NoContent)
+                  }
+                }
+            } ~
+              path("id") {
+                get {
+                  complete {
+                    workspaceAdminServiceConstructor(ctx)
+                      .getWorkspaceId(WorkspaceName(workspaceNamespace, workspaceName))
+                      .map {
+                        case Some(id) => StatusCodes.OK -> Option(JsString(id))
+                        case None     => StatusCodes.NotFound -> None
+                      }
                   }
                 }
               }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
@@ -164,6 +164,20 @@ class WorkspaceAdminService(
       _ = logger.info(s"Successfully deleted SAM resource $resourceTypeName/$resourceId")
     } yield ()
 
+  def getWorkspaceId(workspaceName: WorkspaceName): Future[Option[String]] =
+    for {
+      userIsAdmin <- samDAO.admin
+        .userHasResourceTypeAdminPermission(SamResourceTypeNames.workspace,
+                                            SamResourceTypeAdminActions.readSummaryInformation,
+                                            ctx
+        )
+      _ = if (!userIsAdmin)
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.Forbidden, "You must be an admin to call this API.")
+        )
+      workspaceOpt <- workspaceRepository.getWorkspaceId(workspaceName)
+    } yield workspaceOpt.map(_.toString)
+
   // moved out of WorkspaceSupport because the only usage was in this file,
   // and it has raw datasource/dataAccess usage, which is being refactored out of WorkspaceSupport
   private def withWorkspaceContext[T](workspaceName: WorkspaceName,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.AttributeReferen
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import spray.json.DefaultJsonProtocol._
 
@@ -256,6 +257,37 @@ class AdminApiServiceSpec extends ApiServiceSpec {
           }
       }
     }
+  }
+
+  it should "return workspace ID for a valid workspace" in {
+    val workspaceAdminService = mock[WorkspaceAdminService]
+    when(workspaceAdminService.getWorkspaceId(constantData.workspace.toWorkspaceName))
+      .thenReturn(Future.successful(Option(constantData.workspace.workspaceId)))
+    val service = new MockApiService(workspaceAdminServiceConstructor = _ => workspaceAdminService)
+
+    val idApiUrl = s"/admin/workspaces/${constantData.workspace.namespace}/${constantData.workspace.name}/id"
+    Get(idApiUrl) ~>
+      sealRoute(service.adminRoutes()) ~>
+      check {
+        assertResult(StatusCodes.OK, responseAs[String])(status)
+        println(responseAs[String])
+        assertResult(s"\"${constantData.workspace.workspaceId}\"")(responseAs[String])
+      }
+  }
+
+  it should "return 404 when getting ID for a non-existent workspace" in {
+    val workspaceAdminService = mock[WorkspaceAdminService]
+    when(workspaceAdminService.getWorkspaceId(any())).thenReturn(Future.successful(None))
+    val service = new MockApiService(workspaceAdminServiceConstructor = _ => workspaceAdminService)
+
+    val nonExistentWorkspace = "nonexistent-workspace"
+    val idApiUrl = s"/admin/workspaces/${constantData.workspace.namespace}/$nonExistentWorkspace/id"
+
+    Get(idApiUrl) ~>
+      sealRoute(service.adminRoutes()) ~>
+      check {
+        assertResult(StatusCodes.NotFound)(status)
+      }
   }
 
   it should "get a workspace with its current settings" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
@@ -407,4 +407,79 @@ class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
       ArgumentMatchers.any()
     )
   }
+
+  "getWorkspaceId" should "return the workspace ID if the user is an admin and the workspace exists" in {
+    val workspaceName = workspace.toWorkspaceName
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspaceId(workspaceName))
+      .thenReturn(Future.successful(Option(workspace.workspaceIdAsUUID)))
+
+    val samAdminDAO = mock[SamAdminDAO]
+    when(
+      samAdminDAO.userHasResourceTypeAdminPermission(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(SamResourceTypeAdminActions.readSummaryInformation),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(true))
+    val samDAO = mock[SamDAO]
+    when(samDAO.admin).thenReturn(samAdminDAO)
+
+    val service = workspaceAdminServiceConstructor(
+      samDAO = samDAO,
+      workspaceRepository = workspaceRepository
+    )
+
+    val result = Await.result(service.getWorkspaceId(workspaceName), Duration.Inf)
+    result shouldEqual Option(workspace.workspaceId)
+  }
+
+  it should "return None if the workspace does not exist" in {
+    val workspaceName = workspace.toWorkspaceName
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspaceId(workspaceName)).thenReturn(Future.successful(None))
+
+    val samAdminDAO = mock[SamAdminDAO]
+    when(
+      samAdminDAO.userHasResourceTypeAdminPermission(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(SamResourceTypeAdminActions.readSummaryInformation),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(true))
+    val samDAO = mock[SamDAO]
+    when(samDAO.admin).thenReturn(samAdminDAO)
+
+    val service = workspaceAdminServiceConstructor(
+      samDAO = samDAO,
+      workspaceRepository = workspaceRepository
+    )
+
+    val result = Await.result(service.getWorkspaceId(workspaceName), Duration.Inf)
+    result shouldEqual None
+  }
+
+  it should "throw if the user is not an admin" in {
+    val workspaceName = workspace.toWorkspaceName
+
+    val samAdminDAO = mock[SamAdminDAO]
+    when(
+      samAdminDAO.userHasResourceTypeAdminPermission(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(SamResourceTypeAdminActions.readSummaryInformation),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(false))
+    val samDAO = mock[SamDAO]
+    when(samDAO.admin).thenReturn(samAdminDAO)
+
+    val service = workspaceAdminServiceConstructor(samDAO = samDAO)
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(service.getWorkspaceId(workspaceName), Duration.Inf)
+    }
+    exception.errorReport.statusCode shouldEqual Option(StatusCodes.Forbidden)
+  }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-527

new admin api to translate workspace name to id

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
