### PR TITLE
CORE-546: perf tests for Quicksilver metadata on ENTITY vs ENTITY_KEYS

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -323,6 +323,18 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       where workspace_id=$workspaceId;""".as[EntityTypeAndAttributeKey]
 
   /**
+   * Get all entity attribute keys for a workspace.
+   *
+   * execution plan:
+   *    ENTITY: Using index condition (Using index condition; Using temporary); Using temporary
+   *    t: Table function: json_table; Using temporary
+   */
+  def listEntityKeysViaEntity(workspaceId: UUID): ReadAction[Seq[EntityTypeAndAttributeKey]] =
+    sql"""SELECT distinct entity_type, attribute_key
+      FROM ENTITY, JSON_TABLE(JSON_KEYS(attributes, $slickAttrsPath), '$$[*]' COLUMNS(attribute_key VARCHAR(256) PATH '$$')) t
+      where workspace_id=$workspaceId;""".as[EntityTypeAndAttributeKey]
+
+  /**
    * Gets the count of entities in a workspace, grouped by entity type.
    *
    * `execution plan: Index range scan; using where. Index: idx_entity_keys_workspace_and_entity_type.`

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -332,7 +332,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   def listEntityKeysViaEntity(workspaceId: UUID): ReadAction[Seq[EntityTypeAndAttributeKey]] =
     sql"""SELECT distinct entity_type, attribute_key
       FROM ENTITY, JSON_TABLE(JSON_KEYS(attributes, $slickAttrsPath), '$$[*]' COLUMNS(attribute_key VARCHAR(256) PATH '$$')) t
-      where workspace_id=$workspaceId;""".as[EntityTypeAndAttributeKey]
+      where workspace_id=$workspaceId and deleted = 0;""".as[EntityTypeAndAttributeKey]
 
   /**
    * Gets the count of entities in a workspace, grouped by entity type.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -209,7 +209,13 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
     repository.dataSource.inTransaction(ReadOnly) { _ =>
       for {
         entityTypeAndKeys <- traceDBIOWithParent("listEntityKeys", parentContext) { _ =>
-          repository.queries.listEntityKeys(workspaceId)
+          // temporary hack to gather performance data: if useCache is true, calculate attributes via the ENTITY_KEYS table.
+          // if useCache is false, calculate attributes via the ENTITY table. We'll run these through perf tests over
+          // a period of time to see if ENTITY_KEYS offers significant benefit over ENTITY.
+          if (useCache)
+            repository.queries.listEntityKeys(workspaceId)
+          else
+            repository.queries.listEntityKeysViaEntity(workspaceId)
         }
         entityTypeAndCounts <- traceDBIOWithParent("countEntitiesGroupedByType", parentContext) { _ =>
           repository.queries.countEntitiesGroupedByType(workspaceId)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -439,6 +439,40 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     }
   }
 
+  behavior of "listEntityKeysViaEntity"
+
+  it should "return the keys for a workspace" in withMinimalTestDatabase { _ =>
+    // create 2 entity types with different attributes
+    val entityType1AttributeNames =
+      List("red", "green", "blue", "orange", "yellow", "purple").map(AttributeName.withDefaultNS)
+    val entityType1 = "entityType1"
+    createEntitiesWithKeys(entityType1AttributeNames, entityType1, wsid)
+
+    val entityType2AttributeNames =
+      List("circle", "square", "triangle", "rectangle", "oval", "hexagon").map(AttributeName.withDefaultNS)
+    val entityType2 = "entityType2"
+    createEntitiesWithKeys(entityType2AttributeNames, entityType2, wsid)
+
+    // create an entity with no attributes to make sure it does not break anything
+    insertAndGet(
+      Entity(
+        UUID.randomUUID().toString,
+        "noAttributes",
+        Map.empty
+      )
+    )
+
+    // create entities in a different workspace to make sure they are not included
+    createEntitiesWithKeys(entityType1AttributeNames, entityType2, minimalTestData.workspace2.workspaceIdAsUUID)
+
+    val actual = runAndWait(q.listEntityKeysViaEntity(wsid))
+    actual should contain theSameElementsAs entityType1AttributeNames.map {
+      EntityTypeAndAttributeKey(entityType1, _)
+    } ++ entityType2AttributeNames.map {
+      EntityTypeAndAttributeKey(entityType2, _)
+    }
+  }
+
   behavior of "attributeExists"
 
   it should "find attributes" in withMinimalTestDatabase { _ =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -698,7 +698,7 @@ class CompactEntityProviderSpec
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
 
-    val actual = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
+    val actual = Await.result(provider.entityTypeMetadata(useCache = true, defaultRequestContext), atMost)
 
     actual shouldBe Map()
   }
@@ -726,7 +726,7 @@ class CompactEntityProviderSpec
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
 
-    val actual = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
+    val actual = Await.result(provider.entityTypeMetadata(useCache = true, defaultRequestContext), atMost)
 
     actual shouldBe Map(
       "type1" -> EntityTypeMetadata(1, "type1" + Attributable.entityIdAttributeSuffix, Seq("keyA")),

--- a/k6/quicksilver.js
+++ b/k6/quicksilver.js
@@ -109,6 +109,15 @@ export const options = {
     },
     getEntityMetadataTest: {
       exec: 'getEntityMetadata',
+      tags: { rawlsApi: 'getEntityMetadata', feature: 'cached' },
+      env: { TEST_GROUP: 'test' },
+      executor: 'constant-vus',
+      vus: 3,
+      duration: '20s',
+      startTime: '88s',
+    },
+    getEntityMetadataTestUncached: {
+      exec: 'getEntityMetadataUncached',
       tags: { rawlsApi: 'getEntityMetadata', feature: 'uncached' },
       env: { TEST_GROUP: 'test' },
       executor: 'constant-vus',


### PR DESCRIPTION

For the entity_type_metadata API in Quicksilver workspaces: if useCache is true, calculate attributes via the ENTITY_KEYS table. If useCache is false, calculate attributes via the ENTITY table.

Additionally, set up perf tests for "cached" vs. "uncached", i.e. calculated via ENTITY_KEYS instead of via ENTITY.

After some time, we can review the perf test results. This will tell us if the ENTITY_KEYS table and its triggers offers significant benefit. If it does NOT offer benefit, it is worth dropping ENTITY_KEYS and the triggers that populate it, since those triggers add some overhead to writes.