### PR TITLE
AN-628 Liquibase migration to turn GCP Batch on for all workspaces

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -143,4 +143,5 @@
     <include file="changesets/20250428_entity_keys_update_trigger.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250514_use_names_in_entity_refs.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250604_entity_refs_view.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20250616_remove_all_gcpbatch_workspace_settings.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250616_remove_all_gcpbatch_workspace_settings.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250616_remove_all_gcpbatch_workspace_settings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
+    <changeSet logicalFilePath="dummy" author="jdewar" id="remove_all_gcpbatch_workspace_settings">
+        <sql>
+            UPDATE WORKSPACE_SETTINGS
+                SET STATUS = 'Deleted',
+                    LAST_UPDATED = NOW(6)
+                WHERE SETTING_TYPE = 'UseCromwellGcpBatchBackend'
+                  AND STATUS = 'Applied'
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Ticket: [AN-628](https://broadworkbench.atlassian.net/browse/AN-628)

This liquibase change causes all workspaces to run workflows on GCP Batch. Intended to be released at the same time as https://github.com/DataBiosphere/terra-ui/pull/5348, which removes the UI controls to change this setting.

This is the change that will move GCP Batch to "GA" status in Terra. All users will be forced over to run workflows on Batch, but the functionality to adjust this workspace setting via API still exists for special cases. 

Tested in my BEE, behaved as expected.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[AN-628]: https://broadworkbench.atlassian.net/browse/AN-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AN-611]: https://broadworkbench.atlassian.net/browse/AN-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ