### PR TITLE
CORE-568: snapshot import protected check

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotReferenceCreationValidator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotReferenceCreationValidator.scala
@@ -4,6 +4,7 @@ import bio.terra.datarepo.model.{CloudPlatform => SnapshotCloudPlatform}
 import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.model.WorkspaceCloudPlatform.WorkspaceCloudPlatform
 import org.broadinstitute.dsde.rawls.model.{Workspace, WorkspaceCloudPlatform}
+import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
 
 object SnapshotReferenceCreationValidator {
   def constructor(workspaceContext: Workspace, snapshot: WrappedSnapshot): SnapshotReferenceCreationValidator =
@@ -22,8 +23,8 @@ class SnapshotReferenceCreationValidator(val workspaceContext: Workspace, val sn
   // Ideally this would rely on Terra Policy Service, but until TPS is enabled for GCP
   // We'll have to use this workaround for identifying protected status.
   @throws(classOf[ProtectedDataException])
-  def validateProtectedStatus(): Unit =
-    if (!isWorkspaceProtected && snapshot.isProtected) {
+  def validateProtectedStatus(workspaceService: WorkspaceService): Unit =
+    if (!isWorkspaceProtected(workspaceService) && snapshot.isProtected) {
       throw new ProtectedDataException("Unable to add protected snapshot to unprotected workspace.")
     }
 
@@ -54,6 +55,6 @@ class SnapshotReferenceCreationValidator(val workspaceContext: Workspace, val sn
       throw new UnsupportedPlatformException("Snapshots by reference are not supported for Azure datasets.")
     }
 
-  // TODO: get this information from a more authoritative source rather than relying on the hardcoded bucket prefix
-  private def isWorkspaceProtected: Boolean = workspaceContext.bucketName.startsWith("fc-secure")
+  private def isWorkspaceProtected(workspaceService: WorkspaceService): Boolean =
+    workspaceService.isBucketSecure(workspaceContext)
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -115,7 +115,7 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
         snapshotValidator.validateSnapshotPlatform()
 
         // prevent disallowed access across workspace or dataset protection boundaries
-        snapshotValidator.validateProtectedStatus()
+        snapshotValidator.validateProtectedStatus(workspaceServiceConstructor(ctx))
 
         val wsmPolicyInputs = workspaceAuthDomain.toList match {
           case Nil => None

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -224,8 +224,8 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
 
       // if any snapshots contain protected data, the workspace must be protected
       _ = if (
-        snapshotPaos.exists(PolicyUtilities.containsPolicy(_, TpsPolicies.ProtectedData)) && !PolicyUtilities
-          .containsPolicy(workspacePao, TpsPolicies.ProtectedData)
+        snapshotPaos.exists(PolicyUtilities.containsPolicy(_, TpsPolicies.ProtectedData)) && !rawlsWorkspace.bucketName
+          .startsWith("fc-secure")
       ) {
         throw new ProtectedDataException("Unable to add protected snapshot to unprotected workspace.")
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -224,8 +224,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
 
       // if any snapshots contain protected data, the workspace must be protected
       _ = if (
-        snapshotPaos.exists(PolicyUtilities.containsPolicy(_, TpsPolicies.ProtectedData)) && !rawlsWorkspace.bucketName
-          .startsWith("fc-secure")
+        snapshotPaos.exists(
+          PolicyUtilities.containsPolicy(_, TpsPolicies.ProtectedData)
+        ) && !workspaceServiceConstructor(ctx).isBucketSecure(rawlsWorkspace)
       ) {
         throw new ProtectedDataException("Unable to add protected snapshot to unprotected workspace.")
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1020,9 +1020,7 @@ class WorkspaceService(
             newAttrs = sourceWorkspaceContext.attributes ++ destWorkspaceRequest.attributes
             destWorkspaceContext <- traceDBIOWithParent("createNewWorkspaceContext (cloneWorkspace)", ctx) { s =>
               val forceEnhancedBucketMonitoring =
-                destWorkspaceRequest.enhancedBucketLogging.exists(identity) || sourceWorkspace.bucketName.startsWith(
-                  s"${config.workspaceBucketNamePrefix}-secure"
-                )
+                destWorkspaceRequest.enhancedBucketLogging.exists(identity) || isBucketSecure(sourceWorkspace)
               createNewWorkspaceContext(
                 destWorkspaceRequest.copy(authorizationDomain = Option(newAuthDomain),
                                           attributes = newAttrs,
@@ -2519,6 +2517,9 @@ class WorkspaceService(
                                                      Identity.group(workspaceProjectOwnerEmail.value)
       )
     } yield ()
+
+  def isBucketSecure(workspace: Workspace): Boolean =
+    workspace.bucketName.startsWith(s"${config.workspaceBucketNamePrefix}-secure")
 }
 
 class InvalidWorkspaceAclUpdateException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -751,13 +751,17 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       val workspace = protectedWorkspaceTestData.protectedWorkspace
 
+      val workspaceService = mock[WorkspaceService]
+      when(workspaceService.isBucketSecure(any[Workspace]))
+        .thenReturn(true)
+
       val snapshotService = SnapshotService.constructor(
         new WorkspaceRepository(slickDataSource),
         mockSamDAO,
         mockWorkspaceManagerDAO,
         "fake-terra-data-repo-dev",
         mockDataRepoDAO,
-        defaultWorkspaceServiceConstructor,
+        _ => workspaceService,
         defaultPolicyService
       )(testContext)
 


### PR DESCRIPTION
Ticket: CORE-568

When importing a snapshot, check if the workspace's bucket starts with "fc-secure" instead of checking for a protected-data policy on the workspace. This is more stable and adds backwards compatibility for workspaces which might not have PAOs.

The first commit [09f9f12](https://github.com/broadinstitute/rawls/pull/3359/commits/09f9f129811307e85417ba22415bbfb5654b7e0f) is a simple, basic implementation.

The remainder of the commits centralize logic into `WorkspaceService`. Is this worth it?


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
