### PR TITLE
CORE-549 get policies from tps

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/HttpTpsDAO.scala
@@ -15,6 +15,7 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 import scala.concurrent.{blocking, ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 
 class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec: ExecutionContext) extends TpsDAO {
   protected def getApiClient(ctx: RawlsRequestContext): ApiClient = {
@@ -71,4 +72,10 @@ class HttpTpsDAO(tpsUrl: String, rawlsSaCreds: RawlsCredential)(implicit val ec:
         getTpsApi(ctx).linkPao(request, objectId)
       }
     }
+
+  def listPaos(objectIds: Seq[UUID], ctx: RawlsRequestContext): Future[Seq[TpsPaoGetResult]] = Future {
+    blocking {
+      getTpsApi(ctx).listPaos(objectIds.asJava).asScala.toSeq
+    }
+  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/tps/TpsDAO.scala
@@ -16,4 +16,6 @@ trait TpsDAO {
   def deletePao(objectId: UUID, ctx: RawlsRequestContext): Future[Unit]
 
   def linkPao(request: TpsPaoSourceRequest, objectId: UUID, ctx: RawlsRequestContext): Future[TpsPaoUpdateResult]
+
+  def listPaos(objectIds: Seq[UUID], ctx: RawlsRequestContext): Future[Seq[TpsPaoGetResult]]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -738,7 +738,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
       }
 
       // update ENTITY from the contents of the temp table
-      numEntitiesUpdated <- logAndTrace("migrationUpdateEntityTableAttributes", "updated ENTITY $.attrs from temp table") {
+      numEntitiesUpdated <- logAndTrace("migrationUpdateEntityTableAttributes",
+                                        "updated ENTITY $.attrs from temp table"
+      ) {
         dataAccess.compactEntityQuery.migrationUpdateEntityTableAttributes(workspaceId)
       }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -41,7 +41,7 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) extends L
           .name(TpsPolicies.GroupConstraint.name)
           .additionalData(authDomainGroups.toList.asJava)
         req.setAttributes(new TpsPolicyInputs().inputs(List(protectedDataPolicy, groupConstraintPolicy).asJava))
-      case (None, Some(enhancedBucketLogging)) if enhancedBucketLogging =>
+      case (_, Some(true)) =>
         req.setAttributes(new TpsPolicyInputs().inputs(List(protectedDataPolicy).asJava))
       case _ =>
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/policy/PolicyService.scala
@@ -66,6 +66,9 @@ class PolicyService(tpsDAO: TpsDAO)(implicit val ec: ExecutionContext) extends L
         None
     }
 
+  def listPaos(objectIds: Seq[UUID], ctx: RawlsRequestContext): Future[Seq[TpsPaoGetResult]] =
+    tpsDAO.listPaos(objectIds, ctx)
+
   /**
     * Retrieves the snapshot PAO for the given snapshotId. If it does not exist, it creates a new one with no policies.
     */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -365,10 +365,10 @@ class WorkspaceService(
         WorkspacePolicy(
           input.getName,
           input.getNamespace,
-          Option(
-            input.getAdditionalData.asScala.toList
-              .map(data => Map.apply(data.getKey -> data.getValue))
-          ).getOrElse(List.empty)
+          Option(input.getAdditionalData)
+            .map(_.asScala.toList)
+            .getOrElse(List.empty)
+            .map(data => Map.apply(data.getKey -> data.getValue))
         )
       )
       .toList

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -381,7 +381,8 @@ class WorkspaceService(
     def processDetails(workspace: AggregatedWorkspace,
                        samResource: SamUserResource,
                        accessLevel: WorkspaceAccessLevel,
-                       stats: Option[WorkspaceSubmissionStats]
+                       stats: Option[WorkspaceSubmissionStats],
+                       workspacePolicies: List[WorkspacePolicy]
     ): WorkspaceListResponse = {
       val workspaceDetails =
         WorkspaceDetails.fromWorkspaceAndOptions(
@@ -416,7 +417,7 @@ class WorkspaceService(
         workspaceDetails,
         stats,
         samResource.public.roles.nonEmpty || samResource.public.actions.nonEmpty,
-        Some(workspace.policies)
+        Option(workspacePolicies)
       )
     }
 
@@ -430,6 +431,9 @@ class WorkspaceService(
           Try(UUID.fromString(resource.resourceId)).isSuccess
       )
       accessLevelWorkspaceUUIDs = accessLevelWorkspaceResources.map(resource => UUID.fromString(resource.resourceId))
+      policiesByWorkspaceId <- options.anyPresentFuture("policies") {
+        batchListPolicies(accessLevelWorkspaceUUIDs, ctx)
+      }
       submissionSummaryStats <- options.anyPresentFuture("workspaceSubmissionStats") {
         workspaceRepository.listSubmissionSummaryStats(accessLevelWorkspaceUUIDs)
       }
@@ -452,11 +456,26 @@ class WorkspaceService(
         val stats = submissionSummaryStats.flatMap {
           _.get(wsmContext.baseWorkspace.workspaceIdAsUUID)
         }
-        processDetails(wsmContext, workspaceResource, accessLevel, stats)
+        val workspacePolicies =
+          policiesByWorkspaceId.getOrElse(Map.empty).getOrElse(workspace.workspaceIdAsUUID, List.empty)
+        processDetails(wsmContext, workspaceResource, accessLevel, stats, workspacePolicies)
       }
 
     } yield deepFilterJsValue(responseWorkspaces.toJson, options.options)
   }
+
+  private def batchListPolicies(workspaceIds: Seq[UUID], ctx: RawlsRequestContext) =
+    workspaceIds
+      .grouped(1000)
+      .toList
+      .traverse { batch =>
+        policyService.listPaos(batch, ctx).map { policies =>
+          policies.map { policy =>
+            policy.getObjectId -> convertPolicies(policy)
+          }.toMap
+        }
+      }
+      .map(_.reduce(_ ++ _))
 
   def getGCPWorkspacesByBillingProjects(
     workspaceIds: List[String]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.workspace
 
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.stream.Materializer
+import bio.terra.policy.model.TpsPaoGetResult
 import bio.terra.workspace.client.ApiException
 import cats.implicits._
 import cats.{Applicative, ApplicativeThrow}
@@ -335,6 +336,10 @@ class WorkspaceService(
             getBucketOptions(WorkspaceName(workspace.namespace, workspace.name), userProject)
           )
       }
+
+      policies <- options.anyPresentFuture("policies") {
+        policyService.getPao(UUID.fromString(workspaceId), ctx)
+      }
     } yield WorkspaceResponse(
       options.anyPresent("accessLevel")(accessLevel),
       canShare,
@@ -350,9 +355,23 @@ class WorkspaceService(
       bucketDetails,
       owners,
       wsmContext.azureCloudContext,
-      Some(wsmContext.policies)
+      policies.flatten.map(convertPolicies)
     )
   }
+
+  private def convertPolicies(pao: TpsPaoGetResult): List[WorkspacePolicy] =
+    pao.getEffectiveAttributes.getInputs.asScala
+      .map(input =>
+        WorkspacePolicy(
+          input.getName,
+          input.getNamespace,
+          Option(
+            input.getAdditionalData.asScala.toList
+              .map(data => Map.apply(data.getKey -> data.getValue))
+          ).getOrElse(List.empty)
+        )
+      )
+      .toList
 
   def listWorkspaces(params: WorkspaceFieldSpecs, stringAttributeMaxLength: Int): Future[JsValue] = {
     val options = processOptions(params, stringAttributeMaxLength, WorkspaceFieldNames.workspaceListResponseFieldNames)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -464,18 +464,24 @@ class WorkspaceService(
     } yield deepFilterJsValue(responseWorkspaces.toJson, options.options)
   }
 
-  private def batchListPolicies(workspaceIds: Seq[UUID], ctx: RawlsRequestContext) =
-    workspaceIds
-      .grouped(1000)
-      .toList
-      .traverse { batch =>
-        policyService.listPaos(batch, ctx).map { policies =>
-          policies.map { policy =>
-            policy.getObjectId -> convertPolicies(policy)
-          }.toMap
+  private def batchListPolicies(workspaceIds: Seq[UUID],
+                                ctx: RawlsRequestContext
+  ): Future[Map[UUID, List[WorkspacePolicy]]] =
+    if (workspaceIds.isEmpty) {
+      Future.successful(Map.empty)
+    } else {
+      workspaceIds
+        .grouped(1000)
+        .toList
+        .traverse { batch =>
+          policyService.listPaos(batch, ctx).map { policies =>
+            policies.map { policy =>
+              policy.getObjectId -> convertPolicies(policy)
+            }.toMap
+          }
         }
-      }
-      .map(_.reduce(_ ++ _))
+        .map(_.reduce(_ ++ _))
+    }
 
   def getGCPWorkspacesByBillingProjects(
     workspaceIds: List[String]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -360,7 +360,9 @@ class WorkspaceService(
   }
 
   private def convertPolicies(pao: TpsPaoGetResult): List[WorkspacePolicy] =
-    pao.getEffectiveAttributes.getInputs.asScala
+    Option(pao.getEffectiveAttributes)
+      .map(_.getInputs.asScala)
+      .getOrElse(List.empty)
       .map(input =>
         WorkspacePolicy(
           input.getName,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/policy/PolicyServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/policy/PolicyServiceSpec.scala
@@ -96,6 +96,34 @@ class PolicyServiceSpec extends AnyFlatSpec {
     verify(tpsDAO).createPao(mockitoEq(expectedPaoRequest), any())
   }
 
+  it should "set protected-data policy if auth domain is present but empty and enhanced bucket logging is enabled" in {
+    val workspaceId = UUID.randomUUID()
+    val workspaceRequest =
+      baseWorkspaceRequest.copy(authorizationDomain = Option(Set.empty), enhancedBucketLogging = Some(true))
+
+    val tpsDAO = mock[TpsDAO](RETURNS_SMART_NULLS)
+    when(tpsDAO.createPao(any(), any())).thenReturn(Future.unit)
+    val policyService = new PolicyService(tpsDAO)
+
+    val expectedPaoRequest = new TpsPaoCreateRequest()
+      .objectType(TpsObjectType.WORKSPACE)
+      .objectId(workspaceId)
+      .component(TpsComponent.RAWLS)
+      .attributes(
+        new TpsPolicyInputs().inputs(
+          List(
+            new TpsPolicyInput().namespace(TERRA_POLICY_NAMESPACE).name(TpsPolicies.ProtectedData.name)
+          ).asJava
+        )
+      )
+
+    Await.result(policyService.createWorkspacePao(workspaceId, workspaceRequest, mock[RawlsRequestContext]),
+                 Duration.Inf
+    )
+
+    verify(tpsDAO).createPao(mockitoEq(expectedPaoRequest), any())
+  }
+
   it should "not set any policies if auth domain is not present and enhanced bucket logging is not enabled" in {
     val workspaceId = UUID.randomUUID()
     val workspaceRequest = baseWorkspaceRequest.copy(authorizationDomain = None, enhancedBucketLogging = Some(false))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -191,6 +191,7 @@ trait ApiServiceSpec
       .thenReturn(Future.successful(new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs())))
     when(policyService.linkSnapshotPaoToWorkspacePao(any(), any(), any(), any())).thenReturn(Future.unit)
     when(policyService.deleteWorkspacePao(any(), any())).thenReturn(Future.unit)
+    when(policyService.listPaos(any, any)).thenReturn(Future.successful(List.empty[TpsPaoGetResult]))
 
     override val executionServiceCluster = MockShardedExecutionServiceCluster.fromDAO(
       new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -2587,7 +2587,10 @@ class WorkspaceServiceSpec
 
     when(
       services.policyService.getPao(ArgumentMatchers.eq(createdWorkspace.workspaceIdAsUUID), any[RawlsRequestContext])
-    ).thenReturn(Future.successful(Option(toTpsPao(policies))))
+    ).thenReturn(Future.successful(Option(toTpsPao(createdWorkspace.workspaceIdAsUUID, policies))))
+    when(
+      services.policyService.listPaos(any, any[RawlsRequestContext])
+    ).thenReturn(Future.successful(Seq(toTpsPao(createdWorkspace.workspaceIdAsUUID, policies))))
 
     when(services.workspaceManagerDAO.listWorkspaces(any, any)).thenReturn(
       List(
@@ -2597,23 +2600,25 @@ class WorkspaceServiceSpec
     createdWorkspace
   }
 
-  private def toTpsPao(policies: List[WsmPolicyInput]) =
-    new TpsPaoGetResult().effectiveAttributes(
-      new TpsPolicyInputs().inputs(
-        policies
-          .map(p =>
-            new TpsPolicyInput()
-              .name(p.getName)
-              .namespace(p.getNamespace)
-              .additionalData(
-                p.getAdditionalData.asScala
-                  .map(pair => new TpsPolicyPair().key(pair.getKey).value(pair.getValue))
-                  .asJava
-              )
-          )
-          .asJava
+  private def toTpsPao(objectId: UUID, policies: List[WsmPolicyInput]) =
+    new TpsPaoGetResult()
+      .objectId(objectId)
+      .effectiveAttributes(
+        new TpsPolicyInputs().inputs(
+          policies
+            .map(p =>
+              new TpsPolicyInput()
+                .name(p.getName)
+                .namespace(p.getNamespace)
+                .additionalData(
+                  p.getAdditionalData.asScala
+                    .map(pair => new TpsPolicyPair().key(pair.getKey).value(pair.getValue))
+                    .asJava
+                )
+            )
+            .asJava
+        )
       )
-    )
 
   private def createGcpWorkspaceStub(services: TestApiService,
                                      workspaceName: String,
@@ -2644,7 +2649,10 @@ class WorkspaceServiceSpec
     )
     when(
       services.policyService.getPao(ArgumentMatchers.eq(createdWorkspace.workspaceIdAsUUID), any[RawlsRequestContext])
-    ).thenReturn(Future.successful(Option(toTpsPao(policies))))
+    ).thenReturn(Future.successful(Option(toTpsPao(createdWorkspace.workspaceIdAsUUID, policies))))
+    when(
+      services.policyService.listPaos(any, any[RawlsRequestContext])
+    ).thenReturn(Future.successful(Seq(toTpsPao(createdWorkspace.workspaceIdAsUUID, policies))))
 
     when(services.workspaceManagerDAO.listWorkspaces(any, any)).thenReturn(
       List(
@@ -3004,6 +3012,7 @@ class WorkspaceServiceSpec
           )
         )
       )
+      when(services.policyService.listPaos(any, any)).thenReturn(Future.successful(Seq.empty))
 
       // actually call listWorkspaces to get result it returns given the mocked calls you set up
       val result =
@@ -3106,6 +3115,7 @@ class WorkspaceServiceSpec
         )
       )
     )
+    when(services.policyService.listPaos(any, any)).thenReturn(Future.successful(Seq.empty))
 
     val result =
       Await
@@ -3184,6 +3194,7 @@ class WorkspaceServiceSpec
           )
         )
       )
+      when(services.policyService.listPaos(any, any)).thenReturn(Future.successful(Seq.empty))
 
       val result =
         Await
@@ -3256,6 +3267,7 @@ class WorkspaceServiceSpec
         )
       )
     )
+    when(services.policyService.listPaos(any, any)).thenReturn(Future.successful(Seq.empty))
 
     List(0, 1, 10, 200, 4096) foreach { stringAttributeMaxLength =>
       info(s"for stringAttributeMaxLength = $stringAttributeMaxLength")
@@ -3340,6 +3352,7 @@ class WorkspaceServiceSpec
         )
       )
     )
+    when(services.policyService.listPaos(any, any)).thenReturn(Future.successful(Seq.empty))
 
     val result =
       Await
@@ -3401,6 +3414,7 @@ class WorkspaceServiceSpec
         )
       )
     )
+    when(services.policyService.listPaos(any, any)).thenReturn(Future.successful(Seq.empty))
 
     val stringAttributeMaxLength = 5
 
@@ -3455,33 +3469,6 @@ class WorkspaceServiceSpec
       }
     }
     matchingWorkspaces.size should be(1)
-  }
-
-  it should "return no policy information for GCP workspaces without a stub workspace" in withTestDataServices {
-    services =>
-      val noPoliciesWorkspaceName = s"rawls-no-policies-test-ws-${UUID.randomUUID().toString}"
-      val workspaceNoPoliciesRequest = WorkspaceRequest(
-        testData.testProject1Name.value,
-        noPoliciesWorkspaceName,
-        Map.empty
-      )
-      Await.result(services.workspaceService.createWorkspace(workspaceNoPoliciesRequest), Duration.Inf)
-
-      val result = Await
-        .result(services.workspaceService.listWorkspaces(WorkspaceFieldSpecs(), -1), Duration.Inf)
-        .convertTo[Seq[WorkspaceListResponse]]
-
-      val matchingWorkspaces = result.filter { ws =>
-        if (ws.workspace.name == noPoliciesWorkspaceName) {
-          ws.policies.get should be(empty)
-          // We shouldn't report an error about the workspace not existing in workspace manager.
-          ws.workspace.errorMessage should be(empty)
-          true
-        } else {
-          false
-        }
-      }
-      matchingWorkspaces.size should be(1)
   }
 
   it should "return policy information for Azure workspaces" in withTestDataServices { services =>
@@ -3669,6 +3656,7 @@ class WorkspaceServiceSpec
         )
       )
     )
+    when(services.policyService.listPaos(any, any)).thenReturn(Future.successful(Seq.empty))
 
     // actually call listWorkspaces to get result it returns given the mocked calls you set up
     val result =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.PoisonPill
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import bio.terra.policy.model.TpsPaoGetResult
+import bio.terra.policy.model.{TpsPaoGetResult, TpsPolicyInput, TpsPolicyInputs, TpsPolicyPair}
 import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.{
@@ -2585,6 +2585,10 @@ class WorkspaceServiceSpec
       workspaceDescription
     )
 
+    when(
+      services.policyService.getPao(ArgumentMatchers.eq(createdWorkspace.workspaceIdAsUUID), any[RawlsRequestContext])
+    ).thenReturn(Future.successful(Option(toTpsPao(policies))))
+
     when(services.workspaceManagerDAO.listWorkspaces(any, any)).thenReturn(
       List(
         workspaceDescription
@@ -2592,6 +2596,24 @@ class WorkspaceServiceSpec
     )
     createdWorkspace
   }
+
+  private def toTpsPao(policies: List[WsmPolicyInput]) =
+    new TpsPaoGetResult().effectiveAttributes(
+      new TpsPolicyInputs().inputs(
+        policies
+          .map(p =>
+            new TpsPolicyInput()
+              .name(p.getName)
+              .namespace(p.getNamespace)
+              .additionalData(
+                p.getAdditionalData.asScala
+                  .map(pair => new TpsPolicyPair().key(pair.getKey).value(pair.getValue))
+                  .asJava
+              )
+          )
+          .asJava
+      )
+    )
 
   private def createGcpWorkspaceStub(services: TestApiService,
                                      workspaceName: String,
@@ -2620,6 +2642,10 @@ class WorkspaceServiceSpec
     ).thenReturn(
       workspaceDescription
     )
+    when(
+      services.policyService.getPao(ArgumentMatchers.eq(createdWorkspace.workspaceIdAsUUID), any[RawlsRequestContext])
+    ).thenReturn(Future.successful(Option(toTpsPao(policies))))
+
     when(services.workspaceManagerDAO.listWorkspaces(any, any)).thenReturn(
       List(
         workspaceDescription


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-549

The problem is that we are asking WSM for policies, not TPS directly. We are not creating workspaces in WSM anymore so this PR fixes the problem by asking TPS for policies.

And there was another bug that prevented saving protected data policy.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
