### PR TITLE
[CORE-542] rename compact attribute v2 serialization

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -776,7 +776,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * - updateAttrsKeySql: index range scan on idx_entity_type_name
    * - updateRefsSql: index range scan on idx_entity_type_name
    */
-
   def renameAttribute(
     workspaceId: UUID,
     entityType: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -824,7 +824,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       sql"""update ENTITY
          set attributes = JSON_SET(attributes, $newAttrPath,
                                    JSON_EXTRACT(attributes, $oldAttrPath)),
-             attributes = JSON_REMOVE(attributes, $oldAttrPath)
+             attributes = JSON_REMOVE(attributes, $oldAttrPath),
+             record_version = record_version + 1,
          where workspace_id = $workspaceId
            and entity_type = $entityType
            and deleted = 0

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -785,27 +785,33 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   ): ReadWriteAction[Int] = {
     val newAttributeName = renameRequest.newAttributeName
 
-    // Convert AttributeName to delimited string, preserving namespace (e.g., "import:bar")
     val oldAttrDelimited = AttributeName.toDelimitedName(oldAttributeName)
     val newAttrDelimited = AttributeName.toDelimitedName(newAttributeName)
 
-    // Use helpers to get correct JSON paths
     val oldAttrPath = slickAttributePath(oldAttributeName)
     val newAttrPath = slickAttributePath(newAttributeName)
 
-    // 1. Rename key in $.attrs using JSON_SET + JSON_REMOVE (fixes test issues)
+    // rename is implemented as JSON_REMOVE(JSON_SET(JSON_EXTRACT))
+    // JSON_EXTRACT gets the value of the old attribute
+    // JSON_SET creates the new attribute with that value
+    // JSON_REMOVE deletes the old attribute
     val updateAttrsKeySql =
-      sql"""update ENTITY
-         set attributes = JSON_SET(attributes, $newAttrPath,
-                                   JSON_EXTRACT(attributes, $oldAttrPath)),
-             attributes = JSON_REMOVE(attributes, $oldAttrPath),
-             record_version = record_version + 1
-         where workspace_id = $workspaceId
-           and entity_type = $entityType
-           and deleted = 0
-           and JSON_CONTAINS_PATH(attributes, 'one', $oldAttrPath)""".asUpdate
+    sql"""update ENTITY
+          set record_version = record_version + 1,
+          attributes = JSON_REMOVE(
+                         JSON_SET(
+                           attributes,
+                           $newAttrPath,
+                           JSON_EXTRACT(attributes, $oldAttrPath)),
+                         $oldAttrPath
+                       )
+          where workspace_id = $workspaceId
+          and entity_type = $entityType
+          and deleted = 0
+          and JSON_CONTAINS_PATH(attributes, 'one', $oldAttrPath)
+       """.asUpdate
 
-    // 2. Rename embedded references in $.refs
+    // Renames references in $.refs using JSON_REPLACE + REPLACE
     val oldRef = s""""a": "$oldAttrDelimited", "t": "$entityType""""
     val newRef = s""""a": "$newAttrDelimited", "t": "$entityType""""
     val updateReferencesInAttributesSql =
@@ -818,11 +824,11 @@ class CompactEntityQuery(driverComponent: DriverComponent)
                JSON_OBJECT('a', $oldAttrDelimited, 't', $entityType),
                $slickRefsPath)""".asUpdate
 
-    // 3. Update scalar references (used for sort keys)
+    // Updates scalar references (used for sort keys)
     val updateSortValues =
       sql"""with paths as (
             select id,
-                   REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldAttrDelimited, null, '$$.refs')), '.a', '') as path
+                   REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldAttrDelimited, null, $slickRefsPath)), '.a', '') as path
             from ENTITY
             where workspace_id = $workspaceId
               and JSON_CONTAINS(attributes,
@@ -842,12 +848,12 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         set e.attributes = JSON_REPLACE(e.attributes, CONCAT($slickAttrsPath, '.', attrnames.attr), $newAttrDelimited)
         where e.id = attrnames.id""".asUpdate
 
-    // Execute all updates and return count of updated ENTITY rows (not refs or sort keys)
+    // Execute all updates and return the number of rows updated
     for {
       _ <- updateSortValues
       _ <- updateReferencesInAttributesSql
-      updatedEntities <- updateAttrsKeySql
-    } yield updatedEntities
+      entityRowsUpdated <- updateAttrsKeySql
+    } yield entityRowsUpdated
   }
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -773,77 +773,61 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * @return Number of entities that were updated
    *
    * execution plans:
-   * - updateSortValues (complex CTE query):
-   *    - First CTE (paths): Uses idx_entity_type_name index for workspace_id filtering
-   *    - Second CTE (attrnames): Performs join between paths and ENTITY table
-   *    - Final update: Uses join with materialized CTE results to perform targeted updates
-   *    - Overall: Efficient for handling complex JSON path operations with minimal scanning
-   *
-   * - updateReferencesInAttributesSql:
-   *    - Uses idx_entity_type_name index for workspace_id and entity_type conditions
-   *    - JSON_CONTAINS provides further filtering before any updates occur
-   *    - Performs a bulk update with string replacement within JSON structure
-   *    - Avoids full table scans by leveraging appropriate indexes
+   * - updateAttrSql: index range scan on idx_entity_type_name
+   * - updateReferencesInAttributesSql: index range scan on idx_entity_type_name
    */
   def renameAttribute(workspaceId: UUID,
                       entityType: String,
                       oldAttributeName: AttributeName,
                       renameRequest: AttributeRename
-  ): ReadWriteAction[Int] = {
-
-    // Validate attribute names
+                     ): ReadWriteAction[Int] = {
     val oldName = AttributeName.toDelimitedName(oldAttributeName)
     val newName = AttributeName.toDelimitedName(renameRequest.newAttributeName)
 
-    // String representations for the old and new attribute references
-    // They are used in the REPLACE function for modifying the JSON structure
-    val oldRef = s""""a": "$oldAttributeName", "t": "$entityType""""
-    val newRef = s""""a": "$newName", "t": "$entityType""""
-
-    // Updates references in the attributes.refs array
-    // This finds all entities that reference the old attribute name and updates them
-    val updateReferencesInAttributesSql = sql"""update ENTITY
-          set attributes = JSON_REPLACE(attributes, $slickRefsPath,
-            CAST(REPLACE(JSON_EXTRACT(attributes, $slickRefsPath), $oldRef, $newRef) as JSON)),
-          record_version = record_version + 1
+    // rename is implemented as JSON_REMOVE(JSON_SET(JSON_EXTRACT))
+    // JSON_EXTRACT gets the value of the old attribute
+    // JSON_SET creates the new attribute with that value
+    // JSON_REMOVE deletes the old attribute
+    val updateAttrSql = sql"""update ENTITY
+          set record_version = record_version + 1,
+          attributes = JSON_REMOVE(
+                         JSON_SET(
+                           attributes,
+                           ${slickAttributePath(newName)},
+                           JSON_EXTRACT(attributes, ${slickAttributePath(oldName)})),
+                         ${slickAttributePath(oldName)}
+                       )
           where workspace_id = $workspaceId
           and entity_type = $entityType
           and deleted = 0
-          and JSON_CONTAINS(attributes, JSON_OBJECT('a', $oldName, 't', $entityType), $slickRefsPath)"""
+          and JSON_CONTAINS_PATH(attributes, 'one', ${slickAttributePath(oldName)})
+       """.asUpdate
 
-    // Updates sortable values in the attributes.attrs object
-    val updateSortValues =
-      sql"""with paths as(
-        -- Find entities containing references of the old attribute name
-        select id,
-        REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldName, null, '$$.refs')), '.n', '') as path
-        from ENTITY
-        where workspace_id = $workspaceId
-        and JSON_CONTAINS(attributes, JSON_OBJECT('a', $oldName, 't', $entityType, 'z', true), $slickRefsPath)
-      ),
-      attrnames as (
-        -- Extract metadata about the references (attribute name, is_scalar flag, entity_type)
-        select paths.id,
-          JSON_EXTRACT(attributes, CONCAT(paths.path, '.a')) as attr,
-          JSON_EXTRACT(attributes, CONCAT(paths.path, '.z')) as is_scalar,
-          JSON_EXTRACT(attributes, CONCAT(paths.path, '.t')) as entity_type
-        from ENTITY e join paths on e.id = paths.id
-        -- Filter to only include scalar attributes of the target entity type
-        having is_scalar = true and entity_type = $entityType
-      )
-    -- Update the specific JSON paths in the attributes column
-    update ENTITY e
-    join attrnames on e.id = attrnames.id
-    set e.attributes = JSON_REPLACE(e.attributes, CONCAT('$$.attrs.', attrnames.attr), $newName), e.record_version = e.record_version + 1
-    where e.id = attrnames.id;
-   """.asUpdate
+    val oldRef = s""""n": "$oldName", "t": "$entityType""""
+    val newRef = s""""n": "$newName", "t": "$entityType""""
 
-    // Execute all updates in sequence within the same transaction
-    // First update sortable values, then update references
+    // Update references in the $.refs array.
+    val updateReferencesInAttributesSql =
+      sql"""update ENTITY
+            set attributes = JSON_REPLACE(attributes,
+                                         $slickRefsPath,
+                                         CAST(
+                                           REPLACE(
+                                             JSON_EXTRACT(attributes, $slickRefsPath),
+                                             $oldRef,
+                                             $newRef
+                                           ) as JSON
+                                         )
+                                        ),
+            record_version = record_version + 1
+            where workspace_id = $workspaceId
+            and deleted = 0
+            and JSON_CONTAINS(attributes, JSON_OBJECT('a', $oldName, 't', $entityType), $slickRefsPath)""".asUpdate
+
     for {
-      _ <- updateSortValues
-      entityRowsUpdated <- updateReferencesInAttributesSql.asUpdate
-    } yield entityRowsUpdated
+      attrsUpdated <- updateAttrSql
+      refsUpdated <- updateReferencesInAttributesSql
+    } yield attrsUpdated + refsUpdated
   }
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -714,6 +714,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           set e.attributes = JSON_REPLACE(e.attributes, CONCAT('$$.attrs.', attrnames.attr), $newName) where e.id = attrnames.id;
          """.asUpdate
 
+    // Update non-sortable scalar attributes in the $.attrs object.
     val updateNonSortScalarAttrs =
       sql"""with paths as (
           select id,
@@ -790,6 +791,18 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     } yield entityRowsUpdated
   }
 
+  /**
+   * Renames a single attribute across all entities of the given type in a workspace.
+   * This handles both attribute name changes in the entity's attributes JSON structure and
+   * also updates any references to this attribute in other entities.
+   *
+   * @return Number of entities that were updated
+   *
+   * execution plans:
+   * - updateAttrsKeySql: index range scan on idx_entity_type_name
+   * - updateReferencesInAttributesSql: index range scan on idx_entity_type_name
+   * - updateSortValues: complex query with CTEs, uses idx_entity_type_name for initial filtering
+   */
   def renameAttribute(
     workspaceId: UUID,
     entityType: String,
@@ -860,60 +873,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       _ <- updateReferencesInAttributesSql
       updatedEntities <- updateAttrsKeySql
     } yield updatedEntities
-  }
-
-  /**
-   * Renames a single attribute across all entities of the given type in a workspace.
-   * This handles both attribute name changes in the entity's attributes JSON structure and
-   * also updates any references to this attribute in other entities.
-   *
-   * @return Number of entities that were updated
-   *
-   * execution plans:
-   * - updateAttrSql: index range scan on idx_entity_type_name
-   * - updateReferencesInAttributesSql: index range scan on idx_entity_type_name
-   */
-  def renameAttribute1(workspaceId: UUID,
-                       entityType: String,
-                       oldAttributeName: AttributeName,
-                       renameRequest: AttributeRename
-  ): ReadWriteAction[Int] = {
-    val oldName = AttributeName.toDelimitedName(oldAttributeName)
-    val newName = AttributeName.toDelimitedName(renameRequest.newAttributeName)
-
-    // rename is implemented as JSON_REMOVE(JSON_SET(JSON_EXTRACT))
-    // JSON_EXTRACT gets the value of the old attribute
-    // JSON_SET creates the new attribute with that value
-    // JSON_REMOVE deletes the old attribute
-    val updateAttrSql = sql"""update ENTITY
-          set record_version = record_version + 1,
-          attributes = JSON_REMOVE(
-                         JSON_SET(
-                           attributes,
-                           ${slickAttributePath(newName)},
-                           JSON_EXTRACT(attributes, ${slickAttributePath(oldName)})),
-                         ${slickAttributePath(oldName)}
-                       )
-          where workspace_id = $workspaceId
-          and entity_type = $entityType
-          and deleted = 0
-          and JSON_CONTAINS_PATH(attributes, 'one', ${slickAttributePath(oldName)})
-       """.asUpdate
-
-    // Update references in the $.refs array.
-    val oldRef = s""""a": "$oldName"""""
-    val newRef = s""""a": "$newName"""""
-    val updateReferencesInAttributesSql = sql"""update ENTITY
-            set attributes = JSON_REPLACE(attributes, $slickRefsPath,
-              CAST(REPLACE(JSON_EXTRACT(attributes, $slickRefsPath), $oldRef, $newRef) as JSON))
-            where workspace_id = $workspaceId
-            and deleted = 0
-            and JSON_CONTAINS(attributes, JSON_OBJECT('a', $oldName), $slickRefsPath)""".asUpdate
-
-    for {
-      _ <- updateReferencesInAttributesSql
-      attrsUpdated <- updateAttrSql
-    } yield attrsUpdated
   }
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -6,6 +6,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.entities.EntityUtils
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
 import org.broadinstitute.dsde.rawls.entities.exceptions.AttributeException
+import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 
 import java.sql.Timestamp
 import java.util.{Date, UUID}
@@ -713,9 +714,33 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           set e.attributes = JSON_REPLACE(e.attributes, CONCAT('$$.attrs.', attrnames.attr), $newName) where e.id = attrnames.id;
          """.asUpdate
 
+    val updateNonSortScalarAttrs =
+      sql"""with paths as (
+          select id,
+                 REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldName, null, '$$.refs')), '.n', '') as path
+          from ENTITY
+          where workspace_id = $workspaceId
+            and JSON_CONTAINS(attributes,
+              JSON_OBJECT('n', $oldName, 't', $entityType),
+              $slickRefsPath)
+        ),
+        attrnames as (
+          select paths.id,
+                 JSON_EXTRACT(attributes, CONCAT(paths.path, '.a')) as attr,
+                 JSON_EXTRACT(attributes, CONCAT(paths.path, '.z')) as is_scalar,
+                 JSON_EXTRACT(attributes, CONCAT(paths.path, '.t')) as entity_type
+          from ENTITY e join paths on e.id = paths.id
+          having is_scalar = true and entity_type = $entityType
+        )
+      update ENTITY e
+      join attrnames on e.id = attrnames.id
+      set e.attributes = JSON_REPLACE(e.attributes, CONCAT($slickAttrsPath, '.', attrnames.attr), $newName)
+      where e.id = attrnames.id""".asUpdate
+
     // Execute all updates
     for {
       _ <- updateSortValues
+      _ <- updateNonSortScalarAttrs
       _ <- updateReferencesInAttributesSql
       entityRowsUpdated <- updateEntityNameSql.asUpdate
     } yield entityRowsUpdated
@@ -765,6 +790,78 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     } yield entityRowsUpdated
   }
 
+  def renameAttribute(
+    workspaceId: UUID,
+    entityType: String,
+    oldAttributeName: AttributeName,
+    renameRequest: AttributeRename
+  ): ReadWriteAction[Int] = {
+    val newAttributeName = renameRequest.newAttributeName
+
+    // Convert AttributeName to delimited string, preserving namespace (e.g., "import:bar")
+    val oldAttrDelimited = toDelimitedName(oldAttributeName)
+    val newAttrDelimited = toDelimitedName(newAttributeName)
+
+    // Use helpers to get correct JSON paths
+    val oldAttrPath = slickAttributePath(oldAttributeName)
+    val newAttrPath = slickAttributePath(newAttributeName)
+
+    // 1. Rename key in $.attrs using JSON_SET + JSON_REMOVE (fixes test issues)
+    val updateAttrsKeySql =
+      sql"""update ENTITY
+         set attributes = JSON_SET(attributes, $newAttrPath,
+                                   JSON_EXTRACT(attributes, $oldAttrPath)),
+             attributes = JSON_REMOVE(attributes, $oldAttrPath)
+         where workspace_id = $workspaceId
+           and entity_type = $entityType
+           and deleted = 0
+           and JSON_CONTAINS_PATH(attributes, 'one', $oldAttrPath)""".asUpdate
+
+    // 2. Rename embedded references in $.refs
+    val oldRef = s""""a": "$oldAttrDelimited", "t": "$entityType""""
+    val newRef = s""""a": "$newAttrDelimited", "t": "$entityType""""
+    val updateReferencesInAttributesSql =
+      sql"""update ENTITY
+         set attributes = JSON_REPLACE(attributes, $slickRefsPath,
+              CAST(REPLACE(JSON_EXTRACT(attributes, $slickRefsPath), $oldRef, $newRef) as JSON))
+         where workspace_id = $workspaceId
+           and deleted = 0
+           and JSON_CONTAINS(attributes,
+               JSON_OBJECT('a', $oldAttrDelimited, 't', $entityType),
+               $slickRefsPath)""".asUpdate
+
+    // 3. Update scalar references (used for sort keys)
+    val updateSortValues =
+      sql"""with paths as (
+            select id,
+                   REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldAttrDelimited, null, '$$.refs')), '.a', '') as path
+            from ENTITY
+            where workspace_id = $workspaceId
+              and JSON_CONTAINS(attributes,
+                JSON_OBJECT('a', $oldAttrDelimited, 't', $entityType, 'z', true),
+                $slickRefsPath)
+          ),
+          attrnames as (
+            select paths.id,
+                   JSON_EXTRACT(attributes, CONCAT(paths.path, '.a')) as attr,
+                   JSON_EXTRACT(attributes, CONCAT(paths.path, '.z')) as is_scalar,
+                   JSON_EXTRACT(attributes, CONCAT(paths.path, '.t')) as entity_type
+            from ENTITY e join paths on e.id = paths.id
+            having is_scalar = true and entity_type = $entityType
+          )
+        update ENTITY e
+        join attrnames on e.id = attrnames.id
+        set e.attributes = JSON_REPLACE(e.attributes, CONCAT($slickAttrsPath, '.', attrnames.attr), $newAttrDelimited)
+        where e.id = attrnames.id""".asUpdate
+
+    // Execute all updates and return count of updated ENTITY rows (not refs or sort keys)
+    for {
+      _ <- updateSortValues
+      _ <- updateReferencesInAttributesSql
+      updatedEntities <- updateAttrsKeySql
+    } yield updatedEntities
+  }
+
   /**
    * Renames a single attribute across all entities of the given type in a workspace.
    * This handles both attribute name changes in the entity's attributes JSON structure and
@@ -776,11 +873,11 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * - updateAttrSql: index range scan on idx_entity_type_name
    * - updateReferencesInAttributesSql: index range scan on idx_entity_type_name
    */
-  def renameAttribute(workspaceId: UUID,
-                      entityType: String,
-                      oldAttributeName: AttributeName,
-                      renameRequest: AttributeRename
-                     ): ReadWriteAction[Int] = {
+  def renameAttribute1(workspaceId: UUID,
+                       entityType: String,
+                       oldAttributeName: AttributeName,
+                       renameRequest: AttributeRename
+  ): ReadWriteAction[Int] = {
     val oldName = AttributeName.toDelimitedName(oldAttributeName)
     val newName = AttributeName.toDelimitedName(renameRequest.newAttributeName)
 
@@ -803,31 +900,20 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           and JSON_CONTAINS_PATH(attributes, 'one', ${slickAttributePath(oldName)})
        """.asUpdate
 
-    val oldRef = s""""n": "$oldName", "t": "$entityType""""
-    val newRef = s""""n": "$newName", "t": "$entityType""""
-
     // Update references in the $.refs array.
-    val updateReferencesInAttributesSql =
-      sql"""update ENTITY
-            set attributes = JSON_REPLACE(attributes,
-                                         $slickRefsPath,
-                                         CAST(
-                                           REPLACE(
-                                             JSON_EXTRACT(attributes, $slickRefsPath),
-                                             $oldRef,
-                                             $newRef
-                                           ) as JSON
-                                         )
-                                        ),
-            record_version = record_version + 1
+    val oldRef = s""""a": "$oldName"""""
+    val newRef = s""""a": "$newName"""""
+    val updateReferencesInAttributesSql = sql"""update ENTITY
+            set attributes = JSON_REPLACE(attributes, $slickRefsPath,
+              CAST(REPLACE(JSON_EXTRACT(attributes, $slickRefsPath), $oldRef, $newRef) as JSON))
             where workspace_id = $workspaceId
             and deleted = 0
-            and JSON_CONTAINS(attributes, JSON_OBJECT('a', $oldName, 't', $entityType), $slickRefsPath)""".asUpdate
+            and JSON_CONTAINS(attributes, JSON_OBJECT('a', $oldName), $slickRefsPath)""".asUpdate
 
     for {
+      _ <- updateReferencesInAttributesSql
       attrsUpdated <- updateAttrSql
-      refsUpdated <- updateReferencesInAttributesSql
-    } yield attrsUpdated + refsUpdated
+    } yield attrsUpdated
   }
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -774,9 +774,9 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    *
    * execution plans:
    * - updateAttrsKeySql: index range scan on idx_entity_type_name
-   * - updateReferencesInAttributesSql: index range scan on idx_entity_type_name
-   * - updateSortValues: complex query with CTEs, uses idx_entity_type_name for initial filtering
+   * - updateRefsSql: index range scan on idx_entity_type_name
    */
+
   def renameAttribute(
     workspaceId: UUID,
     entityType: String,
@@ -796,62 +796,44 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     // JSON_SET creates the new attribute with that value
     // JSON_REMOVE deletes the old attribute
     val updateAttrsKeySql =
-    sql"""update ENTITY
-          set record_version = record_version + 1,
-          attributes = JSON_REMOVE(
-                         JSON_SET(
-                           attributes,
-                           $newAttrPath,
-                           JSON_EXTRACT(attributes, $oldAttrPath)),
-                         $oldAttrPath
-                       )
-          where workspace_id = $workspaceId
-          and entity_type = $entityType
-          and deleted = 0
-          and JSON_CONTAINS_PATH(attributes, 'one', $oldAttrPath)
-       """.asUpdate
+      sql"""update ENTITY
+        set record_version = record_version + 1,
+        attributes = JSON_REMOVE(
+                       JSON_SET(
+                         attributes,
+                         $newAttrPath,
+                         JSON_EXTRACT(attributes, $oldAttrPath)),
+                       $oldAttrPath
+                     )
+        where workspace_id = $workspaceId
+        and entity_type = $entityType
+        and deleted = 0
+        and JSON_CONTAINS_PATH(attributes, 'one', $oldAttrPath)
+     """.asUpdate
 
     // Renames references in $.refs using JSON_REPLACE + REPLACE
-    val oldRef = s""""a": "$oldAttrDelimited", "t": "$entityType""""
-    val newRef = s""""a": "$newAttrDelimited", "t": "$entityType""""
-    val updateReferencesInAttributesSql =
-      sql"""update ENTITY
-         set attributes = JSON_REPLACE(attributes, $slickRefsPath,
-              CAST(REPLACE(JSON_EXTRACT(attributes, $slickRefsPath), $oldRef, $newRef) as JSON))
-         where workspace_id = $workspaceId
-           and deleted = 0
-           and JSON_CONTAINS(attributes,
-               JSON_OBJECT('a', $oldAttrDelimited, 't', $entityType),
-               $slickRefsPath)""".asUpdate
+    val searchPattern = s""""a":"$oldAttrDelimited""""
+    val replacePattern = s""""a":"$newAttrDelimited""""
 
-    // Updates scalar references (used for sort keys)
-    val updateSortValues =
-      sql"""with paths as (
-            select id,
-                   REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldAttrDelimited, null, $slickRefsPath)), '.a', '') as path
-            from ENTITY
-            where workspace_id = $workspaceId
-              and JSON_CONTAINS(attributes,
-                JSON_OBJECT('a', $oldAttrDelimited, 't', $entityType, 'z', true),
-                $slickRefsPath)
-          ),
-          attrnames as (
-            select paths.id,
-                   JSON_EXTRACT(attributes, CONCAT(paths.path, '.a')) as attr,
-                   JSON_EXTRACT(attributes, CONCAT(paths.path, '.z')) as is_scalar,
-                   JSON_EXTRACT(attributes, CONCAT(paths.path, '.t')) as entity_type
-            from ENTITY e join paths on e.id = paths.id
-            having is_scalar = true and entity_type = $entityType
+    val updateRefsSql = sql"""update ENTITY
+        set attributes = JSON_SET(
+          attributes,
+          $slickRefsPath,
+          CAST(
+            REPLACE(
+              JSON_EXTRACT(attributes, $slickRefsPath),
+              $searchPattern,
+              $replacePattern
+            ) AS JSON
           )
-        update ENTITY e
-        join attrnames on e.id = attrnames.id
-        set e.attributes = JSON_REPLACE(e.attributes, CONCAT($slickAttrsPath, '.', attrnames.attr), $newAttrDelimited)
-        where e.id = attrnames.id""".asUpdate
+        )
+        where workspace_id = $workspaceId
+        and deleted = 0
+        and JSON_CONTAINS(attributes, JSON_OBJECT('a', $oldAttrDelimited), $slickRefsPath)""".asUpdate
 
-    // Execute all updates and return the number of rows updated
+    // Execute all updates
     for {
-      _ <- updateSortValues
-      _ <- updateReferencesInAttributesSql
+      _ <- updateRefsSql
       entityRowsUpdated <- updateAttrsKeySql
     } yield entityRowsUpdated
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -825,7 +825,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
          set attributes = JSON_SET(attributes, $newAttrPath,
                                    JSON_EXTRACT(attributes, $oldAttrPath)),
              attributes = JSON_REMOVE(attributes, $oldAttrPath),
-             record_version = record_version + 1,
+             record_version = record_version + 1
          where workspace_id = $workspaceId
            and entity_type = $entityType
            and deleted = 0

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -6,7 +6,6 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.entities.EntityUtils
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
 import org.broadinstitute.dsde.rawls.entities.exceptions.AttributeException
-import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 
 import java.sql.Timestamp
 import java.util.{Date, UUID}
@@ -696,10 +695,10 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     val updateSortValues =
       sql"""with paths as(
               select id,
-              REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldName, null, '$$.refs')), '.a', '') as path
+              REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldName, null, '$$.refs')), '.n', '') as path
               from ENTITY
               where workspace_id = $workspaceId
-              and JSON_CONTAINS(attributes, JSON_OBJECT('a', $oldName, 't', $entityType, 'z', true), $slickRefsPath)
+              and JSON_CONTAINS(attributes, JSON_OBJECT('n', $oldName, 't', $entityType, 'z', true), $slickRefsPath)
             ),
             attrnames as (
               select paths.id,
@@ -714,34 +713,9 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           set e.attributes = JSON_REPLACE(e.attributes, CONCAT('$$.attrs.', attrnames.attr), $newName) where e.id = attrnames.id;
          """.asUpdate
 
-    // Update non-sortable scalar attributes in the $.attrs object.
-    val updateNonSortScalarAttrs =
-      sql"""with paths as (
-          select id,
-                 REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldName, null, '$$.refs')), '.n', '') as path
-          from ENTITY
-          where workspace_id = $workspaceId
-            and JSON_CONTAINS(attributes,
-              JSON_OBJECT('n', $oldName, 't', $entityType),
-              $slickRefsPath)
-        ),
-        attrnames as (
-          select paths.id,
-                 JSON_EXTRACT(attributes, CONCAT(paths.path, '.a')) as attr,
-                 JSON_EXTRACT(attributes, CONCAT(paths.path, '.z')) as is_scalar,
-                 JSON_EXTRACT(attributes, CONCAT(paths.path, '.t')) as entity_type
-          from ENTITY e join paths on e.id = paths.id
-          having is_scalar = true and entity_type = $entityType
-        )
-      update ENTITY e
-      join attrnames on e.id = attrnames.id
-      set e.attributes = JSON_REPLACE(e.attributes, CONCAT($slickAttrsPath, '.', attrnames.attr), $newName)
-      where e.id = attrnames.id""".asUpdate
-
     // Execute all updates
     for {
       _ <- updateSortValues
-      _ <- updateNonSortScalarAttrs
       _ <- updateReferencesInAttributesSql
       entityRowsUpdated <- updateEntityNameSql.asUpdate
     } yield entityRowsUpdated
@@ -812,8 +786,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     val newAttributeName = renameRequest.newAttributeName
 
     // Convert AttributeName to delimited string, preserving namespace (e.g., "import:bar")
-    val oldAttrDelimited = toDelimitedName(oldAttributeName)
-    val newAttrDelimited = toDelimitedName(newAttributeName)
+    val oldAttrDelimited = AttributeName.toDelimitedName(oldAttributeName)
+    val newAttrDelimited = AttributeName.toDelimitedName(newAttributeName)
 
     // Use helpers to get correct JSON paths
     val oldAttrPath = slickAttributePath(oldAttributeName)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -693,10 +693,10 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     val updateSortValues =
       sql"""with paths as(
               select id,
-              REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldName, null, '$$.refs')), '.n', '') as path
+              REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldName, null, '$$.refs')), '.a', '') as path
               from ENTITY
               where workspace_id = $workspaceId
-              and JSON_CONTAINS(attributes, JSON_OBJECT('n', $oldName, 't', $entityType, 'z', true), $slickRefsPath)
+              and JSON_CONTAINS(attributes, JSON_OBJECT('a', $oldName, 't', $entityType, 'z', true), $slickRefsPath)
             ),
             attrnames as (
               select paths.id,
@@ -764,36 +764,85 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   }
 
   /**
-    * Renames a single attribute across all entities of the given type and workspace.
-    * This method assumes the old and new attribute names have already been validated!
-    *
-    * TODO CORE-542: also update in $.refs
-    *
-    * `Using where. Index used: idx_entity_type_name`
-    */
+   * Renames a single attribute across all entities of the given type in a workspace.
+   * This handles both attribute name changes in the entity's attributes JSON structure and
+   * also updates any references to this attribute in other entities.
+   *
+   * @return Number of entities that were updated
+   *
+   * execution plans:
+   * - updateSortValues (complex CTE query):
+   *    - First CTE (paths): Uses idx_entity_type_name index for workspace_id filtering
+   *    - Second CTE (attrnames): Performs join between paths and ENTITY table
+   *    - Final update: Uses join with materialized CTE results to perform targeted updates
+   *    - Overall: Efficient for handling complex JSON path operations with minimal scanning
+   *
+   * - updateReferencesInAttributesSql:
+   *    - Uses idx_entity_type_name index for workspace_id and entity_type conditions
+   *    - JSON_CONTAINS provides further filtering before any updates occur
+   *    - Performs a bulk update with string replacement within JSON structure
+   *    - Avoids full table scans by leveraging appropriate indexes
+   */
   def renameAttribute(workspaceId: UUID,
                       entityType: String,
                       oldAttributeName: AttributeName,
                       renameRequest: AttributeRename
-  ): ReadWriteAction[Int] =
-    // rename is implemented as JSON_REMOVE(JSON_SET(JSON_EXTRACT))
-    // JSON_EXTRACT gets the value of the old attribute
-    // JSON_SET creates the new attribute with that value
-    // JSON_REMOVE deletes the old attribute
-    sql"""update ENTITY
-          set record_version = record_version + 1,
-          attributes = JSON_REMOVE(
-                         JSON_SET(
-                           attributes,
-                           ${slickAttributePath(renameRequest.newAttributeName)},
-                           JSON_EXTRACT(attributes, ${slickAttributePath(oldAttributeName)})),
-                         ${slickAttributePath(oldAttributeName)}
-                       )
+  ): ReadWriteAction[Int] = {
+
+    // Validate attribute names
+    val oldName = AttributeName.toDelimitedName(oldAttributeName)
+    val newName = AttributeName.toDelimitedName(renameRequest.newAttributeName)
+
+    // String representations for the old and new attribute references
+    // They are used in the REPLACE function for modifying the JSON structure
+    val oldRef = s""""a": "$oldAttributeName", "t": "$entityType""""
+    val newRef = s""""a": "$newName", "t": "$entityType""""
+
+    // Updates references in the attributes.refs array
+    // This finds all entities that reference the old attribute name and updates them
+    val updateReferencesInAttributesSql = sql"""update ENTITY
+          set attributes = JSON_REPLACE(attributes, $slickRefsPath,
+            CAST(REPLACE(JSON_EXTRACT(attributes, $slickRefsPath), $oldRef, $newRef) as JSON)),
+          record_version = record_version + 1
           where workspace_id = $workspaceId
           and entity_type = $entityType
           and deleted = 0
-          and JSON_CONTAINS_PATH(attributes, 'one', ${slickAttributePath(oldAttributeName)})
-       """.asUpdate
+          and JSON_CONTAINS(attributes, JSON_OBJECT('a', $oldName, 't', $entityType), $slickRefsPath)"""
+
+    // Updates sortable values in the attributes.attrs object
+    val updateSortValues =
+      sql"""with paths as(
+        -- Find entities containing references of the old attribute name
+        select id,
+        REPLACE(JSON_UNQUOTE(JSON_SEARCH(attributes, 'all', $oldName, null, '$$.refs')), '.n', '') as path
+        from ENTITY
+        where workspace_id = $workspaceId
+        and JSON_CONTAINS(attributes, JSON_OBJECT('a', $oldName, 't', $entityType, 'z', true), $slickRefsPath)
+      ),
+      attrnames as (
+        -- Extract metadata about the references (attribute name, is_scalar flag, entity_type)
+        select paths.id,
+          JSON_EXTRACT(attributes, CONCAT(paths.path, '.a')) as attr,
+          JSON_EXTRACT(attributes, CONCAT(paths.path, '.z')) as is_scalar,
+          JSON_EXTRACT(attributes, CONCAT(paths.path, '.t')) as entity_type
+        from ENTITY e join paths on e.id = paths.id
+        -- Filter to only include scalar attributes of the target entity type
+        having is_scalar = true and entity_type = $entityType
+      )
+    -- Update the specific JSON paths in the attributes column
+    update ENTITY e
+    join attrnames on e.id = attrnames.id
+    set e.attributes = JSON_REPLACE(e.attributes, CONCAT('$$.attrs.', attrnames.attr), $newName), e.record_version = e.record_version + 1
+    where e.id = attrnames.id;
+   """.asUpdate
+
+    // Execute all updates in sequence within the same transaction
+    // First update sortable values, then update references
+    for {
+      _ <- updateSortValues
+      entityRowsUpdated <- updateReferencesInAttributesSql.asUpdate
+    } yield entityRowsUpdated
+  }
 
   /**
     * Determine if an attribute exists in any entity of the given type and workspace.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -785,6 +785,11 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   ): ReadWriteAction[Int] = {
     val newAttributeName = renameRequest.newAttributeName
 
+    // Validation ensures that entityType, oldName, and newName are SQL-safe
+    EntityUtils.validateEntityName(oldAttributeName.name)
+    EntityUtils.validateEntityName(newAttributeName.name)
+    EntityUtils.validateEntityType(entityType)
+
     val oldAttrDelimited = AttributeName.toDelimitedName(oldAttributeName)
     val newAttrDelimited = AttributeName.toDelimitedName(newAttributeName)
 
@@ -812,8 +817,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
      """.asUpdate
 
     // Renames references in $.refs using JSON_REPLACE + REPLACE
-    val searchPattern = s""""a":"$oldAttrDelimited""""
-    val replacePattern = s""""a":"$newAttrDelimited""""
+    val searchPattern = s""""a": "$oldAttrDelimited""""
+    val replacePattern = s""""a": "$newAttrDelimited""""
 
     val updateRefsSql = sql"""update ENTITY
         set attributes = JSON_SET(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -896,91 +896,82 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
   }
 
   it should "update both $.attrs and $.refs" in withMinimalTestDatabase { _ =>
-    import scala.language.postfixOps
-    // Create the original entity with an attribute
-    val entityType = "testType"
+    // Create target entities that will be referenced
+    val target1 = Entity("targetName1", "targetType", Map())
+    val target2 = Entity("targetName2", "targetType", Map())
+    insertAndGetAll(Seq(target1, target2))
+
+    // Create entity with a simple attribute
     val originalAttributeName = AttributeName.withDefaultNS("originalAttr")
     val newAttributeName = AttributeName.withDefaultNS("newAttr")
-    val originalEntity = Entity(
-      "entityName",
-      entityType,
-      Map(
-        originalAttributeName -> AttributeString("attributeValue")
-      )
+    val entityWithAttribute = Entity(
+      "entityWithAttribute",
+      "entityType",
+      Map(originalAttributeName -> AttributeString("attributeValue"))
     )
-    insertAndGet(originalEntity)
 
-    // Create source entities referencing the original attribute
-    val sourceEntity1 = Entity(
-      "sourceEntity1",
-      "sourceType",
+    // Create entity with a reference using the same attribute name
+    val entityWithReference = Entity(
+      "entityWithReference",
+      "entityType",
+      Map(originalAttributeName -> AttributeEntityReference("targetType", "targetName1"))
+    )
+
+    // Create entity with a reference list using the same attribute name
+    val entityWithReferenceList = Entity(
+      "entityWithReferenceList",
+      "entityType",
       Map(
-        AttributeName.withDefaultNS("refList") -> AttributeEntityReferenceList(
-          Seq(originalEntity.toReference)
+        originalAttributeName -> AttributeEntityReferenceList(
+          Seq(
+            AttributeEntityReference("targetType", "targetName1"),
+            AttributeEntityReference("targetType", "targetName2")
+          )
         )
       )
     )
-    val sourceEntity2 = Entity(
-      "sourceEntity2",
-      "sourceType",
-      Map(
-        originalAttributeName -> AttributeString("attributeValue")
-      )
-    )
-    insertAndGetAll(Seq(sourceEntity1, sourceEntity2))
+
+    insertAndGetAll(Seq(entityWithAttribute, entityWithReference, entityWithReferenceList))
 
     // Rename the attribute
-    runAndWait(q.renameAttribute(wsid, entityType, originalAttributeName, AttributeRename(newAttributeName))) shouldBe 1
+    runAndWait(
+      q.renameAttribute(wsid, "entityType", originalAttributeName, AttributeRename(newAttributeName))
+    ) shouldBe 3
 
-    // Verify the attribute was renamed in the original entity
-    val updatedEntity = runAndWait(q.getEntity(wsid, entityType, originalEntity.name)).get.toEntity
-    updatedEntity.attributes should contain key newAttributeName
-    updatedEntity.attributes.contains(originalAttributeName) shouldBe false
-
-    // Verify the attribute was NOT updated in sourceEntity2 (different entity type)
-    val source2 = runAndWait(q.getEntity(wsid, "sourceType", "sourceEntity2"))
-    source2 should not be empty
-    source2.get.attributes should not be empty
-    val rawData2 =
-      source2.get.attributes.get.parseJson.convertTo[SqlEntityData](CompactEntitySerialization.sqlEntityDataFormat)
-    rawData2.attrs.keys should contain(originalAttributeName)
-    rawData2.attrs.keys should not contain newAttributeName
-
-    // Verify that sourceEntity1 remains unchanged in $.attrs
-    val source1 = runAndWait(q.getEntity(wsid, "sourceType", "sourceEntity1"))
-    source1 should not be empty
-    source1.get.attributes should not be empty
-    val rawData1 =
-      source1.get.attributes.get.parseJson.convertTo[SqlEntityData](CompactEntitySerialization.sqlEntityDataFormat)
-    rawData1.attrs.keys should not contain newAttributeName
-    rawData1.attrs.keys should contain(AttributeName.withDefaultNS("refList"))
-
-    // Validate the raw JSON string to ensure proper spacing in the pattern matching
-    val rawJson = source1.get.attributes.get
-
-    // Validate that refs follow the proper JSON format with no spaces after colons
-    val refs = rawData1.refs
-    refs should not be empty
-
-    // Check each reference in the raw JSON string
-    refs.foreach { ref =>
-      // The attribute name should be formatted with spaces after colons: "a": "attrName"
-      rawJson should include(s""""a": "${ref.a}"""")
-      // There should not be a version without a space after the colon
-      rawJson should not include s""""a":"${ref.a}""""
-
-      // Same check for entityName
-      rawJson should include(s""""n": "${ref.n}"""")
-      rawJson should not include s""""n":"${ref.n}""""
-
-      // Same check for entityType
-      rawJson should include(s""""t": "${ref.t}"""")
-      rawJson should not include s""""t":"${ref.t}""""
+    // Verify the attribute was renamed in all entities
+    for (entityName <- Seq("entityWithAttribute", "entityWithReference", "entityWithReferenceList")) {
+      val updatedEntity = runAndWait(q.getEntity(wsid, "entityType", entityName)).get.toEntity
+      updatedEntity.attributes should contain key newAttributeName
+      updatedEntity.attributes.contains(originalAttributeName) shouldBe false
     }
 
-    // Additionally, verify the old attribute name is not present
-    rawJson should not include s""""a": "${toDelimitedName(originalAttributeName)}""""
-    rawJson should not include s""""a":"${toDelimitedName(originalAttributeName)}""""
+    // Verify the raw JSON structure of the entity with reference list
+    val entityWithRefList = runAndWait(q.getEntity(wsid, "entityType", "entityWithReferenceList"))
+    entityWithRefList should not be empty
+
+    val rawJson = entityWithRefList.get.attributes.get
+    val entityData = rawJson.parseJson.convertTo[SqlEntityData](CompactEntitySerialization.sqlEntityDataFormat)
+
+    // Check that attrs section has the new attribute name
+    entityData.attrs.keys should contain(newAttributeName)
+    entityData.attrs.keys should not contain originalAttributeName
+
+    // Check that refs section has the new attribute name
+    entityData.refs.exists(_.a == toDelimitedName(newAttributeName)) shouldBe true
+    entityData.refs.exists(_.a == toDelimitedName(originalAttributeName)) shouldBe false
+
+    // Verify that the original attribute name doesn't appear anywhere in the JSON string
+    val originalAttrDelimited = toDelimitedName(originalAttributeName)
+
+    // Check for attribute name in JSON with space after colon (standard JSON format)
+    rawJson should not include s""""a": "$originalAttrDelimited""""
+
+    // Check for attribute name in JSON without space after colon (compact format)
+    rawJson should not include s""""a":"$originalAttrDelimited""""
+
+    // Check raw JSON includes the new attribute name with proper spacing
+    val newAttrDelimited = toDelimitedName(newAttributeName)
+    rawJson should include regex s""""a":\\s*"$newAttrDelimited""""
   }
 
   /**

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -964,9 +964,9 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     // Check each reference in the raw JSON string
     refs.foreach { ref =>
-      // The attribute name should be formatted without spaces after colons: "a":"attrName"
+      // The attribute name should be formatted with spaces after colons: "a": "attrName"
       rawJson should include(s""""a": "${ref.a}"""")
-      // There should not be a version with a space after the colon
+      // There should not be a version without a space after the colon
       rawJson should not include s""""a":"${ref.a}""""
 
       // Same check for entityName

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -954,6 +954,33 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       source1.get.attributes.get.parseJson.convertTo[SqlEntityData](CompactEntitySerialization.sqlEntityDataFormat)
     rawData1.attrs.keys should not contain newAttributeName
     rawData1.attrs.keys should contain(AttributeName.withDefaultNS("refList"))
+
+    // Validate the raw JSON string to ensure proper spacing in the pattern matching
+    val rawJson = source1.get.attributes.get
+
+    // Validate that refs follow the proper JSON format with no spaces after colons
+    val refs = rawData1.refs
+    refs should not be empty
+
+    // Check each reference in the raw JSON string
+    refs.foreach { ref =>
+      // The attribute name should be formatted without spaces after colons: "a":"attrName"
+      rawJson should include(s""""a": "${ref.a}"""")
+      // There should not be a version with a space after the colon
+      rawJson should not include s""""a":"${ref.a}""""
+
+      // Same check for entityName
+      rawJson should include(s""""n": "${ref.n}"""")
+      rawJson should not include s""""n":"${ref.n}""""
+
+      // Same check for entityType
+      rawJson should include(s""""t": "${ref.t}"""")
+      rawJson should not include s""""t":"${ref.t}""""
+    }
+
+    // Additionally, verify the old attribute name is not present
+    rawJson should not include s""""a": "${toDelimitedName(originalAttributeName)}""""
+    rawJson should not include s""""a":"${toDelimitedName(originalAttributeName)}""""
   }
 
   /**

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -895,6 +895,67 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     )
   }
 
+  it should "update both $.attrs and $.refs" in withMinimalTestDatabase { _ =>
+    import scala.language.postfixOps
+    // Create the original entity with an attribute
+    val entityType = "testType"
+    val originalAttributeName = AttributeName.withDefaultNS("originalAttr")
+    val newAttributeName = AttributeName.withDefaultNS("newAttr")
+    val originalEntity = Entity(
+      "entityName",
+      entityType,
+      Map(
+        originalAttributeName -> AttributeString("attributeValue")
+      )
+    )
+    insertAndGet(originalEntity)
+
+    // Create source entities referencing the original attribute
+    val sourceEntity1 = Entity(
+      "sourceEntity1",
+      "sourceType",
+      Map(
+        AttributeName.withDefaultNS("refList") -> AttributeEntityReferenceList(
+          Seq(originalEntity.toReference)
+        )
+      )
+    )
+    val sourceEntity2 = Entity(
+      "sourceEntity2",
+      "sourceType",
+      Map(
+        originalAttributeName -> AttributeString("attributeValue")
+      )
+    )
+    insertAndGetAll(Seq(sourceEntity1, sourceEntity2))
+
+    // Rename the attribute
+    runAndWait(q.renameAttribute(wsid, entityType, originalAttributeName, AttributeRename(newAttributeName))) shouldBe 1
+
+    // Verify the attribute was renamed in the original entity
+    val updatedEntity = runAndWait(q.getEntity(wsid, entityType, originalEntity.name)).get.toEntity
+    updatedEntity.attributes should contain key newAttributeName
+    updatedEntity.attributes.contains(originalAttributeName) shouldBe false
+
+    // Verify the attribute was NOT updated in sourceEntity2 (different entity type)
+    val source2 = runAndWait(q.getEntity(wsid, "sourceType", "sourceEntity2"))
+    source2 should not be empty
+    source2.get.attributes should not be empty
+    val rawData2 =
+      source2.get.attributes.get.parseJson.convertTo[SqlEntityData](CompactEntitySerialization.sqlEntityDataFormat)
+    rawData2.attrs.keys should contain(originalAttributeName)
+    rawData2.attrs.keys should not contain newAttributeName
+
+    // Verify that sourceEntity1 remains unchanged in $.attrs
+    val source1 = runAndWait(q.getEntity(wsid, "sourceType", "sourceEntity1"))
+    source1 should not be empty
+    source1.get.attributes should not be empty
+    val rawData1 =
+      source1.get.attributes.get.parseJson.convertTo[SqlEntityData](CompactEntitySerialization.sqlEntityDataFormat)
+    rawData1.attrs.keys should not contain newAttributeName
+    rawData1.attrs.keys should contain(AttributeName.withDefaultNS("refList"))
+  }
+
   /**
    * Creates 1 entity with the first half of keys, 1 entity with the second half of keys, and 1 entity with no keys.
    */


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-542

Support for rename-entity-attribute for Quicksilver/Compact data tables using v2 Serialization.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
