### PR TITLE
CORE-500 handle 403s

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
@@ -151,8 +151,15 @@ class WorkspaceAdminService(
                                                       ctx: RawlsRequestContext
   ): Future[Unit] =
     for {
-      // Get all child resources
-      children <- samDAO.listResourceChildren(resourceTypeName, resourceId, ctx)
+      // Get all child resources, handle 403 errors by treating them as empty lists
+      // not having permission to list children is not an error, it means children are not allowed
+      children <- samDAO
+        .listResourceChildren(resourceTypeName, resourceId, ctx)
+        .recover {
+          case e: RawlsExceptionWithErrorReport if e.errorReport.statusCode.contains(StatusCodes.Forbidden) =>
+            logger.info(s"Received 403 when listing children of $resourceTypeName/$resourceId, treating as empty list")
+            Seq.empty
+        }
 
       // Recursively delete each child resource
       _ <- Future.traverse(children) { child =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamAdminDAO, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.{
+  ErrorReport,
   RawlsRequestContext,
   RawlsUserEmail,
   RawlsUserSubjectId,
@@ -481,5 +482,72 @@ class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
       Await.result(service.getWorkspaceId(workspaceName), Duration.Inf)
     }
     exception.errorReport.statusCode shouldEqual Option(StatusCodes.Forbidden)
+  }
+
+  it should "handle 403 Forbidden errors when listing resource children" in {
+    val resourceTypeName = SamResourceTypeNames.workspace
+    val resourceId = UUID.randomUUID().toString
+    val childResource = SamFullyQualifiedResourceId("child-id", "child-type")
+
+    val samDAO = mock[SamDAO]
+
+    // Mock a 403 Forbidden error for the parent resource's children
+    when(
+      samDAO.listResourceChildren(
+        ArgumentMatchers.eq(resourceTypeName),
+        ArgumentMatchers.eq(resourceId),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(
+      Future.failed(
+        new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "Forbidden"))
+      )
+    )
+
+    // Mock successful listing for the child resource (this should never be called)
+    when(
+      samDAO.listResourceChildren(
+        ArgumentMatchers.eq(SamResourceTypeName(childResource.resourceTypeName)),
+        ArgumentMatchers.eq(childResource.resourceId),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(List.empty))
+
+    // Mock deleteResource to return success
+    when(
+      samDAO.deleteResource(
+        ArgumentMatchers.any(),
+        ArgumentMatchers.any(),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(()))
+
+    val service = workspaceAdminServiceConstructor(samDAO = samDAO)
+
+    // Call the method under test - should not throw an exception
+    Await.result(service.recursivelyDeleteSamResource(resourceTypeName, resourceId, defaultRequestContext),
+                 Duration.Inf
+    )
+
+    // Verify that listResourceChildren was called for the parent resource
+    verify(samDAO).listResourceChildren(
+      ArgumentMatchers.eq(resourceTypeName),
+      ArgumentMatchers.eq(resourceId),
+      ArgumentMatchers.any()
+    )
+
+    // Verify that no other listResourceChildren calls were made
+    verify(samDAO, times(1)).listResourceChildren(
+      ArgumentMatchers.any(),
+      ArgumentMatchers.any(),
+      ArgumentMatchers.any()
+    )
+
+    // Verify that deleteResource was called only for the parent resource
+    verify(samDAO, times(1)).deleteResource(
+      ArgumentMatchers.eq(resourceTypeName),
+      ArgumentMatchers.eq(resourceId),
+      ArgumentMatchers.any()
+    )
   }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-500

Apparently I never tried this api in dev. Turns out that it fails when listing children of resources for resource types that don't support children. This is the fix.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
