### PR TITLE
CORE-543: migration v2

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -158,7 +158,7 @@ trait CompactEntityMigration {
             group by entity_id, attr_name)
           select
             entity_id,
-            JSON_OBJECT($VERSION_KEY, $CURRENT_VERSION, $ATTRS_KEY, JSON_OBJECTAGG(attr_name, attr_value))
+            JSON_OBJECT($VERSION_KEY, $CURRENT_VERSION, $ATTRS_KEY, JSON_OBJECTAGG(attr_name, attr_value), $REFS_KEY, JSON_ARRAY())
           from CTE
           group by entity_id;""".asUpdate
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -99,27 +99,31 @@ trait CompactEntityMigration {
                 -- use sortable value for references, not the object itself
                 WHEN value_entity_ref is not null THEN
                   CASE
-                    WHEN ea.list_length is null THEN CAST(ref.name as JSON)
+                    WHEN ea.list_length is null THEN CAST(JSON_QUOTE(ref.name) as JSON)
                     ELSE CAST(ea.list_length as JSON)
                   END
                 ELSE null
             END as attr_value,
             CASE
               WHEN value_entity_ref is not null THEN
-                JSON_OBJECT(
-                    'a',
-                    CASE
-                      WHEN ea.namespace = ${AttributeName.defaultNamespace} THEN ea.name
-                      ELSE CONCAT(ea.namespace, ${AttributeName.delimiter.toString}, ea.name)
-                    END,
-                    'n', ref.name,
-                    't', ref.entity_type,
-                    'z',
-                    CASE
-                      WHEN ea.list_length is null THEN TRUE
-                      ELSE null
-                    END
-                )
+                CASE
+                  WHEN ea.list_length is null THEN
+                    JSON_OBJECT(
+                      'a',
+                      CASE
+                        WHEN ea.namespace = ${AttributeName.defaultNamespace} THEN ea.name
+                        ELSE CONCAT(ea.namespace, ${AttributeName.delimiter.toString}, ea.name)
+                      END,
+                      'n', ref.name, 't', ref.entity_type, 'z', TRUE)
+                  ELSE
+                    JSON_OBJECT(
+                      'a',
+                      CASE
+                        WHEN ea.namespace = ${AttributeName.defaultNamespace} THEN ea.name
+                        ELSE CONCAT(ea.namespace, ${AttributeName.delimiter.toString}, ea.name)
+                      END,
+                      'n', ref.name, 't', ref.entity_type)
+                END
               ELSE null
             END as ref_value
           from ENTITY e

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -44,6 +44,7 @@ trait CompactEntityMigration {
             attr_name varchar(240) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
             list_index int,
             attr_value json,
+            ref_value json,
             KEY KEY_LIST_INDEX (list_index),
             KEY KEY_ATTR_INDEX (entity_id, attr_name)
           );""".asUpdate
@@ -53,6 +54,7 @@ trait CompactEntityMigration {
     sql"""create temporary table QS_ENTITY_TEMP(
             entity_id bigint unsigned NOT NULL,
             attributes json,
+            refs json,
             KEY KEY_ENT_ID (entity_id)
           );""".asUpdate
 
@@ -75,23 +77,51 @@ trait CompactEntityMigration {
                                           startEntityId: Long,
                                           endEntityId: Long
   ): ReadWriteAction[Int] =
-    sql"""insert into QS_ATTR_TEMP(entity_id, attr_name, list_index, attr_value)
+    sql"""insert into QS_ATTR_TEMP(entity_id, attr_name, list_index, attr_value, ref_value)
           select
             e.id,
             CASE
               WHEN ea.namespace = ${AttributeName.defaultNamespace} then ea.name
               ELSE CONCAT(ea.namespace, ${AttributeName.delimiter.toString}, ea.name)
             END as attr_name,
-            ea.list_index,
+            CASE
+                -- in the attrs object, reference arrays become a single scalar value containing the array length
+                -- so we need to nullify their list_index values
+                WHEN value_entity_ref is not null and ea.list_index is not null THEN null
+                ELSE ea.list_index
+            END as list_index,
             CASE
                 WHEN value_string is not null THEN CAST(JSON_QUOTE(value_string) as JSON)
                 WHEN value_boolean is not null THEN CAST(value_boolean=1 as JSON)
                 WHEN list_length = 0 THEN JSON_ARRAY()
                 WHEN value_number is not null THEN CAST(value_number as JSON)
-                WHEN VALUE_JSON is not null THEN VALUE_JSON
-                WHEN value_entity_ref is not null THEN JSON_OBJECT(${AttributeFormat.ENTITY_TYPE_KEY}, ref.entity_type, ${AttributeFormat.ENTITY_NAME_KEY}, ref.name)
+                WHEN VALUE_JSON is not null THEN CAST(VALUE_JSON as JSON)
+                -- use sortable value for references, not the object itself
+                WHEN value_entity_ref is not null THEN
+                  CASE
+                    WHEN ea.list_length is null THEN CAST(ref.name as JSON)
+                    ELSE CAST(ea.list_length as JSON)
+                  END
                 ELSE null
-            END as attr_value
+            END as attr_value,
+            CASE
+              WHEN value_entity_ref is not null THEN
+                JSON_OBJECT(
+                    'a',
+                    CASE
+                      WHEN ea.namespace = ${AttributeName.defaultNamespace} THEN ea.name
+                      ELSE CONCAT(ea.namespace, ${AttributeName.delimiter.toString}, ea.name)
+                    END,
+                    'n', ref.name,
+                    't', ref.entity_type,
+                    'z',
+                    CASE
+                      WHEN ea.list_length is null THEN TRUE
+                      ELSE null
+                    END
+                )
+              ELSE null
+            END as ref_value
           from ENTITY e
               join ENTITY_ATTRIBUTE_#$shardId ea on e.id = ea.owner_id
               left outer join ENTITY ref on ea.value_entity_ref = ref.id
@@ -129,13 +159,29 @@ trait CompactEntityMigration {
           group by entity_id;""".asUpdate
 
   /**
-    * Update the ENTITY table with the compact entities stored in QS_ENTITY_TEMP.
+    * Update the ENTITY table with the compact entity attributes stored in QS_ENTITY_TEMP.
     */
-  def migrationUpdateEntityTable(workspaceId: UUID): ReadWriteAction[Int] =
+  def migrationUpdateEntityTableAttributes(workspaceId: UUID): ReadWriteAction[Int] =
     sql"""update ENTITY e
               join QS_ENTITY_TEMP tmp
               on e.id = tmp.entity_id
               set e.attributes = tmp.attributes
+              where e.workspace_id = $workspaceId
+              and deleted = 0;""".asUpdate
+
+  /**
+   * Update the ENTITY table with the compact entity references stored in QS_ATTR_TEMP.
+   */
+  def migrationUpdateEntityTableReferences(workspaceId: UUID): ReadWriteAction[Int] =
+    sql"""with CTE as (
+            select entity_id, JSON_ARRAYAGG(ref_value) as refs
+            from QS_ATTR_TEMP
+            where ref_value is not null
+            group by entity_id)
+          update ENTITY e
+              join CTE tmp
+              on e.id = tmp.entity_id
+              set e.attributes = JSON_SET(e.attributes, $slickRefsPath, tmp.refs)
               where e.workspace_id = $workspaceId
               and deleted = 0;""".asUpdate
 
@@ -146,23 +192,6 @@ trait CompactEntityMigration {
   /** Drop the temp table */
   def migrationDropEntityTempTable: ReadWriteAction[Int] =
     sql"""drop temporary table QS_ENTITY_TEMP;""".asUpdate
-
-  /** Insert references for the entities we just updated
-    * Copying directly from ENTITY_ATTRIBUTE_* can easily generate duplicate references, so we use
-    * `on duplicate key ...` with a noop update to avoid that.
-    * */
-  def migrationAddReferences(workspaceId: UUID, shardId: String): ReadWriteAction[Int] =
-    sql"""insert into ENTITY_REFS(workspace_id, from_entity_type, from_name, to_entity_type, to_name)
-         select e.workspace_id,
-          e.entity_type, e.name,
-          r.entity_type, r.name
-         from ENTITY e, ENTITY_ATTRIBUTE_#$shardId ea, ENTITY r
-         where ea.owner_id = e.id
-         and e.workspace_id = $workspaceId
-         and e.deleted = 0
-         and ea.value_entity_ref is not null
-         and ea.value_entity_ref = r.id
-         on duplicate key update workspace_id = e.workspace_id;""".asUpdate
 
   /** Delete the all_attribute_values text from a compact ENTITY.
       * Currently unused, but leaving here in case we change our mind.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -619,14 +619,6 @@ class EntityService(protected val ctx: RawlsRequestContext,
               })
               numEntitiesUpdated = updateCounts.sum
 
-              // populate the ENTITY_REFS table for this workspace
-              _ <- traceDBIOWithParent("migrationAddReferences", s) { _ =>
-                dataAccess.compactEntityQuery.migrationAddReferences(workspaceId, shardId)
-              }
-              _ = logger.info(
-                s"Quicksilver migration $workspaceId: populated ENTITY_REFS (${stopwatch.formatTime()}) ..."
-              )
-
               /** *** don't delete legacy data; we'll do that en masse after everything is migrated
               *  // delete legacy attributes from the ENTITY_ATTRIBUTE_xx_xx table
               *  _ = logger.info(s"Quicksilver migration: deleting legacy attributes ...")
@@ -746,8 +738,12 @@ class EntityService(protected val ctx: RawlsRequestContext,
       }
 
       // update ENTITY from the contents of the temp table
-      numEntitiesUpdated <- logAndTrace("migrationUpdateEntityTable", "updated ENTITY from temp table") {
-        dataAccess.compactEntityQuery.migrationUpdateEntityTable(workspaceId)
+      numEntitiesUpdated <- logAndTrace("migrationUpdateEntityTableAttributes", "updated ENTITY $.attrs from temp table") {
+        dataAccess.compactEntityQuery.migrationUpdateEntityTableAttributes(workspaceId)
+      }
+
+      _ <- logAndTrace("migrationUpdateEntityTableReferences", "updated ENTITY $.refs from temp table") {
+        dataAccess.compactEntityQuery.migrationUpdateEntityTableReferences(workspaceId)
       }
 
     } yield numEntitiesUpdated) andFinally

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -6,6 +6,7 @@ import akka.stream.scaladsl.Sink
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.typesafe.config.ConfigFactory
+import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.{
@@ -23,6 +24,7 @@ import org.broadinstitute.dsde.rawls.entities.compact.{
 import org.broadinstitute.dsde.rawls.entities.local.LocalEntityProvider
 import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
 import org.broadinstitute.dsde.rawls.mock.MockSamDAO
+import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{
   Attribute,
   AttributeBoolean,
@@ -260,6 +262,96 @@ class EntityServiceCompactMigrationSpec
     )
 
     // save the entity with the various attributes
+    val savedEntity = Await.result(localProvider.createEntity(entity, defaultRequestContext), atMost)
+    savedEntity shouldBe entity
+
+    // perform migration - this keeps legacy attributes and adds Quicksilver attributes
+    val entitiesUpdated =
+      Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName), atMost)
+
+    entitiesUpdated shouldBe 19 // 18 from the test data, plus the one we just created
+
+    val compactEntity =
+      Await.result(compactProvider.getEntity(entity.entityType, entity.name, defaultRequestContext), atMost)
+
+    val localEntity =
+      Await.result(localProvider.getEntity(entity.entityType, entity.name, defaultRequestContext), atMost)
+
+    forEvery(localEntity.attributes.keys) { attributeName =>
+      withClue(s"for attribute $attributeName") {
+        // check that the attributes match
+        compactEntity.attributes.get(attributeName) shouldBe localEntity.attributes.get(attributeName)
+      }
+    }
+
+  }
+
+  it should s"maintain reference array ordering" in withTestDataServices { apiService =>
+    val workspace = testData.workspace // has some entities we can use to test references
+
+    val targetEntityType = "targetEntityType"
+    val targetEntityNames = Seq("targetName1", "targetName2", "targetName3", "targetName4", "targetName5")
+    val targetEntities = targetEntityNames.map { name =>
+      Entity(name, targetEntityType, Map.empty)
+    }
+    val targetReferences = targetEntities.map(_.toReference)
+
+    // Build an attribute map for our source entity with lots of entity reference lists
+    // with randomized naming. The randomization here is used to ensure that nothing implicitly relies
+    // on ordering of attribute names, entity names, or entity types.
+    //
+    // Randomization means there is a chance of false positives, but over time also gives us more breadth of test cases
+    val numAttrsToTest = 100
+    val minReferencesPerList = 5
+    val maxReferencesPerList = 50
+    val chanceOfScalarAttribute = 0.1 // 10% chance of a scalar attribute, otherwise an entity reference list
+    val randomGenerator = RandomStringUtils.insecure() // we don't care about crypto-level security here
+    val attrs: AttributeMap = (Range.inclusive(1, numAttrsToTest) map { _ =>
+      val attrName = AttributeName.fromDelimitedName(
+        s"${randomGenerator.nextAlphabetic(4, 8)}:${randomGenerator.nextAlphanumeric(8, 20)}"
+      ) // random attribute name
+      val isScalar = scala.util.Random.nextDouble() < chanceOfScalarAttribute
+      val attrValue = if (isScalar) {
+        // scalar attribute
+        targetReferences(scala.util.Random.nextInt(targetReferences.length))
+      } else {
+        val refs = Range(0, scala.util.Random.between(minReferencesPerList, maxReferencesPerList)).map { _ =>
+          targetReferences(scala.util.Random.nextInt(targetReferences.length))
+        }
+        AttributeEntityReferenceList(refs)
+      }
+      attrName -> attrValue
+    }).toMap
+
+    val entity = Entity("lotsaDataTypes", "willThisWork", attrs)
+
+    val defaultRequestContext =
+      RawlsRequestContext(
+        UserInfo(RawlsUserEmail("test"), OAuth2BearerToken("Bearer 123"), 123, RawlsUserSubjectId("abc"))
+      )
+
+    val requestArguments = EntityRequestArguments(workspace, defaultRequestContext)
+
+    // get providers
+    val localProvider =
+      new LocalEntityProvider(requestArguments,
+                              slickDataSource,
+                              true,
+                              java.time.Duration.ofSeconds(60),
+                              workbenchMetricBaseName
+      )
+
+    val compactProvider = new CompactEntityProvider(requestArguments,
+                                                    new CompactEntityRepository(slickDataSource),
+                                                    CompactEntityProviderConfig()
+    )
+
+    // save target entities to use as references
+    targetEntities.foreach { target =>
+      Await.result(localProvider.createEntity(target, defaultRequestContext), atMost)
+    }
+
+    // save the entity with the randomized references
     val savedEntity = Await.result(localProvider.createEntity(entity, defaultRequestContext), atMost)
     savedEntity shouldBe entity
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -141,8 +141,7 @@ class EntityServiceCompactMigrationSpec
 
   behavior of "Compact Entity Migration"
   testWorkspaces.foreach { case (workspace, expectedCount) =>
-    // TODO CORE-543: re-enable tests
-    it should s"migrate to compact entities for workspace ${workspace.toWorkspaceName}" ignore withTestDataServices {
+    it should s"migrate to compact entities for workspace ${workspace.toWorkspaceName}" in withTestDataServices {
       apiService =>
         // entity data is already loaded into legacy tables via withTestDataServices
 
@@ -192,8 +191,7 @@ class EntityServiceCompactMigrationSpec
     }
   }
 
-  // TODO CORE-543: re-enable test
-  it should s"migrate to compact entities with various attribute data types" ignore withTestDataServices { apiService =>
+  it should s"migrate to compact entities with various attribute data types" in withTestDataServices { apiService =>
     val workspace = testData.workspace // has some entities we can use to test references
 
     // various attribute types to ensure migration works for all of them


### PR DESCRIPTION
Ticket: CORE-543

Updates the Quicksilver migration API to be compatible with the v2 serialization format. Specifically, the migration now needs to populate the `$.refs` array as well as the `$.attrs` object.

