### PR TITLE
CORE-495: fix Quicksilver hard deletes; add logging and tracing

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -523,15 +523,15 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
     val endSql = sql""" and e.workspace_id = $workspaceId
           and e.id not in (
-            select value_entity_ref from WORKSPACE_ATTRIBUTE where owner_id = $workspaceId
+            select value_entity_ref from WORKSPACE_ATTRIBUTE where owner_id = $workspaceId and value_entity_ref is not null
               union
-            select ENTITY_ID from SUBMISSION where WORKSPACE_ID = $workspaceId
+            select ENTITY_ID from SUBMISSION where WORKSPACE_ID = $workspaceId and ENTITY_ID is not null
               union
-            select cw.ENTITY_ID from CANDIDATE_WORKFLOWS cw
+            select cw.ENTITY_ID from CANDIDATE_WORKFLOWS cw where ENTITY_ID is not null
               union
             select sa.value_entity_ref
             from SUBMISSION_ATTRIBUTE sa, SUBMISSION_VALIDATION sv, CANDIDATE_WORKFLOWS cw
-            where sa.owner_id = sv.id and sv.WORKFLOW_ID = cw.ID
+            where sa.owner_id = sv.id and sv.WORKFLOW_ID = cw.ID and value_entity_ref is not null
           )
        """
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -5,6 +5,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.stream.scaladsl.Source
 import com.google.common.annotations.VisibleForTesting
+import io.opentelemetry.api.common.AttributeKey
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.LookupExpression
@@ -45,7 +46,7 @@ import org.broadinstitute.dsde.rawls.model.{
   SubmissionValidationEntityInputs,
   Workspace
 }
-import org.broadinstitute.dsde.rawls.util.TracingUtils.{trace, traceDBIOWithParent}
+import org.broadinstitute.dsde.rawls.util.TracingUtils.{setTraceSpanAttribute, trace, traceDBIOWithParent}
 import slick.dbio.{DBIO, DBIOAction, Effect, NoStream}
 import slick.jdbc.ResultSetConcurrency.ReadOnly
 import slick.jdbc.{ResultSetConcurrency, ResultSetType}
@@ -263,9 +264,15 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
           throw new DeleteEntitiesConflictException(referencingEntities.map(_.toAttributeEntityReference).toSet)
         }
         // hard-delete everything we can
-        _ <- repository.queries.deleteEntities(workspaceId, pointers)
+        numHardDeletes <- repository.queries.deleteEntities(workspaceId, pointers)
         // soft-delete (i.e. hide) everything that could not be hard-deleted
         res <- repository.queries.batchHide(workspaceId, pointers)
+        _ = logger.info(s"deleteEntities for workspace $workspaceId: $numHardDeletes hard deletes, $res soft deletes")
+        _ = setTraceSpanAttribute(parentContext,
+                                  AttributeKey.longKey("hardDeletes"),
+                                  java.lang.Long.valueOf(numHardDeletes)
+        )
+        _ = setTraceSpanAttribute(parentContext, AttributeKey.longKey("softDeletes"), java.lang.Long.valueOf(res))
       } yield res
     }
 
@@ -279,12 +286,20 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
           throw new DeleteEntitiesOfTypeConflictException(referencingEntities.size)
         }
         // hard-delete everything we can
-        _ <- repository.queries.deleteEntitiesOfType(workspaceId, entityType)
+        numHardDeletes <- repository.queries.deleteEntitiesOfType(workspaceId, entityType)
         // soft-delete (i.e. hide) everything that could not be hard-deleted
         res <- repository.queries.batchHideType(
           workspaceId,
           entityType
         )
+        _ = logger.info(
+          s"deleteEntitiesOfType($entityType) for workspace $workspaceId: $numHardDeletes hard deletes, $res soft deletes"
+        )
+        _ = setTraceSpanAttribute(parentContext,
+                                  AttributeKey.longKey("hardDeletes"),
+                                  java.lang.Long.valueOf(numHardDeletes)
+        )
+        _ = setTraceSpanAttribute(parentContext, AttributeKey.longKey("softDeletes"), java.lang.Long.valueOf(res))
       } yield res
     }
 


### PR DESCRIPTION
Ticket: CORE-495

While researching performance stuff, I noticed that we are not properly hard-deleting entities for Quicksilver.

This is a followup to #3323. It removes nulls from the subquery portion of the "delete from ENTITY where id not in (... subquery ...)" SQL. Nulls in the subquery cause the "in" clause to be false. See:

> To comply with the SQL standard, IN() returns NULL not only if the expression on the left hand side is NULL, but also if no match is found in the list and one of the expressions in the list is NULL.

from https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_in.

Additionally, this PR adds logging and tracing to have better visibility into deletes.