### PR TITLE
CORE-495: simplify quicksilver hard-deletes by using ignore keyword

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -517,7 +517,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   // The `ignore` keyword in the delete statement means this will delete all rows which do NOT
   // have foreign keys pointing to them. It will skip over, and leave in place, any rows which
   // do have foreign keys pointing to them.
-  private def deleteEntitiesImpl(workspaceId: UUID, whereClause: SQLActionBuilder): SQLActionBuilder = {
+  private def deleteEntitiesImpl(workspaceId: UUID, whereClause: SQLActionBuilder): SQLActionBuilder =
     concatSqlActions(
       sql"""delete ignore
               from ENTITY
@@ -526,7 +526,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
               and """,
       whereClause
     )
-  }
 
   // Gets any entities that have references to the entities in the given list
   // Excludes entities that are in the list

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -492,7 +492,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   def deleteEntities(workspaceId: UUID, entities: Seq[EntityPointer]): ReadWriteAction[Int] = {
     // join all the clauses with "or": `(entity_type = ? and name in (?)) or `(entity_type = ? and name in (?))`
     val criteriaSql: SQLActionBuilder = reduceSqlActionsWithDelim(generateTypeNameSql(entities.toSet).toSeq, sql" or ")
-    val whereClause = concatSqlActions(sql" (", criteriaSql, sql")")
+    val whereClause = concatSqlActions(sql"(", criteriaSql, sql")")
     val finalSql = deleteEntitiesImpl(workspaceId, whereClause)
     finalSql.asUpdate
   }
@@ -506,7 +506,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     * execution plan: index range scan; using where. Index: idx_entity_type_name
     */
   def deleteEntitiesOfType(workspaceId: UUID, entityType: String): ReadWriteAction[Int] = {
-    val whereClause = sql" entity_type = $entityType"
+    val whereClause = sql"entity_type = $entityType"
     val finalSql = deleteEntitiesImpl(workspaceId, whereClause)
     finalSql.asUpdate
   }
@@ -517,10 +517,9 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   // do have foreign keys pointing to them.
   private def deleteEntitiesImpl(workspaceId: UUID, whereClause: SQLActionBuilder): SQLActionBuilder =
     concatSqlActions(
-      sql"""delete ignore
-              from ENTITY
+      sql"""delete ignore from ENTITY
               where workspace_id = $workspaceId
-              and deleted = 1
+              and deleted = 0
               and """,
       whereClause
     )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -493,7 +493,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   def deleteEntities(workspaceId: UUID, entities: Seq[EntityPointer]): ReadWriteAction[Int] = {
     // join all the clauses with "or": `(entity_type = ? and name in (?)) or `(entity_type = ? and name in (?))`
     val criteriaSql: SQLActionBuilder = reduceSqlActionsWithDelim(generateTypeNameSql(entities.toSet).toSeq, sql" or ")
-    val whereClause = concatSqlActions(sql"where (", criteriaSql, sql")")
+    val whereClause = concatSqlActions(sql" (", criteriaSql, sql")")
     val finalSql = deleteEntitiesImpl(workspaceId, whereClause)
     finalSql.asUpdate
   }
@@ -508,36 +508,24 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     *   and requires a temporary table for the big union.
     */
   def deleteEntitiesOfType(workspaceId: UUID, entityType: String): ReadWriteAction[Int] = {
-    val whereClause = sql"where entity_type = $entityType"
+    val whereClause = sql" entity_type = $entityType"
     val finalSql = deleteEntitiesImpl(workspaceId, whereClause)
     finalSql.asUpdate
   }
 
-  // private helper for deleteEntities and deleteEntitiesOfType
+  // Private helper for deleteEntities and deleteEntitiesOfType.
+  // The `ignore` keyword in the delete statement means this will delete all rows which do NOT
+  // have foreign keys pointing to them. It will skip over, and leave in place, any rows which
+  // do have foreign keys pointing to them.
   private def deleteEntitiesImpl(workspaceId: UUID, whereClause: SQLActionBuilder): SQLActionBuilder = {
-    val startSql = sql"""with
-            CANDIDATE_WORKFLOWS as (select wf.ID, wf.ENTITY_ID
-              from WORKFLOW wf, SUBMISSION s
-              where wf.SUBMISSION_ID = s.ID and s.WORKSPACE_ID = $workspaceId)
-          delete e from ENTITY e """
-
-    // where clause gets inserted here, e.g. `where e.entity_type = ?`
-
-    val endSql = sql""" and e.workspace_id = $workspaceId
-          and e.id not in (
-            select value_entity_ref from WORKSPACE_ATTRIBUTE where owner_id = $workspaceId and value_entity_ref is not null
-              union
-            select ENTITY_ID from SUBMISSION where WORKSPACE_ID = $workspaceId and ENTITY_ID is not null
-              union
-            select cw.ENTITY_ID from CANDIDATE_WORKFLOWS cw where ENTITY_ID is not null
-              union
-            select sa.value_entity_ref
-            from SUBMISSION_ATTRIBUTE sa, SUBMISSION_VALIDATION sv, CANDIDATE_WORKFLOWS cw
-            where sa.owner_id = sv.id and sv.WORKFLOW_ID = cw.ID and value_entity_ref is not null
-          )
-       """
-
-    concatSqlActions(startSql, whereClause, endSql)
+    concatSqlActions(
+      sql"""delete ignore
+              from ENTITY
+              where workspace_id = $workspaceId
+              and deleted = 1
+              and """,
+      whereClause
+    )
   }
 
   // Gets any entities that have references to the entities in the given list

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -485,10 +485,9 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   }
 
   /**
-    * Hard-delete all of the specified entities that do not have any foreign keys pointed at them.
+    * Hard-delete all the specified entities that do not have any foreign keys pointed at them.
     *
-    * execution plan: admittedly a mess, but no full table scans. Uses indexes and wheres. Lots of joins and unions
-    *   and requires a temporary table for the big union.
+    * execution plan: index range scan; using where. Index: idx_entity_type_name
     */
   def deleteEntities(workspaceId: UUID, entities: Seq[EntityPointer]): ReadWriteAction[Int] = {
     // join all the clauses with "or": `(entity_type = ? and name in (?)) or `(entity_type = ? and name in (?))`
@@ -504,8 +503,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     * Note this does not have a "where deleted=0" clause. Thus, it will also hard-delete any entities
     * that were previously soft-deleted but which no longer have anything pointing at them (this is unlikely)
     *
-    * execution plan: admittedly a mess, but no full table scans. Uses indexes and wheres. Lots of joins and unions
-    *   and requires a temporary table for the big union.
+    * execution plan: index range scan; using where. Index: idx_entity_type_name
     */
   def deleteEntitiesOfType(workspaceId: UUID, entityType: String): ReadWriteAction[Int] = {
     val whereClause = sql" entity_type = $entityType"


### PR DESCRIPTION
Ticket: CORE-495

TIL about the `ignore` keyword for deletes in MySQL: https://dev.mysql.com/doc/refman/8.0/en/delete.html#idm45979719159376

This keyword ignores foreign-key errors when deleting rows.

We can use this to greatly simplify - and improve efficiency of - the hard-delete code in Quicksilver.