### PR TITLE
CORE-483: quicksilver cromwell outputs

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -179,7 +179,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
   /** Given a set of entity ids, return the CompactEntityRecord for those ids.
    *
-   * `TODO: execution plan`
+   * execution plan: index range scan on primary key. Might also use idx_entity_type_name
+   *    depending on the query planner's whims
    */
   def getEntitiesByIds(workspaceId: UUID, ids: Seq[Long]): ReadAction[Seq[CompactEntityRecord]] =
     // short-circuit

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -195,8 +195,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
                where workspace_id = $workspaceId
                and deleted = 0
                and id in ( """,
-              inClause,
-              sql""" );"""
+        inClause,
+        sql""" );"""
       )
 
       // execute

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -105,7 +105,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     *
     * `execution plan: multiple-row insert`
     */
-  def batchCreateEntities(workspaceId: UUID, entities: Seq[Entity], insertOnly: Boolean): ReadWriteAction[Int] = {
+  def batchWriteEntities(workspaceId: UUID, entities: Seq[Entity], insertOnly: Boolean): ReadWriteAction[Int] = {
     val baseSql =
       sql"""insert into ENTITY(name, entity_type, workspace_id, record_version, deleted, attributes) values """
 
@@ -134,7 +134,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     * `execution plan: single-row insert`
     */
   def createEntity(workspaceId: UUID, entity: Entity): ReadWriteAction[Int] =
-    batchCreateEntities(workspaceId, Seq(entity), insertOnly = true)
+    batchWriteEntities(workspaceId, Seq(entity), insertOnly = true)
 
   /**
     * Read a single entity from the db

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -177,6 +177,32 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       query.as[CompactEntityRecord]
     }
 
+  /** Given a set of entity ids, return the CompactEntityRecord for those ids.
+   *
+   * `TODO: execution plan`
+   */
+  def getEntitiesByIds(workspaceId: UUID, ids: Seq[Long]): ReadAction[Seq[CompactEntityRecord]] =
+    // short-circuit
+    if (ids.isEmpty) {
+      DBIO.successful(Seq())
+    } else {
+      val inClause = reduceSqlActionsWithDelim(ids.map(id => sql"$id"), sql", ")
+
+      // build the overall query
+      val query = concatSqlActions(
+        sql"""select id, name, entity_type, workspace_id, record_version, deleted, attributes
+               from ENTITY
+               where workspace_id = $workspaceId
+               and deleted = 0
+               and id in ( """,
+              inClause,
+              sql""" );"""
+      )
+
+      // execute
+      query.as[CompactEntityRecord]
+    }
+
   /** Given a set of entity type/name pairs, return the CompactEntityVersionRecord for those pairs.
     *
     * `execution plan: index range scan on idx_entity_type_name`

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -456,7 +456,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
     dataAccess: DataAccess,
     workspace: Workspace,
     updatedEntities: Seq[Entity]
-  ): ReadWriteAction[Traversable[Entity]] =
+  ): ReadWriteAction[Int] =
     for {
       provider <- DBIO.from(getProviderWithTracing(workspace, ctx))
       res <- provider.saveWorkflowOutputEntities(dataAccess, workspace, updatedEntities)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/AuditLoggingEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/AuditLoggingEntityProvider.scala
@@ -99,7 +99,7 @@ class AuditLoggingEntityProvider(val delegate: EntityProvider, val requestArgume
     dataAccess: DataAccess,
     workspace: Workspace,
     updatedEntities: Seq[Entity]
-  ): ReadWriteAction[Traversable[Entity]] = {
+  ): ReadWriteAction[Int] = {
     logAudit("saveWorkflowOutputEntities")
     delegate.saveWorkflowOutputEntities(dataAccess, workspace, updatedEntities)
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -44,17 +44,6 @@ trait EntityProvider {
                           parentContext: RawlsRequestContext
   ): Future[Int]
 
-  def saveWorkflowOutputEntities(
-    dataAccess: DataAccess,
-    workspace: Workspace,
-    updatedEntities: Seq[Entity]
-  ): ReadWriteAction[Traversable[Entity]]
-
-  def listWorkflowEntities(dataAccess: DataAccess,
-                           workspace: Workspace,
-                           entityIds: Seq[Long]
-  ): ReadAction[Map[Long, Entity]]
-
   def copyEntities(sourceWorkspaceContext: Workspace,
                    destWorkspaceContext: Workspace,
                    entityType: String,
@@ -115,6 +104,11 @@ trait EntityProvider {
 
   def listEntities(entityType: String): Source[Entity, NotUsed]
 
+  def listWorkflowEntities(dataAccess: DataAccess,
+                           workspace: Workspace,
+                           entityIds: Seq[Long]
+                          ): ReadAction[Map[Long, Entity]]
+
   def queryEntities(entityType: String,
                     query: EntityQuery,
                     parentContext: RawlsRequestContext
@@ -138,6 +132,12 @@ trait EntityProvider {
   ): Future[Int]
 
   def renameEntityType(oldName: String, renameInfo: EntityTypeRename, parentContext: RawlsRequestContext): Future[Int]
+
+  def saveWorkflowOutputEntities(
+                                  dataAccess: DataAccess,
+                                  workspace: Workspace,
+                                  updatedEntities: Seq[Entity]
+                                ): ReadWriteAction[Int]
 
   def updateEntity(entityType: String,
                    entityName: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -107,7 +107,7 @@ trait EntityProvider {
   def listWorkflowEntities(dataAccess: DataAccess,
                            workspace: Workspace,
                            entityIds: Seq[Long]
-                          ): ReadAction[Map[Long, Entity]]
+  ): ReadAction[Map[Long, Entity]]
 
   def queryEntities(entityType: String,
                     query: EntityQuery,
@@ -134,10 +134,10 @@ trait EntityProvider {
   def renameEntityType(oldName: String, renameInfo: EntityTypeRename, parentContext: RawlsRequestContext): Future[Int]
 
   def saveWorkflowOutputEntities(
-                                  dataAccess: DataAccess,
-                                  workspace: Workspace,
-                                  updatedEntities: Seq[Entity]
-                                ): ReadWriteAction[Int]
+    dataAccess: DataAccess,
+    workspace: Workspace,
+    updatedEntities: Seq[Entity]
+  ): ReadWriteAction[Int]
 
   def updateEntity(entityType: String,
                    entityName: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -402,10 +402,15 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                                     workspace: Workspace,
                                     entityIds: Seq[Long]
   ): ReadAction[Map[Long, Entity]] =
-    repository.queries.getEntitiesByIds(workspace.workspaceIdAsUUID, entityIds).map { records =>
-      records.map { rec =>
-        rec.id -> rec.toEntity
-      }.toMap
+    if (entityIds.isEmpty)
+      DBIO.successful(Map.empty)
+    else {
+      // get the entities from the database
+      repository.queries.getEntitiesByIds(workspace.workspaceIdAsUUID, entityIds).map { records =>
+        records.map { rec =>
+          rec.id -> rec.toEntity
+        }.toMap
+      }
     }
 
   override def queryEntities(entityType: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -399,9 +399,9 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
   }
 
   override def listWorkflowEntities(dataAccess: DataAccess,
-                           workspace: Workspace,
-                           entityIds: Seq[Long]
-                          ): ReadAction[Map[Long, Entity]] = repository.queries.getEntitiesByIds(workspace.workspaceIdAsUUID, entityIds)
+                                    workspace: Workspace,
+                                    entityIds: Seq[Long]
+  ): ReadAction[Map[Long, Entity]] = repository.queries.getEntitiesByIds(workspace.workspaceIdAsUUID, entityIds)
 
   override def queryEntities(entityType: String,
                              query: EntityQuery,
@@ -588,17 +588,15 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
     renameFuture
   }
 
-
   override def saveWorkflowOutputEntities(
-                                  dataAccess: DataAccess,
-                                  workspace: Workspace,
-                                  updatedEntities: Seq[Entity]
-                                ): ReadWriteAction[Int] = {
+    dataAccess: DataAccess,
+    workspace: Workspace,
+    updatedEntities: Seq[Entity]
+  ): ReadWriteAction[Int] =
     if (updatedEntities.isEmpty)
       DBIO.successful(0)
     else
       repository.queries.batchWriteEntities(workspace.workspaceIdAsUUID, updatedEntities, insertOnly = false)
-  }
 
   override def updateEntity(entityType: String,
                             entityName: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -401,7 +401,12 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
   override def listWorkflowEntities(dataAccess: DataAccess,
                                     workspace: Workspace,
                                     entityIds: Seq[Long]
-  ): ReadAction[Map[Long, Entity]] = repository.queries.getEntitiesByIds(workspace.workspaceIdAsUUID, entityIds)
+  ): ReadAction[Map[Long, Entity]] =
+    repository.queries.getEntitiesByIds(workspace.workspaceIdAsUUID, entityIds).map { records =>
+      records.map { rec =>
+        rec.id -> rec.toEntity
+      }.toMap
+    }
 
   override def queryEntities(entityType: String,
                              query: EntityQuery,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -101,17 +101,6 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
     dbResults
   }
 
-  def saveWorkflowOutputEntities(
-    dataAccess: DataAccess,
-    workspace: Workspace,
-    updatedEntities: Seq[Entity]
-  ): ReadWriteAction[Traversable[Entity]] = DBIO.successful(Seq()) // TODO CORE-483: implement this
-
-  def listWorkflowEntities(dataAccess: DataAccess,
-                           workspace: Workspace,
-                           entityIds: Seq[Long]
-  ): ReadAction[Map[Long, Entity]] = DBIO.successful(Map()) // TODO CORE-483: implement this
-
   override def copyEntities(sourceWorkspaceContext: Workspace,
                             destWorkspaceContext: Workspace,
                             entityType: String,
@@ -409,6 +398,11 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
       .map(_.toEntity)
   }
 
+  override def listWorkflowEntities(dataAccess: DataAccess,
+                           workspace: Workspace,
+                           entityIds: Seq[Long]
+                          ): ReadAction[Map[Long, Entity]] = repository.queries.getEntitiesByIds(workspace.workspaceIdAsUUID, entityIds)
+
   override def queryEntities(entityType: String,
                              query: EntityQuery,
                              parentContext: RawlsRequestContext
@@ -592,6 +586,18 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
 
     // Return the future
     renameFuture
+  }
+
+
+  override def saveWorkflowOutputEntities(
+                                  dataAccess: DataAccess,
+                                  workspace: Workspace,
+                                  updatedEntities: Seq[Entity]
+                                ): ReadWriteAction[Int] = {
+    if (updatedEntities.isEmpty)
+      DBIO.successful(0)
+    else
+      repository.queries.batchWriteEntities(workspace.workspaceIdAsUUID, updatedEntities, insertOnly = false)
   }
 
   override def updateEntity(entityType: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -211,7 +211,7 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
     for {
       // Batch insert to ENTITY table. Save the whole batch first to handle cases where an entity in this batch
       // has a reference to another entity in the same batch.
-      entitiesCreated <- repository.queries.batchCreateEntities(workspaceId, batch, insertOnly = false)
+      entitiesWritten <- repository.queries.batchWriteEntities(workspaceId, batch, insertOnly = false)
 
       // Find all requested references within this batch
       allReferences: Set[RefMapping] = findAllReferences(batch)
@@ -227,6 +227,6 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
       _ = if (!allExist)
         throw new EntityReferenceNotFoundException("Some entity references do not exist")
 
-    } yield entitiesCreated
+    } yield entitiesWritten
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -629,10 +629,10 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     dataAccess: DataAccess,
     workspace: Workspace,
     updatedEntities: Seq[Entity]
-  ): ReadWriteAction[Traversable[Entity]] =
+  ): ReadWriteAction[Int] =
     dataAccess.entityQuery
       .save(workspace, updatedEntities)
-      .withStatementParameters(statementInit = _.setQueryTimeout(queryTimeout.toSeconds.toInt))
+      .withStatementParameters(statementInit = _.setQueryTimeout(queryTimeout.toSeconds.toInt)).map(_.size)
 
   override def listWorkflowEntities(dataAccess: DataAccess,
                                     workspace: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -632,7 +632,8 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
   ): ReadWriteAction[Int] =
     dataAccess.entityQuery
       .save(workspace, updatedEntities)
-      .withStatementParameters(statementInit = _.setQueryTimeout(queryTimeout.toSeconds.toInt)).map(_.size)
+      .withStatementParameters(statementInit = _.setQueryTimeout(queryTimeout.toSeconds.toInt))
+      .map(_.size)
 
   override def listWorkflowEntities(dataAccess: DataAccess,
                                     workspace: Workspace,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -81,7 +81,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     // should throw a primary key violation error
     intercept[SQLIntegrityConstraintViolationException](
-      runAndWait(q.batchCreateEntities(wsid, entities, insertOnly = true))
+      runAndWait(q.batchWriteEntities(wsid, entities, insertOnly = true))
     )
 
     // entity 2 should still exist
@@ -2202,8 +2202,8 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     )
 
     // insert the entities
-    runAndWait(q.batchCreateEntities(wsid, ws1Entities, insertOnly = true)) shouldBe ws1Entities.size
-    runAndWait(q.batchCreateEntities(ws2id, ws2Entities, insertOnly = true)) shouldBe ws2Entities.size
+    runAndWait(q.batchWriteEntities(wsid, ws1Entities, insertOnly = true)) shouldBe ws1Entities.size
+    runAndWait(q.batchWriteEntities(ws2id, ws2Entities, insertOnly = true)) shouldBe ws2Entities.size
 
     // validate listed entities of entityType "testEntityType" in the first workspace
     runAndWait(q.listEntities(wsid, testEntityType)).map(_.toEntity) should contain theSameElementsAs Seq(entity1,
@@ -2711,7 +2711,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
         AttributeName.withDefaultNS("ref") -> AttributeEntityReference(entity1.entityType, entity1.name)
       )
     )
-    runAndWait(q.batchCreateEntities(workspaceId, Seq(entity1Update, entity2Update), insertOnly = false))
+    runAndWait(q.batchWriteEntities(workspaceId, Seq(entity1Update, entity2Update), insertOnly = false))
 
     // Perform the recursive query
     val recursiveReferences = runAndWait(q.recursiveGetEntityReferences(workspaceId, Set(entity1.toPointer)))
@@ -2756,7 +2756,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     }
 
     // insert the entities
-    runAndWait(q.batchCreateEntities(workspaceId, entities, insertOnly = true)) shouldBe entities.size
+    runAndWait(q.batchWriteEntities(workspaceId, entities, insertOnly = true)) shouldBe entities.size
     // retrieve the entities; retrieved value includes its id
     entities.map { entity =>
       val actual = runAndWait(q.getEntity(workspaceId, entity.entityType, entity.name))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -194,6 +194,75 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     actual.map(_.toAttributeEntityReference) should contain theSameElementsAs expected
   }
 
+  behavior of "getEntitiesByIds"
+
+  it should "return nothing if asked for nothing" in withMinimalTestDatabase { _ =>
+    val entity1 = Entity("entityName1", "entityType", Map())
+    val entity2 = Entity("entityName2", "entityType", Map())
+    val entity3 = Entity("entityName3", "entityType", Map())
+
+    insertAndGetAll(Seq(entity1, entity2, entity3))
+
+    val actual = runAndWait(q.getEntitiesByIds(wsid, Seq.empty))
+    actual shouldBe empty
+  }
+
+  it should "return existent entities" in withMinimalTestDatabase { dataSource =>
+    import driver.api._ // for Slick queries in this test
+
+    val entity1 = Entity("entityName1", "entityType", Map())
+    val entity2 = Entity("entityName2", "entityType", Map())
+    val entity3 = Entity("entityName3", "entityType", Map())
+
+    insertAndGetAll(Seq(entity1, entity2, entity3))
+
+    // use the high-level Slick query object to get the actual rows saved to the database
+    val slickQuery: ReadAction[Seq[CompactEntityRecord]] = dataSource.dataAccess.compactEntitySlickQuery
+      .filter(e => e.workspaceId === wsid && e.entityType === entity1.entityType)
+      .result
+
+    val records: Seq[CompactEntityRecord] = runAndWait(slickQuery)
+
+    val ids = records.map(_.id)
+
+    val actual = runAndWait(q.getEntitiesByIds(wsid, ids))
+
+    actual should contain theSameElementsAs records
+  }
+
+  it should "return what it found even if not all entities exist" in withMinimalTestDatabase { dataSource =>
+    import driver.api._ // for Slick queries in this test
+
+    val entity1 = Entity("entityName1", "entityType", Map())
+    val entity2 = Entity("entityName2", "entityType", Map())
+    val entity3 = Entity("entityName3", "entityType", Map())
+
+    insertAndGetAll(Seq(entity1, entity2, entity3))
+
+    // use the high-level Slick query object to get the actual rows saved to the database
+    val slickQuery: ReadAction[Seq[CompactEntityRecord]] = dataSource.dataAccess.compactEntitySlickQuery
+      .filter(e => e.workspaceId === wsid && e.entityType === entity1.entityType)
+      .result
+
+    val records: Seq[CompactEntityRecord] = runAndWait(slickQuery)
+
+    // and another query to find the max id currently in ENTITY
+    val maxEntityId = runAndWait(sql"select max(id) from ENTITY".as[Long].head)
+
+    // define which entity we are asking for (entity2)
+    val selectedRecords = records.filter(_.name == entity2.name)
+
+    // request 1 of the ids that exists, and more that do not
+    val ids = selectedRecords.map(_.id) ++ Seq(
+      maxEntityId + 1,
+      maxEntityId + 2
+    )
+
+    val actual = runAndWait(q.getEntitiesByIds(wsid, ids))
+
+    actual should contain theSameElementsAs selectedRecords
+  }
+
   behavior of "ENTITY_KEYS population triggers"
   // the ENTITY_KEYS table is populated by triggers on the ENTITY table.
   // these tests verify the behavior of those triggers.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -1163,6 +1163,39 @@ class CompactEntityProviderSpec
     actual.code shouldBe StatusCodes.NotFound
   }
 
+  behavior of "saveWorkflowOutputEntities"
+
+  it should "pass the workspace and requested entities to the downstream query" in {
+    val mockQueries = mock[CompactEntityQuery]
+    when(mockQueries.batchWriteEntities(any(), any(), any()))
+      .thenReturn(DBIO.successful(2))
+    val provider = providerWithMocks(mockQueries)
+
+    val mockDataAccess = mock[DataAccess]
+
+    val entitiesToUpdate = Seq(
+      Entity("name1", "type", Map(AttributeName.withDefaultNS("foo") -> AttributeString("bar"))),
+      Entity("name2", "type", Map(AttributeName.withDefaultNS("baz") -> AttributeNumber(42)))
+    )
+
+    val actual = runAndWait(provider.saveWorkflowOutputEntities(mockDataAccess, defaultWorkspace, entitiesToUpdate), atMost)
+
+    verify(mockQueries, times(1)).batchWriteEntities(defaultWorkspace.workspaceIdAsUUID, entitiesToUpdate, insertOnly = false)
+  }
+
+  it should "bypass the database when asked to save nothing" in {
+    val mockQueries = mock[CompactEntityQuery]
+    val provider = providerWithMocks(mockQueries)
+
+    val mockDataAccess = mock[DataAccess]
+
+    val actual = runAndWait(provider.saveWorkflowOutputEntities(mockDataAccess, defaultWorkspace, Seq.empty[Entity]), atMost)
+
+    actual shouldBe 0
+
+    verify(mockQueries, never()).batchWriteEntities(any(), any(), any())
+  }
+
   // ====================================================================================================
   // tests for CompactEntityProvider helper methods
   // ====================================================================================================

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -740,6 +740,40 @@ class CompactEntityProviderSpec
     actual shouldBe a[EntityNotFoundException]
   }
 
+  behavior of "listWorkflowEntities"
+
+  it should "pass the workspace and requested entity ids to the downstream query" in {
+    val mockQueries = mock[CompactEntityQuery]
+
+    val requestedIds = Seq(111L, 222L, 333L)
+
+    when(mockQueries.getEntitiesByIds(any(), any()))
+      .thenReturn(
+        DBIO.successful(Seq())
+      )
+    val provider = providerWithMocks(mockQueries)
+
+    val mockDataAccess = mock[DataAccess]
+
+    runAndWait(provider.listWorkflowEntities(mockDataAccess, defaultWorkspace, requestedIds), atMost)
+
+    verify(mockQueries, times(1)).getEntitiesByIds(defaultWorkspace.workspaceIdAsUUID, requestedIds)
+  }
+
+  it should "bypass the database when asked to save nothing" in {
+    val mockQueries = mock[CompactEntityQuery]
+    val provider = providerWithMocks(mockQueries)
+
+    val mockDataAccess = mock[DataAccess]
+
+    val actual =
+      runAndWait(provider.listWorkflowEntities(mockDataAccess, defaultWorkspace, Seq.empty[Long]), atMost)
+
+    actual shouldBe empty
+
+    verify(mockQueries, never()).getEntitiesByIds(any(), any())
+  }
+
   "queryEntities" should "have tests" is pending
   "queryEntitiesSource" should "have tests" is pending
 
@@ -1178,9 +1212,12 @@ class CompactEntityProviderSpec
       Entity("name2", "type", Map(AttributeName.withDefaultNS("baz") -> AttributeNumber(42)))
     )
 
-    val actual = runAndWait(provider.saveWorkflowOutputEntities(mockDataAccess, defaultWorkspace, entitiesToUpdate), atMost)
+    runAndWait(provider.saveWorkflowOutputEntities(mockDataAccess, defaultWorkspace, entitiesToUpdate), atMost)
 
-    verify(mockQueries, times(1)).batchWriteEntities(defaultWorkspace.workspaceIdAsUUID, entitiesToUpdate, insertOnly = false)
+    verify(mockQueries, times(1)).batchWriteEntities(defaultWorkspace.workspaceIdAsUUID,
+                                                     entitiesToUpdate,
+                                                     insertOnly = false
+    )
   }
 
   it should "bypass the database when asked to save nothing" in {
@@ -1189,7 +1226,8 @@ class CompactEntityProviderSpec
 
     val mockDataAccess = mock[DataAccess]
 
-    val actual = runAndWait(provider.saveWorkflowOutputEntities(mockDataAccess, defaultWorkspace, Seq.empty[Entity]), atMost)
+    val actual =
+      runAndWait(provider.saveWorkflowOutputEntities(mockDataAccess, defaultWorkspace, Seq.empty[Entity]), atMost)
 
     actual shouldBe 0
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -94,7 +94,7 @@ class CompactEntityProviderSpec
 
   it should "issue one insert statement for multiple entities" in {
     val mockQuery = mock[CompactEntityQuery]
-    when(mockQuery.batchCreateEntities(any(), any(), any())).thenReturn(DBIO.successful(0))
+    when(mockQuery.batchWriteEntities(any(), any(), any())).thenReturn(DBIO.successful(0))
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.getEntities(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityVersions(any(), any())).thenReturn(DBIO.successful(Seq()))
@@ -111,12 +111,12 @@ class CompactEntityProviderSpec
     Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
 
     // should have called one batch-insert to write the entities
-    verify(mockQuery, times(1)).batchCreateEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), any())
+    verify(mockQuery, times(1)).batchWriteEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), any())
   }
 
   it should "issue multiple insert statements when given large batches" in {
     val mockQuery = mock[CompactEntityQuery]
-    when(mockQuery.batchCreateEntities(any(), any(), any())).thenReturn(DBIO.successful(0))
+    when(mockQuery.batchWriteEntities(any(), any(), any())).thenReturn(DBIO.successful(0))
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.getEntities(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityVersions(any(), any())).thenReturn(DBIO.successful(Seq()))
@@ -142,12 +142,12 @@ class CompactEntityProviderSpec
 
     // should have called batchCreateEntities multiple times to write the entities
     verify(mockQuery, Mockito.atLeast(2))
-      .batchCreateEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), any())
+      .batchWriteEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), any())
   }
 
   it should "ask to insert references" in {
     val mockQuery = mock[CompactEntityQuery]
-    when(mockQuery.batchCreateEntities(any(), any(), any())).thenReturn(DBIO.successful(-1))
+    when(mockQuery.batchWriteEntities(any(), any(), any())).thenReturn(DBIO.successful(-1))
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.getEntities(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityVersions(any(), any())).thenReturn(DBIO.successful(Seq()))
@@ -184,7 +184,7 @@ class CompactEntityProviderSpec
     val ref3 = EntityPointer("typeB", "name3")
 
     // should have called one batch-insert to write the entities
-    verify(mockQuery, times(1)).batchCreateEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), any())
+    verify(mockQuery, times(1)).batchWriteEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any(), any())
   }
 
   "copyEntities" should "have tests" is pending


### PR DESCRIPTION
Ticket: CORE-483

Proactive implementation of the Quicksilver methods involved in writing Cromwell outputs back to data tables.

We will not be able to test this end-to-end until #3316 lands.

Some refactoring in this PR:
* rename `batchCreateEntities` to `batchWriteEntities`, since it is not limited to writes
* reorder methods in EntityProvider/CompactEntityProvider to remain alphabetical
* simplify the return value from `saveWorkflowOutputEntities`; the return value is not actually used anywhere.