### PR TITLE
CORE-537 call sam api that does not require owner

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2460,20 +2460,14 @@ class WorkspaceService(
             )
           )
         )
-      billingProjectPolicies <- samDAO.listPoliciesForResource(SamResourceTypeNames.billingProject,
-                                                               workspace.namespace,
-                                                               parentContext
-      )
-      billingProjectOwnerEmail = billingProjectPolicies
-        .find(_.policyName == SamBillingProjectPolicyNames.owner)
-        .map(_.email)
-        .getOrElse(
-          throw new RawlsExceptionWithErrorReport(
-            ErrorReport(StatusCodes.InternalServerError,
-                        s"Unable to find project owner policy for billing project ${workspace.namespace}"
-            )
-          )
+      billingProjectOwnerEmail <- samDAO
+        .getPolicySyncStatus(SamResourceTypeNames.billingProject,
+                             workspace.namespace,
+                             SamBillingProjectPolicyNames.owner,
+                             parentContext
         )
+        .map(_.email)
+
       _ <- gcsDAO.changeProjectOwnerBucketIamBinding(GcsBucketName(workspace.bucketName),
                                                      Identity.group(billingProjectOwnerEmail.value),
                                                      Identity.group(workspaceProjectOwnerEmail.value)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -3932,19 +3932,17 @@ class WorkspaceServiceSpec
     )
     val billingOwnerEmail = "billing email"
     when(
-      services.samDAO.listPoliciesForResource(
+      services.samDAO.getPolicySyncStatus(
         ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
         ArgumentMatchers.eq(workspace.namespace),
+        ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner),
         any
       )
     ).thenReturn(
       Future.successful(
-        Set(
-          SamPolicyWithNameAndEmail(
-            SamBillingProjectPolicyNames.owner,
-            SamPolicy(Set.empty, Set.empty, Set.empty),
-            WorkbenchEmail(billingOwnerEmail)
-          )
+        SamPolicySyncStatus(
+          "",
+          WorkbenchEmail(billingOwnerEmail)
         )
       )
     )


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-537

The problem is that the sam api used to get the billing project owner policy email requires owner access on the billing project. This PR switches to a different sam api that does not have the same requirement.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
