### PR TITLE
CORE-544: optimize execution for reference-related queries

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -536,6 +536,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   // `execution plan:
   //    Using index condition (idx_entity_type_name); Using where; Using temporary on ENTITY
   //    Table function: json_table; Using temporary; Using where for view.`
+  // TODO CORE-544: evaluate optimizing this away from using ENTITY_REFS
   def getReferencesTo(workspaceId: UUID, refs: Seq[EntityPointer]): ReadAction[Seq[EntityPointer]] = {
     val toNameClause = reduceSqlActionsWithDelim(
       generateTypeNameSql(refs.toSet, typeColumn = "to_entity_type", nameColumn = "to_name").toSeq,
@@ -560,15 +561,14 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   // Excludes entities with the same type
   //
   // `execution plan:
-  //    Using index condition (idx_entity_type_name); Using where; Using temporary on ENTITY
-  //    Table function: json_table; Using temporary; Using where for view.`
+  //    Using index condition (idx_entity_type_name); Using where`
   def getReferencesToType(workspaceId: UUID, entityType: String): ReadAction[Seq[EntityPointer]] =
-    sql"""select from_entity_type, from_name
-         from ENTITY_REFS
-         where workspace_id = $workspaceId
-         and to_entity_type = $entityType
-         and from_entity_type != $entityType
-       """.as[EntityPointer]
+    sql"""select entity_type, name
+          from ENTITY
+          where workspace_id = $workspaceId
+          and entity_type != $entityType
+          and deleted = 0
+          and JSON_CONTAINS(attributes, JSON_OBJECT('t', $entityType), $slickRefsPath);""".as[EntityPointer]
 
   /*
    * Helper: generate `(entity_type = ? and name in (?, ?, ?))` sql clauses for a set of
@@ -1070,7 +1070,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   // ====================================================================================================
 
   /** look up the types&names of all entities referenced by the given entity */
-  // TODO CORE-544: optimize this away from using ENTITY_REFS; only used in tests
+  // N.B. MySQL effectively pushes this query's where clause down into the ENTITY_REFS view,
+  // so the query is efficient.
   @VisibleForTesting
   def getReferencesFrom(workspaceId: UUID, from: EntityPointer): ReadAction[Seq[EntityPointer]] =
     sql"""select to_entity_type, to_name

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -305,35 +305,41 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         .sequence(batches.map(batch => recursiveGetEntityReferences(workspaceId, batch)))
         .map(_.flatten.toSet)
     } else {
-      val entityTypeNameClauses =
-        generateTypeNameSql(entities, typeColumn = "from_entity_type", nameColumn = "from_name")
+      val entityTypeNameClauses = reduceSqlActionsWithDelim(generateTypeNameSql(entities).toSeq, sql" or ")
 
-      val baseSql = concatSqlActions(
+      val query = concatSqlActions(
         sql"""with recursive EntityReferences as (
-              select er.workspace_id, er.from_entity_id, er.from_entity_type, er.from_name, er.from_attribute_name, er.to_entity_type, er.to_name
-              from ENTITY_REFS er
-              where er.workspace_id = $workspaceId
-              and (""",
-        reduceSqlActionsWithDelim(entityTypeNameClauses.toSeq, sql" or "),
+                select workspace_id, id as from_entity_id, entity_type as from_entity_type, name as from_name,
+             	  jt.from_attribute_name, jt.to_entity_type, jt.to_name
+             	from ENTITY, JSON_TABLE(
+                             attributes,
+                             '$$.refs[*]' COLUMNS (
+                                 from_attribute_name varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.a',
+             					to_entity_type varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.t',
+             		            to_name varchar(254) PATH '$$.n'
+                              )) jt
+             	where workspace_id = $workspaceId
+             	and (""",
+        entityTypeNameClauses,
         sql""")
-           """
+             			union distinct
+             	select e.workspace_id, e.id as from_entity_id, e.entity_type as from_entity_type, e.name as from_name,
+             	  jt.from_attribute_name, jt.to_entity_type, jt.to_name
+             	from EntityReferences er1, ENTITY e, JSON_TABLE(
+                             e.attributes,
+                             '$$.refs[*]' COLUMNS (
+                                 from_attribute_name varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.a',
+             					to_entity_type varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.t',
+             		            to_name varchar(254) PATH '$$.n'
+                              )) jt
+             	where er1.to_entity_type = e.entity_type and er1.to_name = e.name
+             	and e.workspace_id = $workspaceId
+             )
+             select workspace_id, from_entity_id, from_entity_type, from_name, from_attribute_name, to_entity_type, to_name
+                     from EntityReferences;"""
       )
-      val recursiveSql = sql"""
-            union distinct
-            select er.workspace_id, er.from_entity_id, er.from_entity_type, er.from_name, er.from_attribute_name, er.to_entity_type, er.to_name
-            from EntityReferences er1
-            join ENTITY_REFS er
-            on er1.to_entity_type = er.from_entity_type and er1.to_name = er.from_name
-            where er.workspace_id = $workspaceId
-            )
-        """
 
-      val finalSql = sql"""
-        select workspace_id, from_entity_id, from_entity_type, from_name, from_attribute_name, to_entity_type, to_name
-        from EntityReferences
-      """
-
-      concatSqlActions(baseSql, recursiveSql, finalSql).as[RefPointerRecord].map { rows =>
+      query.as[RefPointerRecord].map { rows =>
         rows
           .groupMap(row => EntityPointer(row.fromEntityType, row.fromName))(row =>
             EntityPointer(row.toEntityType, row.toName)
@@ -1064,6 +1070,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   // ====================================================================================================
 
   /** look up the types&names of all entities referenced by the given entity */
+  // TODO CORE-544: optimize this away from using ENTITY_REFS; only used in tests
   @VisibleForTesting
   def getReferencesFrom(workspaceId: UUID, from: EntityPointer): ReadAction[Seq[EntityPointer]] =
     sql"""select to_entity_type, to_name

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -534,23 +534,28 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   // Excludes entities that are in the list
   //
   // `execution plan:
-  //    Using index condition (idx_entity_type_name); Using where; Using temporary on ENTITY
-  //    Table function: json_table; Using temporary; Using where for view.`
-  // TODO CORE-544: evaluate optimizing this away from using ENTITY_REFS
+  //    Using index condition (idx_entity_type_name); Using where
+  //    Table function: json_table; Using temporary; Using where`
   def getReferencesTo(workspaceId: UUID, refs: Seq[EntityPointer]): ReadAction[Seq[EntityPointer]] = {
     val toNameClause = reduceSqlActionsWithDelim(
       generateTypeNameSql(refs.toSet, typeColumn = "to_entity_type", nameColumn = "to_name").toSeq,
       sql" or "
     )
     val fromNameClause = reduceSqlActionsWithDelim(
-      generateTypeNameSql(refs.toSet, typeColumn = "from_entity_type", nameColumn = "from_name").toSeq,
+      generateTypeNameSql(refs.toSet).toSeq,
       sql" or "
     )
 
     val baseSql =
-      sql"""select from_entity_type, from_name
-            from ENTITY_REFS
-        where workspace_id = $workspaceId
+      sql"""select e.entity_type, e.name
+            from ENTITY e, JSON_TABLE(
+                e.attributes,
+                '$$.refs[*]' COLUMNS (
+					to_entity_type varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.t',
+		            to_name varchar(254) PATH '$$.n'
+                 )) jt
+        where e.workspace_id = $workspaceId
+        and e.deleted = 0
         and ("""
 
     concatSqlActions(baseSql, toNameClause, sql") and NOT (", fromNameClause, sql")")


### PR DESCRIPTION
Ticket: CORE-544

Optimizes the SQL execution for reference-related queries by NOT using the `ENTITY_REFS` view and directly using `JSON_TABLE` instead. I tried a few different SQL structures and ended up on the code in this PR. Query plans below - and yes I did switch from visual explain to `explain analyze` partway through.

---


## recursiveGetEntityReferences

Sample execution plan before:
![recursive-view](https://github.com/user-attachments/assets/e7013c2c-b62d-48f5-931a-bbf30e052584)

Sample execution plan after:
![recursive-noview](https://github.com/user-attachments/assets/fe98262d-571b-451e-9884-bc422b12051f)

## getReferencesToType

before:
```
-> Table scan on ENTITY_REFS  (cost=5..5 rows=0) (actual time=107..107 rows=0 loops=1)
    -> Materialize  (cost=2.5..2.5 rows=0) (actual time=107..107 rows=0 loops=1)
        -> Table scan on <temporary>  (cost=2.5..2.5 rows=0) (actual time=107..107 rows=0 loops=1)
            -> Temporary table with deduplication  (cost=0..0 rows=0) (actual time=107..107 rows=0 loops=1)
                -> Nested loop inner join  (actual time=107..107 rows=0 loops=1)
                    -> Filter: ((ENTITY.deleted = 0) and (ENTITY.attributes is not null))  (cost=107925 rows=40477) (actual time=0.0333..72.1 rows=39211 loops=1)
                        -> Index range scan on ENTITY using idx_entity_type_name over (workspace_id = 0xf1c1e3058735499281a30842956db245 AND NULL < entity_type < 'file_inventory') OR (workspace_id = 0xf1c1e3058735499281a30842956db245 AND 'file_inventory' < entity_type), with index condition: ((ENTITY.workspace_id = 0xf1c1e3058735499281a30842956db245) and (ENTITY.entity_type <> 'file_inventory'))  (cost=107925 rows=89948) (actual time=0.0319..67.5 rows=39211 loops=1)
                    -> Filter: (refs_tbl.to_entity_type = 'file_inventory')  (actual time=784e-6..784e-6 rows=0 loops=39211)
                        -> Materialize table function  (actual time=630e-6..653e-6 rows=0.246 loops=39211)
```

after:
```
-> Filter: ((ENTITY.deleted = 0) and json_contains(ENTITY.attributes,<cache>(json_object('t','file_inventory')),'$.refs'))  (cost=107925 rows=44974) (actual time=113..113 rows=0 loops=1)
    -> Index range scan on ENTITY using idx_entity_type_name over (workspace_id = 0xf1c1e3058735499281a30842956db245 AND NULL < entity_type < 'file_inventory') OR (workspace_id = 0xf1c1e3058735499281a30842956db245 AND 'file_inventory' < entity_type), with index condition: ((ENTITY.workspace_id = 0xf1c1e3058735499281a30842956db245) and (ENTITY.entity_type <> 'file_inventory'))  (cost=107925 rows=89948) (actual time=0.0923..81.3 rows=39211 loops=1)
```

## getReferencesTo

before:
```
-> Table scan on ENTITY_REFS  (cost=5..5 rows=0) (actual time=148..148 rows=3 loops=1)
    -> Materialize  (cost=2.5..2.5 rows=0) (actual time=148..148 rows=3 loops=1)
        -> Table scan on <temporary>  (cost=2.5..2.5 rows=0) (actual time=148..148 rows=3 loops=1)
            -> Temporary table with deduplication  (cost=0..0 rows=0) (actual time=148..148 rows=3 loops=1)
                -> Nested loop inner join  (actual time=0.0508..148 rows=3 loops=1)
                    -> Filter: ((ENTITY.deleted = 0) and (ENTITY.attributes is not null))  (cost=109975 rows=46004) (actual time=0.0319..104 rows=50701 loops=1)
                        -> Index lookup on ENTITY using idx_entity_type_name (workspace_id=0xf1c1e3058735499281a30842956db245), with index condition: ((ENTITY.workspace_id = 0xf1c1e3058735499281a30842956db245) and ((ENTITY.entity_type <> 'anvil_file') or (ENTITY.`name` not in ('e804b901-1ddf-363d-a72e-521e524b366d','1c27ae9b-9f7b-336d-b605-955daa765f23','ce8d7437-2e3f-3fac-8b8d-5bdcbbbccc5b'))))  (cost=109975 rows=105392) (actual time=0.0305..98.6 rows=50701 loops=1)
                    -> Filter: ((refs_tbl.to_entity_type = 'anvil_file') and (refs_tbl.to_name in ('e804b901-1ddf-363d-a72e-521e524b366d','1c27ae9b-9f7b-336d-b605-955daa765f23','ce8d7437-2e3f-3fac-8b8d-5bdcbbbccc5b')))  (actual time=761e-6..761e-6 rows=59.2e-6 loops=50701)
                        -> Materialize table function  (actual time=613e-6..631e-6 rows=0.19 loops=50701)
```

after:
```
-> Nested loop inner join  (actual time=0.0472..132 rows=3 loops=1)
    -> Filter: (e.deleted = 0)  (cost=110486 rows=51115) (actual time=0.0263..91.6 rows=50701 loops=1)
        -> Index lookup on e using idx_entity_type_name (workspace_id=0xf1c1e3058735499281a30842956db245), with index condition: ((e.workspace_id = 0xf1c1e3058735499281a30842956db245) and ((e.entity_type <> 'anvil_file') or (e.`name` not in ('e804b901-1ddf-363d-a72e-521e524b366d','1c27ae9b-9f7b-336d-b605-955daa765f23','ce8d7437-2e3f-3fac-8b8d-5bdcbbbccc5b'))))  (cost=110486 rows=105392) (actual time=0.025..87.3 rows=50701 loops=1)
    -> Filter: ((jt.to_entity_type = 'anvil_file') and (jt.to_name in ('e804b901-1ddf-363d-a72e-521e524b366d','1c27ae9b-9f7b-336d-b605-955daa765f23','ce8d7437-2e3f-3fac-8b8d-5bdcbbbccc5b')))  (actual time=696e-6..696e-6 rows=59.2e-6 loops=50701)
        -> Materialize table function  (actual time=546e-6..565e-6 rows=0.19 loops=50701)
```

