### PR TITLE
CORE-551: deduplicate calls to requireUserInfo

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -37,130 +37,99 @@ trait AdminApiService extends UserInfoDirectives {
   val bucketMigrationServiceConstructor: RawlsRequestContext => BucketMigrationService
   val billingAdminServiceConstructor: RawlsRequestContext => BillingAdminService
 
-  def adminRoutes(otelContext: Context = Context.root()): server.Route = {
-    requireUserInfo(Option(otelContext)) { userInfo =>
-      val ctx = RawlsRequestContext(userInfo, Option(otelContext))
-      path("admin" / "billing" / Segment) { projectId =>
-        val billingProjectName = RawlsBillingProjectName(projectId)
+  def adminRoutes(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
+    val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+    path("admin" / "billing" / Segment) { projectId =>
+      val billingProjectName = RawlsBillingProjectName(projectId)
+      get {
+        complete {
+          billingAdminServiceConstructor(ctx)
+            .getBillingProjectSupportSummary(billingProjectName)
+            .map(StatusCodes.OK -> _)
+        }
+      } ~
+        delete {
+          entity(as[Map[String, String]]) { ownerInfo =>
+            complete {
+              userServiceConstructor(ctx)
+                .adminDeleteBillingProject(billingProjectName, ownerInfo)
+                .map(_ => StatusCodes.NoContent)
+            }
+          }
+        }
+    } ~
+      path("admin" / "submissions") {
         get {
           complete {
-            billingAdminServiceConstructor(ctx)
-              .getBillingProjectSupportSummary(billingProjectName)
-              .map(StatusCodes.OK -> _)
+            submissionsServiceConstructor(ctx).adminListAllActiveSubmissions()
           }
-        } ~
-          delete {
-            entity(as[Map[String, String]]) { ownerInfo =>
-              complete {
-                userServiceConstructor(ctx)
-                  .adminDeleteBillingProject(billingProjectName, ownerInfo)
-                  .map(_ => StatusCodes.NoContent)
-              }
-            }
-          }
+        }
       } ~
-        path("admin" / "submissions") {
-          get {
-            complete {
-              submissionsServiceConstructor(ctx).adminListAllActiveSubmissions()
-            }
+      path("admin" / "submissions" / Segment / Segment / Segment) { (workspaceNamespace, workspaceName, submissionId) =>
+        delete {
+          complete {
+            submissionsServiceConstructor(ctx)
+              .adminAbortSubmission(WorkspaceName(workspaceNamespace, workspaceName), submissionId)
+              .map { count =>
+                if (count == 1) StatusCodes.NoContent -> None
+                else
+                  StatusCodes.NotFound -> Option(
+                    ErrorReport(StatusCodes.NotFound,
+                                s"Unable to abort submission. Submission ${submissionId} could not be found."
+                    )
+                  )
+              }
           }
-        } ~
-        path("admin" / "submissions" / Segment / Segment / Segment) {
-          (workspaceNamespace, workspaceName, submissionId) =>
-            delete {
-              complete {
-                submissionsServiceConstructor(ctx)
-                  .adminAbortSubmission(WorkspaceName(workspaceNamespace, workspaceName), submissionId)
-                  .map { count =>
-                    if (count == 1) StatusCodes.NoContent -> None
-                    else
-                      StatusCodes.NotFound -> Option(
-                        ErrorReport(StatusCodes.NotFound,
-                                    s"Unable to abort submission. Submission ${submissionId} could not be found."
-                        )
-                      )
-                  }
+        }
+      } ~
+      path("admin" / "submissions" / "queueStatusByUser") {
+        get {
+          complete {
+            submissionsServiceConstructor(ctx).adminWorkflowQueueStatusByUser
+          }
+        }
+      } ~
+      pathPrefix("admin" / "bucketMigration") {
+        pathPrefix("workspaces") {
+          pathEndOrSingleSlash {
+            post {
+              entity(as[List[WorkspaceName]]) { workspaceNames =>
+                complete {
+                  bucketMigrationServiceConstructor(ctx)
+                    .adminMigrateAllWorkspaceBuckets(workspaceNames)
+                    .map(StatusCodes.Created -> _)
+                }
               }
             }
-        } ~
-        path("admin" / "submissions" / "queueStatusByUser") {
-          get {
-            complete {
-              submissionsServiceConstructor(ctx).adminWorkflowQueueStatusByUser
-            }
-          }
-        } ~
-        pathPrefix("admin" / "bucketMigration") {
-          pathPrefix("workspaces") {
-            pathEndOrSingleSlash {
-              post {
-                entity(as[List[WorkspaceName]]) { workspaceNames =>
-                  complete {
-                    bucketMigrationServiceConstructor(ctx)
-                      .adminMigrateAllWorkspaceBuckets(workspaceNames)
-                      .map(StatusCodes.Created -> _)
+          } ~
+            pathPrefix("getProgress") {
+              pathEndOrSingleSlash {
+                post {
+                  entity(as[List[WorkspaceName]]) { workspaceNames =>
+                    complete {
+                      bucketMigrationServiceConstructor(ctx)
+                        .adminGetBucketMigrationProgressForWorkspaces(workspaceNames)
+                        .map(StatusCodes.OK -> _)
+                    }
                   }
                 }
               }
             } ~
-              pathPrefix("getProgress") {
-                pathEndOrSingleSlash {
-                  post {
-                    entity(as[List[WorkspaceName]]) { workspaceNames =>
-                      complete {
-                        bucketMigrationServiceConstructor(ctx)
-                          .adminGetBucketMigrationProgressForWorkspaces(workspaceNames)
-                          .map(StatusCodes.OK -> _)
-                      }
-                    }
-                  }
-                }
-              } ~
-              pathPrefix(Segment / Segment) { (namespace, name) =>
-                val workspaceName = WorkspaceName(namespace, name)
-                pathEndOrSingleSlash {
-                  get {
-                    complete {
-                      bucketMigrationServiceConstructor(ctx)
-                        .adminGetBucketMigrationAttemptsForWorkspace(workspaceName)
-                        .map(ms => StatusCodes.OK -> ms)
-                    }
-                  } ~
-                    post {
-                      complete {
-                        bucketMigrationServiceConstructor(ctx)
-                          .adminMigrateWorkspaceBucket(workspaceName)
-                          .map(StatusCodes.Created -> _)
-                      }
-                    }
-                } ~
-                  path("progress") {
-                    get {
-                      complete {
-                        bucketMigrationServiceConstructor(ctx)
-                          .adminGetBucketMigrationProgressForWorkspace(workspaceName)
-                          .map(StatusCodes.OK -> _)
-                      }
-                    }
-                  }
-              }
-          } ~
-            pathPrefix("billing" / Segment) { projectName =>
-              val billingProjectName = RawlsBillingProjectName(projectName)
+            pathPrefix(Segment / Segment) { (namespace, name) =>
+              val workspaceName = WorkspaceName(namespace, name)
               pathEndOrSingleSlash {
-                post {
+                get {
                   complete {
                     bucketMigrationServiceConstructor(ctx)
-                      .adminMigrateWorkspaceBucketsInBillingProject(billingProjectName)
-                      .map(StatusCodes.Created -> _)
+                      .adminGetBucketMigrationAttemptsForWorkspace(workspaceName)
+                      .map(ms => StatusCodes.OK -> ms)
                   }
                 } ~
-                  get {
+                  post {
                     complete {
                       bucketMigrationServiceConstructor(ctx)
-                        .adminGetBucketMigrationAttemptsForBillingProject(billingProjectName)
-                        .map(ms => StatusCodes.OK -> ms)
+                        .adminMigrateWorkspaceBucket(workspaceName)
+                        .map(StatusCodes.Created -> _)
                     }
                   }
               } ~
@@ -168,66 +137,94 @@ trait AdminApiService extends UserInfoDirectives {
                   get {
                     complete {
                       bucketMigrationServiceConstructor(ctx)
-                        .adminGetBucketMigrationProgressForBillingProject(billingProjectName)
+                        .adminGetBucketMigrationProgressForWorkspace(workspaceName)
                         .map(StatusCodes.OK -> _)
                     }
                   }
                 }
             }
         } ~
-        pathPrefix("admin" / "workspaces") {
-          pathPrefix(Segment / Segment) { (workspaceNamespace, workspaceName) =>
-            path("flags") {
-              get {
+          pathPrefix("billing" / Segment) { projectName =>
+            val billingProjectName = RawlsBillingProjectName(projectName)
+            pathEndOrSingleSlash {
+              post {
                 complete {
-                  workspaceAdminServiceConstructor(ctx).adminListWorkspaceFeatureFlags(
-                    WorkspaceName(workspaceNamespace, workspaceName)
-                  )
+                  bucketMigrationServiceConstructor(ctx)
+                    .adminMigrateWorkspaceBucketsInBillingProject(billingProjectName)
+                    .map(StatusCodes.Created -> _)
                 }
               } ~
-                put {
-                  entity(as[List[String]]) { flagNames =>
-                    complete {
-                      workspaceAdminServiceConstructor(ctx).adminOverwriteWorkspaceFeatureFlags(
-                        WorkspaceName(workspaceNamespace, workspaceName),
-                        flagNames
-                      )
-                    }
+                get {
+                  complete {
+                    bucketMigrationServiceConstructor(ctx)
+                      .adminGetBucketMigrationAttemptsForBillingProject(billingProjectName)
+                      .map(ms => StatusCodes.OK -> ms)
                   }
                 }
             } ~
-              path("deleteAzureWorkspace") {
-                delete {
-                  complete {
-                    workspaceAdminServiceConstructor(ctx)
-                      .adminDeleteMcWorkspace(WorkspaceName(workspaceNamespace, workspaceName))
-                      .map(_ => StatusCodes.NoContent)
-                  }
-                }
-              } ~
-              path("id") {
+              path("progress") {
                 get {
                   complete {
-                    workspaceAdminServiceConstructor(ctx)
-                      .getWorkspaceId(WorkspaceName(workspaceNamespace, workspaceName))
-                      .map {
-                        case Some(id) => StatusCodes.OK -> Option(JsString(id))
-                        case None     => StatusCodes.NotFound -> None
-                      }
+                    bucketMigrationServiceConstructor(ctx)
+                      .adminGetBucketMigrationProgressForBillingProject(billingProjectName)
+                      .map(StatusCodes.OK -> _)
+                  }
+                }
+              }
+          }
+      } ~
+      pathPrefix("admin" / "workspaces") {
+        pathPrefix(Segment / Segment) { (workspaceNamespace, workspaceName) =>
+          path("flags") {
+            get {
+              complete {
+                workspaceAdminServiceConstructor(ctx).adminListWorkspaceFeatureFlags(
+                  WorkspaceName(workspaceNamespace, workspaceName)
+                )
+              }
+            } ~
+              put {
+                entity(as[List[String]]) { flagNames =>
+                  complete {
+                    workspaceAdminServiceConstructor(ctx).adminOverwriteWorkspaceFeatureFlags(
+                      WorkspaceName(workspaceNamespace, workspaceName),
+                      flagNames
+                    )
                   }
                 }
               }
           } ~
-            path(Segment) { workspaceId =>
+            path("deleteAzureWorkspace") {
+              delete {
+                complete {
+                  workspaceAdminServiceConstructor(ctx)
+                    .adminDeleteMcWorkspace(WorkspaceName(workspaceNamespace, workspaceName))
+                    .map(_ => StatusCodes.NoContent)
+                }
+              }
+            } ~
+            path("id") {
               get {
                 complete {
                   workspaceAdminServiceConstructor(ctx)
-                    .getWorkspaceById(UUID.fromString(workspaceId))
-                    .map(StatusCodes.OK -> _)
+                    .getWorkspaceId(WorkspaceName(workspaceNamespace, workspaceName))
+                    .map {
+                      case Some(id) => StatusCodes.OK -> Option(JsString(id))
+                      case None     => StatusCodes.NotFound -> None
+                    }
                 }
               }
             }
-        }
-    }
+        } ~
+          path(Segment) { workspaceId =>
+            get {
+              complete {
+                workspaceAdminServiceConstructor(ctx)
+                  .getWorkspaceById(UUID.fromString(workspaceId))
+                  .map(StatusCodes.OK -> _)
+              }
+            }
+          }
+      }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiService.scala
@@ -23,38 +23,37 @@ trait BillingApiService extends UserInfoDirectives {
 
   val userServiceConstructor: RawlsRequestContext => UserService
 
-  def billingRoutes(otelContext: Context = Context.root()): server.Route =
-    requireUserInfo(Option(otelContext)) { userInfo =>
-      val ctx = RawlsRequestContext(userInfo, Option(otelContext))
-      pathPrefix("billing" / Segment) { projectId =>
-        path("members") {
-          get {
-            complete {
-              userServiceConstructor(ctx).getBillingProjectMembers(RawlsBillingProjectName(projectId))
-            }
+  def billingRoutes(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
+    val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+    pathPrefix("billing" / Segment) { projectId =>
+      path("members") {
+        get {
+          complete {
+            userServiceConstructor(ctx).getBillingProjectMembers(RawlsBillingProjectName(projectId))
           }
-        } ~
-          // these routes are for adding/removing users from projects
-          path(Segment / Segment) { (workbenchRole, userEmail) =>
-            put {
+        }
+      } ~
+        // these routes are for adding/removing users from projects
+        path(Segment / Segment) { (workbenchRole, userEmail) =>
+          put {
+            complete {
+              userServiceConstructor(ctx)
+                .addUserToBillingProject(RawlsBillingProjectName(projectId),
+                                         ProjectAccessUpdate(userEmail, ProjectRoles.withName(workbenchRole))
+                )
+                .map(_ => StatusCodes.OK)
+            }
+          } ~
+            delete {
               complete {
                 userServiceConstructor(ctx)
-                  .addUserToBillingProject(RawlsBillingProjectName(projectId),
-                                           ProjectAccessUpdate(userEmail, ProjectRoles.withName(workbenchRole))
+                  .removeUserFromBillingProject(RawlsBillingProjectName(projectId),
+                                                ProjectAccessUpdate(userEmail, ProjectRoles.withName(workbenchRole))
                   )
                   .map(_ => StatusCodes.OK)
               }
-            } ~
-              delete {
-                complete {
-                  userServiceConstructor(ctx)
-                    .removeUserFromBillingProject(RawlsBillingProjectName(projectId),
-                                                  ProjectAccessUpdate(userEmail, ProjectRoles.withName(workbenchRole))
-                    )
-                    .map(_ => StatusCodes.OK)
-                }
-              }
-          }
-      }
+            }
+        }
     }
+  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -56,249 +56,245 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
 
   implicit def dateTimeUnmarshaller: Unmarshaller[String, DateTime] = Unmarshaller.strict(DateTime.parse)
 
-  def billingRoutesV2(otelContext: Context = Context.root()): server.Route = {
-    requireUserInfo(Option(otelContext)) { userInfo =>
-      val ctx = RawlsRequestContext(userInfo, Option(otelContext))
-      pathPrefix("billing" / "v2") {
-        pathPrefix("id") {
-          pathPrefix(Segment) { id =>
-            pathEndOrSingleSlash {
-              get {
-                complete {
-                  userServiceConstructor(ctx).getBillingProjectById(UUID.fromString(id)).map {
-                    case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse)
-                    case None                  => StatusCodes.NotFound -> None
-                  }
-                }
-              }
-            } ~
-              pathPrefix("verifyAction") {
-                path(Segment) { action =>
-                  get {
-                    complete {
-                      userServiceConstructor(ctx)
-                        .verifyBillingProjectAccess(UUID.fromString(id), SamResourceAction(action))
-                        .map {
-                          case Some(true)  => StatusCodes.OK -> None
-                          case Some(false) => StatusCodes.Forbidden -> None
-                          case None        => StatusCodes.NotFound -> None
-                        }
-                    }
-                  }
-                }
-              }
-          }
-        } ~
-          pathPrefix("spendReport") {
-            pathEndOrSingleSlash {
-              get {
-                parameters(
-                  "startDate".as[DateTime],
-                  "endDate".as[DateTime],
-                  "pageSize".as[Int],
-                  "offset".as[Int]
-                ) { (startDate, endDate, pageSize, offset) =>
-                  complete {
-                    spendReportingConstructor(ctx).getSpendForAllWorkspaces(
-                      startDate,
-                      endDate.plusDays(1).minusMillis(1),
-                      pageSize,
-                      offset
-                    )
-                  }
+  def billingRoutesV2(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
+    val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+    pathPrefix("billing" / "v2") {
+      pathPrefix("id") {
+        pathPrefix(Segment) { id =>
+          pathEndOrSingleSlash {
+            get {
+              complete {
+                userServiceConstructor(ctx).getBillingProjectById(UUID.fromString(id)).map {
+                  case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse)
+                  case None                  => StatusCodes.NotFound -> None
                 }
               }
             }
           } ~
-          pathPrefix(Segment) { projectId =>
-            pathEnd {
-              get {
-                complete {
-                  import spray.json._
-                  userServiceConstructor(ctx).getBillingProject(RawlsBillingProjectName(projectId)).map {
-                    case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse).toJson
-                    case None => StatusCodes.NotFound -> Option(StatusCodes.NotFound.defaultMessage).toJson
-                  }
-                }
-              } ~
-                delete {
+            pathPrefix("verifyAction") {
+              path(Segment) { action =>
+                get {
                   complete {
-                    billingProjectOrchestratorConstructor(ctx)
-                      .deleteBillingProjectV2(RawlsBillingProjectName(projectId))
-                      .map(_ => StatusCodes.NoContent)
-                  }
-                }
-            } ~
-              pathPrefix("spendReport") {
-                pathEndOrSingleSlash {
-                  get {
-                    parameters(
-                      "startDate".as[DateTime],
-                      "endDate".as[DateTime],
-                      "aggregationKey"
-                        .as[SpendReportingAggregationKeyWithSub](aggregationKeyParameterUnmarshaller)
-                        .repeated
-                    ) { (startDate, endDate, aggregationKeyParameters) =>
-                      complete {
-                        spendReportingConstructor(ctx).getSpendForBillingProject(
-                          RawlsBillingProjectName(projectId),
-                          startDate,
-                          endDate.plusDays(1).minusMillis(1),
-                          aggregationKeyParameters.toSet
-                        )
-                      }
-                    }
-                  }
-                }
-              } ~
-              pathPrefix("spendReportConfiguration") {
-                pathEnd {
-                  put {
-                    entity(as[BillingProjectSpendConfiguration]) { spendConfiguration =>
-                      complete {
-                        userServiceConstructor(ctx)
-                          .setBillingProjectSpendConfiguration(RawlsBillingProjectName(projectId), spendConfiguration)
-                          .map(_ => StatusCodes.NoContent)
-                      }
-                    }
-                  } ~
-                    delete {
-                      complete {
-                        userServiceConstructor(ctx)
-                          .clearBillingProjectSpendConfiguration(RawlsBillingProjectName(projectId))
-                          .map(_ => StatusCodes.NoContent)
-                      }
-                    } ~
-                    get {
-                      complete {
-                        userServiceConstructor(ctx)
-                          .getBillingProjectSpendConfiguration(RawlsBillingProjectName(projectId))
-                          .map {
-                            case Some(config) => StatusCodes.OK -> Option(config)
-                            case None         => StatusCodes.NoContent -> None
-                          }
-                      }
-                    }
-                }
-              } ~
-              pathPrefix("billingAccount") {
-                pathEnd {
-                  put {
-                    entity(as[UpdateRawlsBillingAccountRequest]) { updateProjectRequest =>
-                      complete {
-                        userServiceConstructor(ctx)
-                          .updateBillingProjectBillingAccount(RawlsBillingProjectName(projectId), updateProjectRequest)
-                          .map {
-                            case Some(billingProject) => StatusCodes.OK -> Option(billingProject)
-                            case None                 => StatusCodes.NoContent -> None
-                          }
-                      }
-                    }
-                  } ~
-                    delete {
-                      complete {
-                        userServiceConstructor(ctx).deleteBillingAccount(RawlsBillingProjectName(projectId)).map {
-                          case Some(billingProject) => StatusCodes.OK -> Option(billingProject)
-                          case None                 => StatusCodes.NoContent -> None
-                        }
-                      }
-                    }
-                }
-              } ~
-              pathPrefix("members") {
-                pathEnd {
-                  get {
-                    complete {
-                      userServiceConstructor(ctx).getBillingProjectMembers(RawlsBillingProjectName(projectId))
-                    }
-                  } ~
-                    patch {
-                      parameter(Symbol("inviteUsersNotFound").?) { inviteUsersNotFound =>
-                        entity(as[BatchProjectAccessUpdate]) { batchProjectAccessUpdate =>
-                          complete {
-                            userServiceConstructor(ctx)
-                              .batchUpdateBillingProjectMembers(RawlsBillingProjectName(projectId),
-                                                                batchProjectAccessUpdate,
-                                                                inviteUsersNotFound.getOrElse("false").toBoolean
-                              )
-                              .map(_ => StatusCodes.NoContent -> None)
-                          }
-                        }
-                      }
-                    }
-                } ~
-                  // these routes are for adding/removing users from projects
-                  path(Segment / Segment) { (workbenchRole, userEmail) =>
-                    put {
-                      complete {
-                        userServiceConstructor(ctx)
-                          .addUserToBillingProjectV2(RawlsBillingProjectName(projectId),
-                                                     ProjectAccessUpdate(userEmail,
-                                                                         ProjectRoles.withName(workbenchRole)
-                                                     )
-                          )
-                          .map(_ => StatusCodes.OK)
-                      }
-                    } ~
-                      delete {
-                        complete {
-                          userServiceConstructor(ctx)
-                            .removeUserFromBillingProjectV2(RawlsBillingProjectName(projectId),
-                                                            ProjectAccessUpdate(userEmail,
-                                                                                ProjectRoles.withName(workbenchRole)
-                                                            )
-                            )
-                            .map(_ => StatusCodes.OK)
-                        }
+                    userServiceConstructor(ctx)
+                      .verifyBillingProjectAccess(UUID.fromString(id), SamResourceAction(action))
+                      .map {
+                        case Some(true)  => StatusCodes.OK -> None
+                        case Some(false) => StatusCodes.Forbidden -> None
+                        case None        => StatusCodes.NotFound -> None
                       }
                   }
-              } ~
-              pathPrefix("bucketMigration") {
-                val billingProjectName = RawlsBillingProjectName(projectId)
-                pathEndOrSingleSlash {
-                  post {
-                    complete {
-                      bucketMigrationServiceConstructor(ctx)
-                        .migrateWorkspaceBucketsInBillingProject(billingProjectName)
-                        .map(StatusCodes.Created -> _)
-                    }
-                  } ~
-                    get {
-                      complete {
-                        bucketMigrationServiceConstructor(ctx)
-                          .getBucketMigrationAttemptsForBillingProject(billingProjectName)
-                          .map(ms => StatusCodes.OK -> ms)
-                      }
-                    }
-                } ~
-                  path("progress") {
-                    get {
-                      complete {
-                        bucketMigrationServiceConstructor(ctx)
-                          .getBucketMigrationProgressForBillingProject(billingProjectName)
-                          .map(StatusCodes.OK -> _)
-                      }
-                    }
-                  }
+                }
               }
-          } ~
+            }
+        }
+      } ~
+        pathPrefix("spendReport") {
+          pathEndOrSingleSlash {
+            get {
+              parameters(
+                "startDate".as[DateTime],
+                "endDate".as[DateTime],
+                "pageSize".as[Int],
+                "offset".as[Int]
+              ) { (startDate, endDate, pageSize, offset) =>
+                complete {
+                  spendReportingConstructor(ctx).getSpendForAllWorkspaces(
+                    startDate,
+                    endDate.plusDays(1).minusMillis(1),
+                    pageSize,
+                    offset
+                  )
+                }
+              }
+            }
+          }
+        } ~
+        pathPrefix(Segment) { projectId =>
           pathEnd {
             get {
               complete {
-                userServiceConstructor(ctx).listBillingProjectsV2()
+                import spray.json._
+                userServiceConstructor(ctx).getBillingProject(RawlsBillingProjectName(projectId)).map {
+                  case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse).toJson
+                  case None => StatusCodes.NotFound -> Option(StatusCodes.NotFound.defaultMessage).toJson
+                }
               }
             } ~
-              post {
-                entity(as[CreateRawlsV2BillingProjectFullRequest]) { createProjectRequest =>
-                  complete {
-                    billingProjectOrchestratorConstructor(ctx)
-                      .createBillingProjectV2(createProjectRequest)
-                      .map(_ => StatusCodes.Created)
+              delete {
+                complete {
+                  billingProjectOrchestratorConstructor(ctx)
+                    .deleteBillingProjectV2(RawlsBillingProjectName(projectId))
+                    .map(_ => StatusCodes.NoContent)
+                }
+              }
+          } ~
+            pathPrefix("spendReport") {
+              pathEndOrSingleSlash {
+                get {
+                  parameters(
+                    "startDate".as[DateTime],
+                    "endDate".as[DateTime],
+                    "aggregationKey"
+                      .as[SpendReportingAggregationKeyWithSub](aggregationKeyParameterUnmarshaller)
+                      .repeated
+                  ) { (startDate, endDate, aggregationKeyParameters) =>
+                    complete {
+                      spendReportingConstructor(ctx).getSpendForBillingProject(
+                        RawlsBillingProjectName(projectId),
+                        startDate,
+                        endDate.plusDays(1).minusMillis(1),
+                        aggregationKeyParameters.toSet
+                      )
+                    }
                   }
                 }
               }
-          }
-      }
+            } ~
+            pathPrefix("spendReportConfiguration") {
+              pathEnd {
+                put {
+                  entity(as[BillingProjectSpendConfiguration]) { spendConfiguration =>
+                    complete {
+                      userServiceConstructor(ctx)
+                        .setBillingProjectSpendConfiguration(RawlsBillingProjectName(projectId), spendConfiguration)
+                        .map(_ => StatusCodes.NoContent)
+                    }
+                  }
+                } ~
+                  delete {
+                    complete {
+                      userServiceConstructor(ctx)
+                        .clearBillingProjectSpendConfiguration(RawlsBillingProjectName(projectId))
+                        .map(_ => StatusCodes.NoContent)
+                    }
+                  } ~
+                  get {
+                    complete {
+                      userServiceConstructor(ctx)
+                        .getBillingProjectSpendConfiguration(RawlsBillingProjectName(projectId))
+                        .map {
+                          case Some(config) => StatusCodes.OK -> Option(config)
+                          case None         => StatusCodes.NoContent -> None
+                        }
+                    }
+                  }
+              }
+            } ~
+            pathPrefix("billingAccount") {
+              pathEnd {
+                put {
+                  entity(as[UpdateRawlsBillingAccountRequest]) { updateProjectRequest =>
+                    complete {
+                      userServiceConstructor(ctx)
+                        .updateBillingProjectBillingAccount(RawlsBillingProjectName(projectId), updateProjectRequest)
+                        .map {
+                          case Some(billingProject) => StatusCodes.OK -> Option(billingProject)
+                          case None                 => StatusCodes.NoContent -> None
+                        }
+                    }
+                  }
+                } ~
+                  delete {
+                    complete {
+                      userServiceConstructor(ctx).deleteBillingAccount(RawlsBillingProjectName(projectId)).map {
+                        case Some(billingProject) => StatusCodes.OK -> Option(billingProject)
+                        case None                 => StatusCodes.NoContent -> None
+                      }
+                    }
+                  }
+              }
+            } ~
+            pathPrefix("members") {
+              pathEnd {
+                get {
+                  complete {
+                    userServiceConstructor(ctx).getBillingProjectMembers(RawlsBillingProjectName(projectId))
+                  }
+                } ~
+                  patch {
+                    parameter(Symbol("inviteUsersNotFound").?) { inviteUsersNotFound =>
+                      entity(as[BatchProjectAccessUpdate]) { batchProjectAccessUpdate =>
+                        complete {
+                          userServiceConstructor(ctx)
+                            .batchUpdateBillingProjectMembers(RawlsBillingProjectName(projectId),
+                                                              batchProjectAccessUpdate,
+                                                              inviteUsersNotFound.getOrElse("false").toBoolean
+                            )
+                            .map(_ => StatusCodes.NoContent -> None)
+                        }
+                      }
+                    }
+                  }
+              } ~
+                // these routes are for adding/removing users from projects
+                path(Segment / Segment) { (workbenchRole, userEmail) =>
+                  put {
+                    complete {
+                      userServiceConstructor(ctx)
+                        .addUserToBillingProjectV2(RawlsBillingProjectName(projectId),
+                                                   ProjectAccessUpdate(userEmail, ProjectRoles.withName(workbenchRole))
+                        )
+                        .map(_ => StatusCodes.OK)
+                    }
+                  } ~
+                    delete {
+                      complete {
+                        userServiceConstructor(ctx)
+                          .removeUserFromBillingProjectV2(RawlsBillingProjectName(projectId),
+                                                          ProjectAccessUpdate(userEmail,
+                                                                              ProjectRoles.withName(workbenchRole)
+                                                          )
+                          )
+                          .map(_ => StatusCodes.OK)
+                      }
+                    }
+                }
+            } ~
+            pathPrefix("bucketMigration") {
+              val billingProjectName = RawlsBillingProjectName(projectId)
+              pathEndOrSingleSlash {
+                post {
+                  complete {
+                    bucketMigrationServiceConstructor(ctx)
+                      .migrateWorkspaceBucketsInBillingProject(billingProjectName)
+                      .map(StatusCodes.Created -> _)
+                  }
+                } ~
+                  get {
+                    complete {
+                      bucketMigrationServiceConstructor(ctx)
+                        .getBucketMigrationAttemptsForBillingProject(billingProjectName)
+                        .map(ms => StatusCodes.OK -> ms)
+                    }
+                  }
+              } ~
+                path("progress") {
+                  get {
+                    complete {
+                      bucketMigrationServiceConstructor(ctx)
+                        .getBucketMigrationProgressForBillingProject(billingProjectName)
+                        .map(StatusCodes.OK -> _)
+                    }
+                  }
+                }
+            }
+        } ~
+        pathEnd {
+          get {
+            complete {
+              userServiceConstructor(ctx).listBillingProjectsV2()
+            }
+          } ~
+            post {
+              entity(as[CreateRawlsV2BillingProjectFullRequest]) { createProjectRequest =>
+                complete {
+                  billingProjectOrchestratorConstructor(ctx)
+                    .createBillingProjectV2(createProjectRequest)
+                    .map(_ => StatusCodes.Created)
+                }
+              }
+            }
+        }
     }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -42,329 +42,325 @@ trait EntityApiService extends UserInfoDirectives {
   // then have more fine-grained size validation using withSizeLimit specifically for the batchUpsert API
   implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json(Int.MaxValue)
 
-  def entityRoutes(otelContext: Context = Context.root()): server.Route = {
-    requireUserInfo(Option(otelContext)) { userInfo =>
-      val ctx = RawlsRequestContext(userInfo, Option(otelContext))
-      path("workspaces" / Segment / Segment / "entityQuery" / Segment) {
-        (workspaceNamespace, workspaceName, entityType) =>
+  def entityRoutes(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
+    val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+    path("workspaces" / Segment / Segment / "entityQuery" / Segment) { (workspaceNamespace, workspaceName, entityType) =>
+      get {
+        parameters('page.?,
+                   'pageSize.?,
+                   'sortField.?,
+                   'sortDirection.?,
+                   'filterTerms.?,
+                   'filterOperator.?,
+                   'columnFilter.?
+        ) { (page, pageSize, sortField, sortDirection, filterTerms, filterOperator, columnFilterStringOpt) =>
+          parameterSeq { allParams =>
+            val toIntTries = Map("page" -> page, "pageSize" -> pageSize).map { case (k, s) =>
+              k -> Try(s.map(_.toInt))
+            }
+            val sortDirectionTry =
+              sortDirection.map(dir => Try(SortDirections.fromString(dir))).getOrElse(Success(Ascending))
+            val operatorTry =
+              filterOperator.map(op => Try(FilterOperators.fromString(op))).getOrElse(Success(And))
+
+            val filterValidation =
+              if (Seq(filterTerms, columnFilterStringOpt).count(_.isDefined) > 1) {
+                Seq(
+                  "filterTerms and columnFilter are mutually exclusive; you may specify only one of these parameters."
+                )
+              } else Seq.empty
+
+            val columnFilter: Option[Either[Seq[String], EntityColumnFilter]] =
+              EntityApiService.createColumnFilter(columnFilterStringOpt)
+            val errors = Seq(
+              toIntTries.collect {
+                case (k, Failure(t))                 => s"$k must be a positive integer"
+                case (k, Success(Some(i))) if i <= 0 => s"$k must be a positive integer"
+              },
+              if (sortDirectionTry.isFailure) Seq(sortDirectionTry.failed.get.getMessage) else Seq.empty,
+              filterValidation,
+              columnFilter.flatMap(_.swap.toOption).getOrElse(Seq.empty)
+            ).flatten
+
+            if (errors.isEmpty) {
+              val entityQuery = EntityQuery(
+                toIntTries("page").get.getOrElse(1),
+                toIntTries("pageSize").get.getOrElse(10),
+                sortField.getOrElse("name"),
+                sortDirectionTry.get,
+                filterTerms,
+                operatorTry.get,
+                WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
+                columnFilter.flatMap(_.toOption)
+              )
+
+              onSuccess(
+                entityServiceConstructor(ctx).queryEntitiesSource(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                  entityType,
+                                                                  entityQuery
+                )
+              ) { (entityQueryResultMetadata, resultsSource) =>
+                val responseSource: Source[ByteString, _] =
+                  EntityStreamingUtils.createResponseSource(resultsSource, entityQuery, entityQueryResultMetadata)
+                complete(HttpEntity(ContentTypes.`application/json`, responseSource))
+              }
+            } else {
+              complete(StatusCodes.BadRequest, ErrorReport(StatusCodes.BadRequest, errors.mkString(", ")))
+            }
+          }
+        }
+      }
+    } ~
+      path("workspaces" / Segment / Segment / "entities") { (workspaceNamespace, workspaceName) =>
+        get {
+          // if useCache param is unset or set to a value that won't coerce to a boolean, default to true
+          parameters("useCache".?) { useCache =>
+            val useCacheBool = Try(useCache.getOrElse("true").toBoolean).getOrElse(true)
+            complete {
+              entityServiceConstructor(ctx).entityTypeMetadata(WorkspaceName(workspaceNamespace, workspaceName),
+                                                               useCacheBool
+              )
+            }
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "entities") { (workspaceNamespace, workspaceName) =>
+        post {
+          entity(as[Entity]) { entity =>
+            addLocationHeader(entity.path(WorkspaceName(workspaceNamespace, workspaceName))) {
+              complete {
+                entityServiceConstructor(ctx)
+                  .createEntity(WorkspaceName(workspaceNamespace, workspaceName), entity)
+                  .map(StatusCodes.Created -> _)
+              }
+            }
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "entities" / Segment / Segment) {
+        (workspaceNamespace, workspaceName, entityType, entityName) =>
           get {
-            parameters('page.?,
-                       'pageSize.?,
-                       'sortField.?,
-                       'sortDirection.?,
-                       'filterTerms.?,
-                       'filterOperator.?,
-                       'columnFilter.?
-            ) { (page, pageSize, sortField, sortDirection, filterTerms, filterOperator, columnFilterStringOpt) =>
-              parameterSeq { allParams =>
-                val toIntTries = Map("page" -> page, "pageSize" -> pageSize).map { case (k, s) =>
-                  k -> Try(s.map(_.toInt))
-                }
-                val sortDirectionTry =
-                  sortDirection.map(dir => Try(SortDirections.fromString(dir))).getOrElse(Success(Ascending))
-                val operatorTry =
-                  filterOperator.map(op => Try(FilterOperators.fromString(op))).getOrElse(Success(And))
-
-                val filterValidation =
-                  if (Seq(filterTerms, columnFilterStringOpt).count(_.isDefined) > 1) {
-                    Seq(
-                      "filterTerms and columnFilter are mutually exclusive; you may specify only one of these parameters."
-                    )
-                  } else Seq.empty
-
-                val columnFilter: Option[Either[Seq[String], EntityColumnFilter]] =
-                  EntityApiService.createColumnFilter(columnFilterStringOpt)
-                val errors = Seq(
-                  toIntTries.collect {
-                    case (k, Failure(t))                 => s"$k must be a positive integer"
-                    case (k, Success(Some(i))) if i <= 0 => s"$k must be a positive integer"
-                  },
-                  if (sortDirectionTry.isFailure) Seq(sortDirectionTry.failed.get.getMessage) else Seq.empty,
-                  filterValidation,
-                  columnFilter.flatMap(_.swap.toOption).getOrElse(Seq.empty)
-                ).flatten
-
-                if (errors.isEmpty) {
-                  val entityQuery = EntityQuery(
-                    toIntTries("page").get.getOrElse(1),
-                    toIntTries("pageSize").get.getOrElse(10),
-                    sortField.getOrElse("name"),
-                    sortDirectionTry.get,
-                    filterTerms,
-                    operatorTry.get,
-                    WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
-                    columnFilter.flatMap(_.toOption)
-                  )
-
-                  onSuccess(
-                    entityServiceConstructor(ctx).queryEntitiesSource(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                      entityType,
-                                                                      entityQuery
-                    )
-                  ) { (entityQueryResultMetadata, resultsSource) =>
-                    val responseSource: Source[ByteString, _] =
-                      EntityStreamingUtils.createResponseSource(resultsSource, entityQuery, entityQueryResultMetadata)
-                    complete(HttpEntity(ContentTypes.`application/json`, responseSource))
-                  }
-                } else {
-                  complete(StatusCodes.BadRequest, ErrorReport(StatusCodes.BadRequest, errors.mkString(", ")))
-                }
+            complete {
+              entityServiceConstructor(ctx).getEntity(WorkspaceName(workspaceNamespace, workspaceName),
+                                                      entityType,
+                                                      entityName
+              )
+            }
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "entities" / Segment / Segment) {
+        (workspaceNamespace, workspaceName, entityType, entityName) =>
+          patch {
+            entity(as[Array[AttributeUpdateOperation]]) { operations =>
+              complete {
+                entityServiceConstructor(ctx).updateEntity(WorkspaceName(workspaceNamespace, workspaceName),
+                                                           entityType,
+                                                           entityName,
+                                                           operations
+                )
               }
             }
           }
       } ~
-        path("workspaces" / Segment / Segment / "entities") { (workspaceNamespace, workspaceName) =>
-          get {
-            // if useCache param is unset or set to a value that won't coerce to a boolean, default to true
-            parameters("useCache".?) { useCache =>
-              val useCacheBool = Try(useCache.getOrElse("true").toBoolean).getOrElse(true)
+      path("workspaces" / Segment / Segment / "entities" / "delete") { (workspaceNamespace, workspaceName) =>
+        post {
+          entity(as[Array[AttributeEntityReference]]) { entities =>
+            if (entities.isEmpty) {
+              complete(
+                StatusCodes.BadRequest -> ErrorReport(StatusCodes.BadRequest, "No entities specified to delete")
+              )
+            } else {
               complete {
-                entityServiceConstructor(ctx).entityTypeMetadata(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                 useCacheBool
-                )
+                entityServiceConstructor(ctx)
+                  .deleteEntities(WorkspaceName(workspaceNamespace, workspaceName), entities)
+                  .map {
+                    case entities if entities.isEmpty => StatusCodes.NoContent -> None
+                    case entities                     => StatusCodes.Conflict -> Option(entities)
+                  }
               }
             }
           }
-        } ~
-        path("workspaces" / Segment / Segment / "entities") { (workspaceNamespace, workspaceName) =>
-          post {
-            entity(as[Entity]) { entity =>
-              addLocationHeader(entity.path(WorkspaceName(workspaceNamespace, workspaceName))) {
-                complete {
-                  entityServiceConstructor(ctx)
-                    .createEntity(WorkspaceName(workspaceNamespace, workspaceName), entity)
-                    .map(StatusCodes.Created -> _)
-                }
-              }
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "entities" / Segment / Segment) {
-          (workspaceNamespace, workspaceName, entityType, entityName) =>
-            get {
-              complete {
-                entityServiceConstructor(ctx).getEntity(WorkspaceName(workspaceNamespace, workspaceName),
-                                                        entityType,
-                                                        entityName
-                )
-              }
-            }
-        } ~
-        path("workspaces" / Segment / Segment / "entities" / Segment / Segment) {
-          (workspaceNamespace, workspaceName, entityType, entityName) =>
-            patch {
-              entity(as[Array[AttributeUpdateOperation]]) { operations =>
-                complete {
-                  entityServiceConstructor(ctx).updateEntity(WorkspaceName(workspaceNamespace, workspaceName),
-                                                             entityType,
-                                                             entityName,
-                                                             operations
-                  )
-                }
-              }
-            }
-        } ~
-        path("workspaces" / Segment / Segment / "entities" / "delete") { (workspaceNamespace, workspaceName) =>
-          post {
-            entity(as[Array[AttributeEntityReference]]) { entities =>
-              if (entities.isEmpty) {
-                complete(
-                  StatusCodes.BadRequest -> ErrorReport(StatusCodes.BadRequest, "No entities specified to delete")
-                )
-              } else {
-                complete {
-                  entityServiceConstructor(ctx)
-                    .deleteEntities(WorkspaceName(workspaceNamespace, workspaceName), entities)
-                    .map {
-                      case entities if entities.isEmpty => StatusCodes.NoContent -> None
-                      case entities                     => StatusCodes.Conflict -> Option(entities)
-                    }
-                }
-              }
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "entities" / "batchUpsert") { (workspaceNamespace, workspaceName) =>
-          post {
-            withSizeLimit(batchUpsertMaxBytes) {
-              entity(asSourceOf[EntityUpdateDefinition]) { operations =>
-                complete {
-                  entityServiceConstructor(ctx)
-                    .batchUpsertEntities(WorkspaceName(workspaceNamespace, workspaceName), operations)
-                    .map(_ => StatusCodes.NoContent)
-                    .recover { case _: EntityStreamSizeException =>
-                      StatusCodes.PayloadTooLarge
-                    }
-                }
-              }
-
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "entities" / "batchUpdate") { (workspaceNamespace, workspaceName) =>
-          post {
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "entities" / "batchUpsert") { (workspaceNamespace, workspaceName) =>
+        post {
+          withSizeLimit(batchUpsertMaxBytes) {
             entity(asSourceOf[EntityUpdateDefinition]) { operations =>
               complete {
                 entityServiceConstructor(ctx)
-                  .batchUpdateEntities(WorkspaceName(workspaceNamespace, workspaceName), operations)
+                  .batchUpsertEntities(WorkspaceName(workspaceNamespace, workspaceName), operations)
+                  .map(_ => StatusCodes.NoContent)
+                  .recover { case _: EntityStreamSizeException =>
+                    StatusCodes.PayloadTooLarge
+                  }
+              }
+            }
+
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "entities" / "batchUpdate") { (workspaceNamespace, workspaceName) =>
+        post {
+          entity(asSourceOf[EntityUpdateDefinition]) { operations =>
+            complete {
+              entityServiceConstructor(ctx)
+                .batchUpdateEntities(WorkspaceName(workspaceNamespace, workspaceName), operations)
+                .map(_ => StatusCodes.NoContent)
+            }
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "entities" / Segment / Segment / "rename") {
+        (workspaceNamespace, workspaceName, entityType, entityName) =>
+          post {
+            entity(as[EntityName]) { newEntityName =>
+              complete {
+                entityServiceConstructor(ctx)
+                  .renameEntity(WorkspaceName(workspaceNamespace, workspaceName),
+                                entityType,
+                                entityName,
+                                newEntityName.name
+                  )
                   .map(_ => StatusCodes.NoContent)
               }
             }
           }
-        } ~
-        path("workspaces" / Segment / Segment / "entities" / Segment / Segment / "rename") {
-          (workspaceNamespace, workspaceName, entityType, entityName) =>
-            post {
-              entity(as[EntityName]) { newEntityName =>
-                complete {
-                  entityServiceConstructor(ctx)
-                    .renameEntity(WorkspaceName(workspaceNamespace, workspaceName),
-                                  entityType,
-                                  entityName,
-                                  newEntityName.name
-                    )
-                    .map(_ => StatusCodes.NoContent)
-                }
+      } ~
+      path("workspaces" / Segment / Segment / "entityTypes" / Segment) {
+        (workspaceNamespace, workspaceName, entityType) =>
+          patch {
+            entity(as[EntityTypeRename]) { rename =>
+              complete {
+                entityServiceConstructor(ctx)
+                  .renameEntityType(WorkspaceName(workspaceNamespace, workspaceName), entityType, rename)
+                  .map(_ => StatusCodes.NoContent)
               }
             }
-        } ~
-        path("workspaces" / Segment / Segment / "entityTypes" / Segment) {
-          (workspaceNamespace, workspaceName, entityType) =>
-            patch {
-              entity(as[EntityTypeRename]) { rename =>
-                complete {
-                  entityServiceConstructor(ctx)
-                    .renameEntityType(WorkspaceName(workspaceNamespace, workspaceName), entityType, rename)
-                    .map(_ => StatusCodes.NoContent)
-                }
-              }
-            } ~
-              delete {
-                complete {
-                  entityServiceConstructor(ctx)
-                    .deleteEntitiesOfType(WorkspaceName(workspaceNamespace, workspaceName), entityType, None, None)
-                    .map(_ => StatusCodes.NoContent)
-                }
-              }
-        } ~
-        path("workspaces" / Segment / Segment / "entities" / Segment / Segment / "evaluate") {
-          (workspaceNamespace, workspaceName, entityType, entityName) =>
-            post {
-              entity(as[String]) { expression =>
-                complete {
-                  entityServiceConstructor(ctx).evaluateExpression(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                   entityType,
-                                                                   entityName,
-                                                                   expression
-                  )
-                }
+          } ~
+            delete {
+              complete {
+                entityServiceConstructor(ctx)
+                  .deleteEntitiesOfType(WorkspaceName(workspaceNamespace, workspaceName), entityType, None, None)
+                  .map(_ => StatusCodes.NoContent)
               }
             }
-        } ~
-        path("workspaces" / Segment / Segment / "entities" / Segment) {
-          (workspaceNamespace, workspaceName, entityType) =>
-            get {
-              // listEntities returns a source of Entity. We will stream-output each successful entity to the user,
-              // and if an exception occurs midstream we want to output the exception (wrapped in an ErrorReport)
-              // as the final element. Akka and Spray have a hard time with the mixed element types in the stream,
-              // so we manually convert them all to JsValue here and then output the stream of JsValue.
-              val jsValueSource = entityServiceConstructor(ctx)
-                .listEntities(WorkspaceName(workspaceNamespace, workspaceName), entityType)
-                .map(source =>
-                  source
-                    .map(entity => entity.toJson)
-                    .recover {
-                      case rex: RawlsExceptionWithErrorReport =>
-                        rex.errorReport.copy(stackTrace = Seq.empty).toJson
-                      case ex: Exception =>
-                        ErrorReport(ex).copy(message = ex.getMessage, stackTrace = Seq.empty).toJson
-                    }
-                )
-
-              complete(jsValueSource)
-            } ~
-              delete {
-                parameterSeq { allParams =>
-                  def parseAttributeNames() = {
-                    val paramName = "attributeNames"
-                    WorkspaceFieldSpecs.fromQueryParams(allParams, paramName).fields match {
-                      case None =>
-                        throw new RawlsExceptionWithErrorReport(
-                          ErrorReport(BadRequest, s"Parameter '$paramName' must be included.")(
-                            ErrorReportSource("rawls")
-                          )
-                        )
-                      case Some(atts) =>
-                        atts.toSet.map((value: String) => AttributeName.fromDelimitedName(value.trim))
-                    }
-                  }
-
-                  complete {
-                    entityServiceConstructor(ctx)
-                      .deleteEntityAttributes(WorkspaceName(workspaceNamespace, workspaceName),
-                                              entityType,
-                                              parseAttributeNames()
-                      )
-                      .map(_ => StatusCodes.NoContent)
-                  }
-                }
-              }
-        } ~
-        path("workspaces" / "entities" / "copy") {
+      } ~
+      path("workspaces" / Segment / Segment / "entities" / Segment / Segment / "evaluate") {
+        (workspaceNamespace, workspaceName, entityType, entityName) =>
           post {
-            parameters('linkExistingEntities.?) { linkExistingEntities =>
-              extractRequest { request =>
-                val linkExistingEntitiesBool = Try(linkExistingEntities.getOrElse("false").toBoolean).getOrElse(false)
-                entity(as[EntityCopyDefinition]) { copyDefinition =>
-                  complete {
-                    entityServiceConstructor(ctx)
-                      .copyEntities(copyDefinition, linkExistingEntitiesBool)
-                      .map { response =>
-                        if (
-                          response.hardConflicts.isEmpty && (response.softConflicts.isEmpty || linkExistingEntitiesBool)
-                        ) StatusCodes.Created -> response
-                        else StatusCodes.Conflict -> response
-                      }
-                  }
-                }
+            entity(as[String]) { expression =>
+              complete {
+                entityServiceConstructor(ctx).evaluateExpression(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                 entityType,
+                                                                 entityName,
+                                                                 expression
+                )
               }
             }
           }
+      } ~
+      path("workspaces" / Segment / Segment / "entities" / Segment) { (workspaceNamespace, workspaceName, entityType) =>
+        get {
+          // listEntities returns a source of Entity. We will stream-output each successful entity to the user,
+          // and if an exception occurs midstream we want to output the exception (wrapped in an ErrorReport)
+          // as the final element. Akka and Spray have a hard time with the mixed element types in the stream,
+          // so we manually convert them all to JsValue here and then output the stream of JsValue.
+          val jsValueSource = entityServiceConstructor(ctx)
+            .listEntities(WorkspaceName(workspaceNamespace, workspaceName), entityType)
+            .map(source =>
+              source
+                .map(entity => entity.toJson)
+                .recover {
+                  case rex: RawlsExceptionWithErrorReport =>
+                    rex.errorReport.copy(stackTrace = Seq.empty).toJson
+                  case ex: Exception =>
+                    ErrorReport(ex).copy(message = ex.getMessage, stackTrace = Seq.empty).toJson
+                }
+            )
+
+          complete(jsValueSource)
         } ~
-        path("workspaces" / Segment / Segment / "entityTypes" / Segment / "attributes" / Segment) {
-          (workspaceNamespace, workspaceName, entityType, attributeName) =>
-            patch {
-              entity(as[AttributeRename]) { attributeRenameRequest =>
-                complete {
-                  entityServiceConstructor(ctx)
-                    .renameAttribute(WorkspaceName(workspaceNamespace, workspaceName),
-                                     entityType,
-                                     AttributeName.fromDelimitedName(attributeName),
-                                     attributeRenameRequest
+          delete {
+            parameterSeq { allParams =>
+              def parseAttributeNames() = {
+                val paramName = "attributeNames"
+                WorkspaceFieldSpecs.fromQueryParams(allParams, paramName).fields match {
+                  case None =>
+                    throw new RawlsExceptionWithErrorReport(
+                      ErrorReport(BadRequest, s"Parameter '$paramName' must be included.")(
+                        ErrorReportSource("rawls")
+                      )
                     )
-                    .map(_ => StatusCodes.NoContent)
+                  case Some(atts) =>
+                    atts.toSet.map((value: String) => AttributeName.fromDelimitedName(value.trim))
                 }
               }
+
+              complete {
+                entityServiceConstructor(ctx)
+                  .deleteEntityAttributes(WorkspaceName(workspaceNamespace, workspaceName),
+                                          entityType,
+                                          parseAttributeNames()
+                  )
+                  .map(_ => StatusCodes.NoContent)
+              }
             }
-        } ~
-        path("workspaces" / Segment / Segment / "quicksilverMigration") { (workspaceNamespace, workspaceName) =>
-          post {
-            entity(as[String]) { postBody =>
-              if (postBody != "I understand that this API will delete all my data tables.") {
-                complete(StatusCodes.BadRequest -> "You must consent to use this API.")
-              } else {
+          }
+      } ~
+      path("workspaces" / "entities" / "copy") {
+        post {
+          parameters('linkExistingEntities.?) { linkExistingEntities =>
+            extractRequest { request =>
+              val linkExistingEntitiesBool = Try(linkExistingEntities.getOrElse("false").toBoolean).getOrElse(false)
+              entity(as[EntityCopyDefinition]) { copyDefinition =>
                 complete {
                   entityServiceConstructor(ctx)
-                    .quicksilverMigration(WorkspaceName(workspaceNamespace, workspaceName))
-                    .map { migrationResults =>
-                      StatusCodes.OK -> Map("entitiesUpdated" -> migrationResults)
+                    .copyEntities(copyDefinition, linkExistingEntitiesBool)
+                    .map { response =>
+                      if (
+                        response.hardConflicts.isEmpty && (response.softConflicts.isEmpty || linkExistingEntitiesBool)
+                      ) StatusCodes.Created -> response
+                      else StatusCodes.Conflict -> response
                     }
                 }
               }
             }
           }
         }
-    }
+      } ~
+      path("workspaces" / Segment / Segment / "entityTypes" / Segment / "attributes" / Segment) {
+        (workspaceNamespace, workspaceName, entityType, attributeName) =>
+          patch {
+            entity(as[AttributeRename]) { attributeRenameRequest =>
+              complete {
+                entityServiceConstructor(ctx)
+                  .renameAttribute(WorkspaceName(workspaceNamespace, workspaceName),
+                                   entityType,
+                                   AttributeName.fromDelimitedName(attributeName),
+                                   attributeRenameRequest
+                  )
+                  .map(_ => StatusCodes.NoContent)
+              }
+            }
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "quicksilverMigration") { (workspaceNamespace, workspaceName) =>
+        post {
+          entity(as[String]) { postBody =>
+            if (postBody != "I understand that this API will delete all my data tables.") {
+              complete(StatusCodes.BadRequest -> "You must consent to use this API.")
+            } else {
+              complete {
+                entityServiceConstructor(ctx)
+                  .quicksilverMigration(WorkspaceName(workspaceNamespace, workspaceName))
+                  .map { migrationResults =>
+                    StatusCodes.OK -> Map("entitiesUpdated" -> migrationResults)
+                  }
+              }
+            }
+          }
+        }
+      }
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/GoogleProjectRegistrationApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/GoogleProjectRegistrationApiService.scala
@@ -11,7 +11,8 @@ import org.broadinstitute.dsde.rawls.model.{
   GoogleProjectId,
   GoogleProjectRegistration,
   RawlsBillingProjectName,
-  RawlsRequestContext
+  RawlsRequestContext,
+  UserInfo
 }
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
 
@@ -22,57 +23,56 @@ trait GoogleProjectRegistrationApiService extends UserInfoDirectives {
 
   val googleProjectRegServiceConstructor: RawlsRequestContext => GoogleProjectRegistrationService
 
-  def googleProjectRegistrationRoutes(otelContext: Context = Context.root()): server.Route =
-    requireUserInfo(Option(otelContext)) { userInfo =>
-      val ctx = RawlsRequestContext(userInfo, Option(otelContext))
-      pathPrefix("googleProjects") {
-        pathEnd {
-          put {
-            entity(as[GoogleProjectRegistration]) { entity =>
+  def googleProjectRegistrationRoutes(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
+    val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+    pathPrefix("googleProjects") {
+      pathEnd {
+        put {
+          entity(as[GoogleProjectRegistration]) { entity =>
+            complete {
+              googleProjectRegServiceConstructor(ctx)
+                .registerGoogleProject(
+                  entity
+                )
+                .map {
+                  case None          => StatusCodes.OK -> None
+                  case Some(project) => StatusCodes.Created -> Some(project)
+                }
+            }
+          }
+        } ~
+          get {
+            parameters(
+              "billingProjectId".optional,
+              "pageSize".as[Int].withDefault(100),
+              "offset".as[Int].withDefault(0)
+            ) { (billingProjectId, pageSize, offset) =>
               complete {
                 googleProjectRegServiceConstructor(ctx)
-                  .registerGoogleProject(
-                    entity
-                  )
-                  .map {
-                    case None          => StatusCodes.OK -> None
-                    case Some(project) => StatusCodes.Created -> Some(project)
-                  }
+                  .getGoogleProjects(billingProjectId.map(RawlsBillingProjectName), pageSize, offset)
               }
+            }
+          }
+      } ~
+        path(Segment) { googleProjectId =>
+          delete {
+            complete {
+              googleProjectRegServiceConstructor(ctx)
+                .unregisterGoogleProject(GoogleProjectId(googleProjectId))
+                .map(_ => StatusCodes.NoContent)
             }
           } ~
             get {
-              parameters(
-                "billingProjectId".optional,
-                "pageSize".as[Int].withDefault(100),
-                "offset".as[Int].withDefault(0)
-              ) { (billingProjectId, pageSize, offset) =>
-                complete {
-                  googleProjectRegServiceConstructor(ctx)
-                    .getGoogleProjects(billingProjectId.map(RawlsBillingProjectName), pageSize, offset)
-                }
+              onSuccess(
+                googleProjectRegServiceConstructor(ctx)
+                  .getGoogleProjectById(GoogleProjectId(googleProjectId))
+              ) {
+                case Some(project) => complete(StatusCodes.OK -> project)
+                case None =>
+                  complete(StatusCodes.NotFound -> "Google project does not exist or you don't have access.")
               }
             }
-        } ~
-          path(Segment) { googleProjectId =>
-            delete {
-              complete {
-                googleProjectRegServiceConstructor(ctx)
-                  .unregisterGoogleProject(GoogleProjectId(googleProjectId))
-                  .map(_ => StatusCodes.NoContent)
-              }
-            } ~
-              get {
-                onSuccess(
-                  googleProjectRegServiceConstructor(ctx)
-                    .getGoogleProjectById(GoogleProjectId(googleProjectId))
-                ) {
-                  case Some(project) => complete(StatusCodes.OK -> project)
-                  case None =>
-                    complete(StatusCodes.NotFound -> "Google project does not exist or you don't have access.")
-                }
-              }
-          }
-      }
+        }
     }
+  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiService.scala
@@ -24,69 +24,55 @@ trait MethodConfigApiService extends UserInfoDirectives {
 
   val methodConfigurationServiceConstructor: RawlsRequestContext => MethodConfigurationService
 
-  def methodConfigRoutes(otelContext: Context = Context.root()): server.Route = {
-    requireUserInfo(Option(otelContext)) { userInfo =>
-      val ctx = RawlsRequestContext(userInfo, Option(otelContext))
-      path("workspaces" / Segment / Segment / "methodconfigs") { (workspaceNamespace, workspaceName) =>
-        get {
-          parameters("allRepos".as[Boolean] ? false) { allRepos =>
-            if (allRepos) {
-              complete {
-                methodConfigurationServiceConstructor(ctx).listMethodConfigurations(
-                  WorkspaceName(workspaceNamespace, workspaceName)
-                )
-              }
-            } else {
-              complete {
-                methodConfigurationServiceConstructor(ctx).listAgoraMethodConfigurations(
-                  WorkspaceName(workspaceNamespace, workspaceName)
-                )
-              }
+  def methodConfigRoutes(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
+    val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+    path("workspaces" / Segment / Segment / "methodconfigs") { (workspaceNamespace, workspaceName) =>
+      get {
+        parameters("allRepos".as[Boolean] ? false) { allRepos =>
+          if (allRepos) {
+            complete {
+              methodConfigurationServiceConstructor(ctx).listMethodConfigurations(
+                WorkspaceName(workspaceNamespace, workspaceName)
+              )
+            }
+          } else {
+            complete {
+              methodConfigurationServiceConstructor(ctx).listAgoraMethodConfigurations(
+                WorkspaceName(workspaceNamespace, workspaceName)
+              )
             }
           }
-        } ~
-          post {
-            entity(as[MethodConfiguration]) { methodConfiguration =>
-              addLocationHeader(methodConfiguration.path(WorkspaceName(workspaceNamespace, workspaceName))) {
-                complete {
-                  methodConfigurationServiceConstructor(ctx)
-                    .createMethodConfiguration(WorkspaceName(workspaceNamespace, workspaceName), methodConfiguration)
-                    .map(StatusCodes.Created -> _)
-                }
-              }
-            }
-          }
+        }
       } ~
-        path("workspaces" / Segment / Segment / "methodconfigs" / Segment / Segment) {
-          (workspaceNamespace, workspaceName, methodConfigurationNamespace, methodConfigName) =>
-            get {
+        post {
+          entity(as[MethodConfiguration]) { methodConfiguration =>
+            addLocationHeader(methodConfiguration.path(WorkspaceName(workspaceNamespace, workspaceName))) {
               complete {
-                methodConfigurationServiceConstructor(ctx).getMethodConfiguration(WorkspaceName(workspaceNamespace,
-                                                                                                workspaceName
-                                                                                  ),
-                                                                                  methodConfigurationNamespace,
-                                                                                  methodConfigName
-                )
+                methodConfigurationServiceConstructor(ctx)
+                  .createMethodConfiguration(WorkspaceName(workspaceNamespace, workspaceName), methodConfiguration)
+                  .map(StatusCodes.Created -> _)
               }
-            } ~
-              put {
-                entity(as[MethodConfiguration]) { newMethodConfiguration =>
-                  addLocationHeader(newMethodConfiguration.path(WorkspaceName(workspaceNamespace, workspaceName))) {
-                    complete {
-                      methodConfigurationServiceConstructor(ctx).overwriteMethodConfiguration(
-                        WorkspaceName(workspaceNamespace, workspaceName),
-                        methodConfigurationNamespace,
-                        methodConfigName,
-                        newMethodConfiguration
-                      )
-                    }
-                  }
-                }
-              } ~
-              post {
-                entity(as[MethodConfiguration]) { newMethodConfiguration =>
+            }
+          }
+        }
+    } ~
+      path("workspaces" / Segment / Segment / "methodconfigs" / Segment / Segment) {
+        (workspaceNamespace, workspaceName, methodConfigurationNamespace, methodConfigName) =>
+          get {
+            complete {
+              methodConfigurationServiceConstructor(ctx).getMethodConfiguration(WorkspaceName(workspaceNamespace,
+                                                                                              workspaceName
+                                                                                ),
+                                                                                methodConfigurationNamespace,
+                                                                                methodConfigName
+              )
+            }
+          } ~
+            put {
+              entity(as[MethodConfiguration]) { newMethodConfiguration =>
+                addLocationHeader(newMethodConfiguration.path(WorkspaceName(workspaceNamespace, workspaceName))) {
                   complete {
-                    methodConfigurationServiceConstructor(ctx).updateMethodConfiguration(
+                    methodConfigurationServiceConstructor(ctx).overwriteMethodConfiguration(
                       WorkspaceName(workspaceNamespace, workspaceName),
                       methodConfigurationNamespace,
                       methodConfigName,
@@ -94,103 +80,115 @@ trait MethodConfigApiService extends UserInfoDirectives {
                     )
                   }
                 }
-              } ~
-              delete {
-                complete {
-                  methodConfigurationServiceConstructor(ctx)
-                    .deleteMethodConfiguration(WorkspaceName(workspaceNamespace, workspaceName),
-                                               methodConfigurationNamespace,
-                                               methodConfigName
-                    )
-                    .map(_ => StatusCodes.NoContent)
-                }
               }
-        } ~
-        path("workspaces" / Segment / Segment / "methodconfigs" / Segment / Segment / "validate") {
-          (workspaceNamespace, workspaceName, methodConfigurationNamespace, methodConfigName) =>
-            get {
-              complete {
-                methodConfigurationServiceConstructor(ctx).getAndValidateMethodConfiguration(
-                  WorkspaceName(workspaceNamespace, workspaceName),
-                  methodConfigurationNamespace,
-                  methodConfigName
-                )
-              }
-            }
-        } ~
-        path("workspaces" / Segment / Segment / "methodconfigs" / Segment / Segment / "rename") {
-          (workspaceNamespace, workspaceName, methodConfigurationNamespace, methodConfigurationName) =>
+            } ~
             post {
-              entity(as[MethodConfigurationName]) { newName =>
+              entity(as[MethodConfiguration]) { newMethodConfiguration =>
                 complete {
-                  methodConfigurationServiceConstructor(ctx)
-                    .renameMethodConfiguration(WorkspaceName(workspaceNamespace, workspaceName),
-                                               methodConfigurationNamespace,
-                                               methodConfigurationName,
-                                               newName
-                    )
-                    .map(_ => StatusCodes.NoContent)
+                  methodConfigurationServiceConstructor(ctx).updateMethodConfiguration(
+                    WorkspaceName(workspaceNamespace, workspaceName),
+                    methodConfigurationNamespace,
+                    methodConfigName,
+                    newMethodConfiguration
+                  )
                 }
               }
+            } ~
+            delete {
+              complete {
+                methodConfigurationServiceConstructor(ctx)
+                  .deleteMethodConfiguration(WorkspaceName(workspaceNamespace, workspaceName),
+                                             methodConfigurationNamespace,
+                                             methodConfigName
+                  )
+                  .map(_ => StatusCodes.NoContent)
+              }
             }
-        } ~
-        path("methodconfigs" / "copy") {
+      } ~
+      path("workspaces" / Segment / Segment / "methodconfigs" / Segment / Segment / "validate") {
+        (workspaceNamespace, workspaceName, methodConfigurationNamespace, methodConfigName) =>
+          get {
+            complete {
+              methodConfigurationServiceConstructor(ctx).getAndValidateMethodConfiguration(
+                WorkspaceName(workspaceNamespace, workspaceName),
+                methodConfigurationNamespace,
+                methodConfigName
+              )
+            }
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "methodconfigs" / Segment / Segment / "rename") {
+        (workspaceNamespace, workspaceName, methodConfigurationNamespace, methodConfigurationName) =>
           post {
-            entity(as[MethodConfigurationNamePair]) { confNames =>
-              onSuccess(methodConfigurationServiceConstructor(ctx).copyMethodConfiguration(confNames)) {
-                validatedMethodConfig =>
-                  addLocationHeader(
-                    validatedMethodConfig.methodConfiguration.path(confNames.destination.workspaceName)
-                  ) {
-                    complete {
-                      StatusCodes.Created -> validatedMethodConfig
-                    }
+            entity(as[MethodConfigurationName]) { newName =>
+              complete {
+                methodConfigurationServiceConstructor(ctx)
+                  .renameMethodConfiguration(WorkspaceName(workspaceNamespace, workspaceName),
+                                             methodConfigurationNamespace,
+                                             methodConfigurationName,
+                                             newName
+                  )
+                  .map(_ => StatusCodes.NoContent)
+              }
+            }
+          }
+      } ~
+      path("methodconfigs" / "copy") {
+        post {
+          entity(as[MethodConfigurationNamePair]) { confNames =>
+            onSuccess(methodConfigurationServiceConstructor(ctx).copyMethodConfiguration(confNames)) {
+              validatedMethodConfig =>
+                addLocationHeader(
+                  validatedMethodConfig.methodConfiguration.path(confNames.destination.workspaceName)
+                ) {
+                  complete {
+                    StatusCodes.Created -> validatedMethodConfig
                   }
-              }
-            }
-          }
-        } ~
-        path("methodconfigs" / "copyFromMethodRepo") {
-          post {
-            entity(as[MethodRepoConfigurationImport]) { query =>
-              onSuccess(methodConfigurationServiceConstructor(ctx).copyMethodConfigurationFromMethodRepo(query)) {
-                validatedMethodConfig =>
-                  addLocationHeader(validatedMethodConfig.methodConfiguration.path(query.destination.workspaceName)) {
-                    complete {
-                      StatusCodes.Created -> validatedMethodConfig
-                    }
-                  }
-              }
-            }
-          }
-        } ~
-        path("methodconfigs" / "copyToMethodRepo") {
-          post {
-            entity(as[MethodRepoConfigurationExport]) { query =>
-              complete {
-                methodConfigurationServiceConstructor(ctx).copyMethodConfigurationToMethodRepo(query)
-              }
-            }
-          }
-        } ~
-        path("methodconfigs" / "template") {
-          post {
-            entity(as[MethodRepoMethod]) { methodRepoMethod =>
-              complete {
-                methodConfigurationServiceConstructor(ctx).createMethodConfigurationTemplate(methodRepoMethod)
-              }
-            }
-          }
-        } ~
-        path("methodconfigs" / "inputsOutputs") {
-          post {
-            entity(as[MethodRepoMethod]) { methodRepoMethod =>
-              complete {
-                methodConfigurationServiceConstructor(ctx).getMethodInputsOutputs(userInfo, methodRepoMethod)
-              }
+                }
             }
           }
         }
-    }
+      } ~
+      path("methodconfigs" / "copyFromMethodRepo") {
+        post {
+          entity(as[MethodRepoConfigurationImport]) { query =>
+            onSuccess(methodConfigurationServiceConstructor(ctx).copyMethodConfigurationFromMethodRepo(query)) {
+              validatedMethodConfig =>
+                addLocationHeader(validatedMethodConfig.methodConfiguration.path(query.destination.workspaceName)) {
+                  complete {
+                    StatusCodes.Created -> validatedMethodConfig
+                  }
+                }
+            }
+          }
+        }
+      } ~
+      path("methodconfigs" / "copyToMethodRepo") {
+        post {
+          entity(as[MethodRepoConfigurationExport]) { query =>
+            complete {
+              methodConfigurationServiceConstructor(ctx).copyMethodConfigurationToMethodRepo(query)
+            }
+          }
+        }
+      } ~
+      path("methodconfigs" / "template") {
+        post {
+          entity(as[MethodRepoMethod]) { methodRepoMethod =>
+            complete {
+              methodConfigurationServiceConstructor(ctx).createMethodConfigurationTemplate(methodRepoMethod)
+            }
+          }
+        }
+      } ~
+      path("methodconfigs" / "inputsOutputs") {
+        post {
+          entity(as[MethodRepoMethod]) { methodRepoMethod =>
+            complete {
+              methodConfigurationServiceConstructor(ctx).getMethodInputsOutputs(userInfo, methodRepoMethod)
+            }
+          }
+        }
+      }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
@@ -134,19 +134,21 @@ trait RawlsApiService
   implicit val materializer: Materializer
 
   val baseApiRoutes: Context => Route = (otelContext: Context) =>
-    workspaceRoutesV2(otelContext) ~
-      workspaceRoutes(otelContext) ~
-      entityRoutes(otelContext) ~
-      methodConfigRoutes(otelContext) ~
-      submissionRoutes(otelContext) ~
-      adminRoutes(otelContext) ~
-      userRoutes(otelContext) ~
-      billingRoutesV2(otelContext) ~
-      billingRoutes(otelContext) ~
-      notificationsRoutes ~
-      servicePerimeterRoutes(otelContext) ~
-      snapshotRoutes(otelContext) ~
-      googleProjectRegistrationRoutes(otelContext)
+    requireUserInfo(Option(otelContext)) { userInfo =>
+      workspaceRoutesV2(otelContext, userInfo) ~
+        workspaceRoutes(otelContext, userInfo) ~
+        entityRoutes(otelContext, userInfo) ~
+        methodConfigRoutes(otelContext, userInfo) ~
+        submissionRoutes(otelContext, userInfo) ~
+        adminRoutes(otelContext, userInfo) ~
+        userRoutes(otelContext, userInfo) ~
+        billingRoutesV2(otelContext, userInfo) ~
+        billingRoutes(otelContext, userInfo) ~
+        notificationsRoutes ~
+        servicePerimeterRoutes(otelContext, userInfo) ~
+        snapshotRoutes(otelContext, userInfo) ~
+        googleProjectRegistrationRoutes(otelContext, userInfo)
+    }
 
   def apiRoutes =
     options(complete(OK)) ~

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/ServicePerimeterApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/ServicePerimeterApiService.scala
@@ -20,19 +20,18 @@ trait ServicePerimeterApiService extends UserInfoDirectives {
   implicit val executionContext: ExecutionContext
 
   val userServiceConstructor: RawlsRequestContext => UserService
-  def servicePerimeterRoutes(otelContext: Context = Context.root()): server.Route =
-    requireUserInfo(Option(otelContext)) { userInfo =>
-      val ctx = RawlsRequestContext(userInfo, Option(otelContext))
-      path("servicePerimeters" / Segment / "projects" / Segment) { (servicePerimeterName, projectId) =>
-        put {
-          complete {
-            userServiceConstructor(ctx)
-              .addProjectToServicePerimeter(ServicePerimeterName(URLDecoder.decode(servicePerimeterName, UTF_8.name)),
-                                            RawlsBillingProjectName(projectId)
-              )
-              .map(_ => StatusCodes.NoContent)
-          }
+  def servicePerimeterRoutes(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
+    val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+    path("servicePerimeters" / Segment / "projects" / Segment) { (servicePerimeterName, projectId) =>
+      put {
+        complete {
+          userServiceConstructor(ctx)
+            .addProjectToServicePerimeter(ServicePerimeterName(URLDecoder.decode(servicePerimeterName, UTF_8.name)),
+                                          RawlsBillingProjectName(projectId)
+            )
+            .map(_ => StatusCodes.NoContent)
         }
       }
     }
+  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -30,127 +30,124 @@ trait SnapshotApiService extends UserInfoDirectives {
 
   val snapshotServiceConstructor: RawlsRequestContext => SnapshotService
 
-  def snapshotRoutes(otelContext: Context = Context.root()): server.Route =
-    requireUserInfo(Option(otelContext)) { userInfo =>
-      val ctx = RawlsRequestContext(userInfo, Option(otelContext))
-      path("workspaces" / Segment / Segment / "snapshots" / "v3") { (workspaceNamespace, workspaceName) =>
+  def snapshotRoutes(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
+    val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+    path("workspaces" / Segment / Segment / "snapshots" / "v3") { (workspaceNamespace, workspaceName) =>
+      post {
+        entity(as[Set[String]]) { snapshotIds =>
+          complete {
+            snapshotServiceConstructor(ctx)
+              .createSnapshotsByWorkspaceNameV3(WorkspaceName(workspaceNamespace, workspaceName),
+                                                snapshotIds.map(UUID.fromString)
+              )
+              .map(_ => StatusCodes.NoContent)
+          }
+        }
+      }
+    } ~
+      path("workspaces" / Segment / "snapshots" / "v3") { workspaceId =>
         post {
           entity(as[Set[String]]) { snapshotIds =>
             complete {
               snapshotServiceConstructor(ctx)
-                .createSnapshotsByWorkspaceNameV3(WorkspaceName(workspaceNamespace, workspaceName),
-                                                  snapshotIds.map(UUID.fromString)
-                )
+                .createSnapshotsByWorkspaceIdV3(workspaceId, snapshotIds.map(UUID.fromString))
                 .map(_ => StatusCodes.NoContent)
             }
           }
         }
       } ~
-        path("workspaces" / Segment / "snapshots" / "v3") { workspaceId =>
-          post {
-            entity(as[Set[String]]) { snapshotIds =>
-              complete {
-                snapshotServiceConstructor(ctx)
-                  .createSnapshotsByWorkspaceIdV3(workspaceId, snapshotIds.map(UUID.fromString))
-                  .map(_ => StatusCodes.NoContent)
-              }
+      path("workspaces" / Segment / Segment / "snapshots" / "v2") { (workspaceNamespace, workspaceName) =>
+        post {
+          entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>
+            complete {
+              snapshotServiceConstructor(ctx)
+                .createSnapshotByWorkspaceName(WorkspaceName(workspaceNamespace, workspaceName), namedDataRepoSnapshot)
+                .map(StatusCodes.Created -> _)
             }
           }
         } ~
-        path("workspaces" / Segment / Segment / "snapshots" / "v2") { (workspaceNamespace, workspaceName) =>
-          post {
-            entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>
-              complete {
-                snapshotServiceConstructor(ctx)
-                  .createSnapshotByWorkspaceName(WorkspaceName(workspaceNamespace, workspaceName),
-                                                 namedDataRepoSnapshot
+          get {
+            // N.B. the "as[UUID]" delegates to SnapshotService.validateSnapshotId, which is in scope;
+            // that method provides a 400 Bad Request response and nice error message
+            parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) {
+              (offset, limit, referencedSnapshotId) =>
+                complete {
+                  snapshotServiceConstructor(ctx).enumerateSnapshotsByWorkspaceName(WorkspaceName(workspaceNamespace,
+                                                                                                  workspaceName
+                                                                                    ),
+                                                                                    offset,
+                                                                                    limit,
+                                                                                    referencedSnapshotId
                   )
-                  .map(StatusCodes.Created -> _)
-              }
+                }
+            }
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "snapshots" / "v2" / Segment) {
+        (workspaceNamespace, workspaceName, snapshotId) =>
+          get {
+            complete {
+              snapshotServiceConstructor(ctx).getSnapshotResourceFromWsm(WorkspaceName(workspaceNamespace,
+                                                                                       workspaceName
+                                                                         ),
+                                                                         snapshotId
+              )
             }
           } ~
-            get {
-              // N.B. the "as[UUID]" delegates to SnapshotService.validateSnapshotId, which is in scope;
-              // that method provides a 400 Bad Request response and nice error message
-              parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) {
-                (offset, limit, referencedSnapshotId) =>
-                  complete {
-                    snapshotServiceConstructor(ctx).enumerateSnapshotsByWorkspaceName(WorkspaceName(workspaceNamespace,
-                                                                                                    workspaceName
-                                                                                      ),
-                                                                                      offset,
-                                                                                      limit,
-                                                                                      referencedSnapshotId
-                    )
-                  }
-              }
-            }
-        } ~
-        path("workspaces" / Segment / Segment / "snapshots" / "v2" / Segment) {
-          (workspaceNamespace, workspaceName, snapshotId) =>
-            get {
-              complete {
-                snapshotServiceConstructor(ctx).getSnapshotResourceFromWsm(WorkspaceName(workspaceNamespace,
-                                                                                         workspaceName
-                                                                           ),
-                                                                           snapshotId
-                )
-              }
-            } ~
-              patch {
-                entity(as[UpdateDataRepoSnapshotReferenceRequestBody]) { updateDataRepoSnapshotReferenceRequestBody =>
-                  complete {
-                    snapshotServiceConstructor(ctx)
-                      .updateSnapshot(WorkspaceName(workspaceNamespace, workspaceName),
-                                      snapshotId,
-                                      updateDataRepoSnapshotReferenceRequestBody
-                      )
-                      .map(_ => StatusCodes.NoContent)
-                  }
-                }
-              } ~
-              delete {
+            patch {
+              entity(as[UpdateDataRepoSnapshotReferenceRequestBody]) { updateDataRepoSnapshotReferenceRequestBody =>
                 complete {
                   snapshotServiceConstructor(ctx)
-                    .deleteSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId)
+                    .updateSnapshot(WorkspaceName(workspaceNamespace, workspaceName),
+                                    snapshotId,
+                                    updateDataRepoSnapshotReferenceRequestBody
+                    )
                     .map(_ => StatusCodes.NoContent)
                 }
               }
-        } ~
-        path("workspaces" / Segment / Segment / "snapshots" / "v2" / "name" / Segment) {
-          (workspaceNamespace, workspaceName, referenceName) =>
-            get {
-              complete {
-                snapshotServiceConstructor(ctx).getSnapshotByName(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                  referenceName
-                )
-              }
-            }
-        } ~
-        path("workspaces" / Segment / "snapshots" / "v2") { workspaceId =>
-          post {
-            entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>
+            } ~
+            delete {
               complete {
                 snapshotServiceConstructor(ctx)
-                  .createSnapshotByWorkspaceId(workspaceId, namedDataRepoSnapshot)
-                  .map(StatusCodes.Created -> _)
+                  .deleteSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId)
+                  .map(_ => StatusCodes.NoContent)
               }
             }
-          } ~
-            get {
-              // N.B. the "as[UUID]" delegates to SnapshotService.validateSnapshotId, which is in scope;
-              // that method provides a 400 Bad Request response and nice error message
-              parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) {
-                (offset, limit, referencedSnapshotId) =>
-                  complete {
-                    snapshotServiceConstructor(ctx).enumerateSnapshotsById(workspaceId,
-                                                                           offset,
-                                                                           limit,
-                                                                           referencedSnapshotId
-                    )
-                  }
-              }
+      } ~
+      path("workspaces" / Segment / Segment / "snapshots" / "v2" / "name" / Segment) {
+        (workspaceNamespace, workspaceName, referenceName) =>
+          get {
+            complete {
+              snapshotServiceConstructor(ctx).getSnapshotByName(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                referenceName
+              )
             }
-        }
-    }
+          }
+      } ~
+      path("workspaces" / Segment / "snapshots" / "v2") { workspaceId =>
+        post {
+          entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>
+            complete {
+              snapshotServiceConstructor(ctx)
+                .createSnapshotByWorkspaceId(workspaceId, namedDataRepoSnapshot)
+                .map(StatusCodes.Created -> _)
+            }
+          }
+        } ~
+          get {
+            // N.B. the "as[UUID]" delegates to SnapshotService.validateSnapshotId, which is in scope;
+            // that method provides a 400 Bad Request response and nice error message
+            parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) {
+              (offset, limit, referencedSnapshotId) =>
+                complete {
+                  snapshotServiceConstructor(ctx).enumerateSnapshotsById(workspaceId,
+                                                                         offset,
+                                                                         limit,
+                                                                         referencedSnapshotId
+                  )
+                }
+            }
+          }
+      }
+  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
@@ -26,128 +26,125 @@ trait SubmissionApiService extends UserInfoDirectives {
   val submissionsServiceConstructor: RawlsRequestContext => SubmissionsService
   val submissionTimeout: FiniteDuration
 
-  def submissionRoutes(otelContext: Context = Context.root()): server.Route = {
-    requireUserInfo(Option(otelContext)) { userInfo =>
-      val ctx = RawlsRequestContext(userInfo, Option(otelContext))
-      path("workspaces" / Segment / Segment / "submissions") { (workspaceNamespace, workspaceName) =>
+  def submissionRoutes(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
+    val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+    path("workspaces" / Segment / Segment / "submissions") { (workspaceNamespace, workspaceName) =>
+      get {
+        complete {
+          submissionsServiceConstructor(ctx).listSubmissions(WorkspaceName(workspaceNamespace, workspaceName), ctx)
+        }
+      }
+    } ~
+      path("workspaces" / Segment / Segment / "submissionsCount") { (workspaceNamespace, workspaceName) =>
         get {
           complete {
-            submissionsServiceConstructor(ctx).listSubmissions(WorkspaceName(workspaceNamespace, workspaceName), ctx)
+            submissionsServiceConstructor(ctx).countSubmissions(WorkspaceName(workspaceNamespace, workspaceName))
           }
         }
       } ~
-        path("workspaces" / Segment / Segment / "submissionsCount") { (workspaceNamespace, workspaceName) =>
+      path("workspaces" / Segment / Segment / "submissions") { (workspaceNamespace, workspaceName) =>
+        post {
+          entity(as[SubmissionRequest]) { submission =>
+            complete {
+              submissionsServiceConstructor(ctx)
+                .createSubmission(WorkspaceName(workspaceNamespace, workspaceName), submission)
+                .map(StatusCodes.Created -> _)
+            }
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "submissions" / Segment / "retry") {
+        (workspaceNamespace, workspaceName, submissionId) =>
+          post {
+            entity(as[SubmissionRetry]) { retry =>
+              complete {
+                submissionsServiceConstructor(ctx).retrySubmission(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                   retry,
+                                                                   submissionId
+                )
+              }
+            }
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "submissions" / "validate") { (workspaceNamespace, workspaceName) =>
+        post {
+          entity(as[SubmissionRequest]) { submission =>
+            complete {
+              submissionsServiceConstructor(ctx).validateSubmission(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                    submission
+              )
+            }
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "submissions" / Segment) {
+        (workspaceNamespace, workspaceName, submissionId) =>
           get {
             complete {
-              submissionsServiceConstructor(ctx).countSubmissions(WorkspaceName(workspaceNamespace, workspaceName))
+              submissionsServiceConstructor(ctx).getSubmissionStatus(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                     submissionId,
+                                                                     ctx
+              )
             }
           }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions") { (workspaceNamespace, workspaceName) =>
-          post {
-            entity(as[SubmissionRequest]) { submission =>
+      } ~
+      path("workspaces" / Segment / Segment / "submissions" / Segment) {
+        (workspaceNamespace, workspaceName, submissionId) =>
+          patch {
+            entity(as[UserCommentUpdateOperation]) { newComment =>
               complete {
                 submissionsServiceConstructor(ctx)
-                  .createSubmission(WorkspaceName(workspaceNamespace, workspaceName), submission)
-                  .map(StatusCodes.Created -> _)
-              }
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment / "retry") {
-          (workspaceNamespace, workspaceName, submissionId) =>
-            post {
-              entity(as[SubmissionRetry]) { retry =>
-                complete {
-                  submissionsServiceConstructor(ctx).retrySubmission(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                     retry,
-                                                                     submissionId
+                  .updateSubmissionUserComment(WorkspaceName(workspaceNamespace, workspaceName),
+                                               submissionId,
+                                               newComment
                   )
-                }
-              }
-            }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions" / "validate") { (workspaceNamespace, workspaceName) =>
-          post {
-            entity(as[SubmissionRequest]) { submission =>
-              complete {
-                submissionsServiceConstructor(ctx).validateSubmission(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                      submission
-                )
-              }
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment) {
-          (workspaceNamespace, workspaceName, submissionId) =>
-            get {
-              complete {
-                submissionsServiceConstructor(ctx).getSubmissionStatus(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                       submissionId,
-                                                                       ctx
-                )
-              }
-            }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment) {
-          (workspaceNamespace, workspaceName, submissionId) =>
-            patch {
-              entity(as[UserCommentUpdateOperation]) { newComment =>
-                complete {
-                  submissionsServiceConstructor(ctx)
-                    .updateSubmissionUserComment(WorkspaceName(workspaceNamespace, workspaceName),
-                                                 submissionId,
-                                                 newComment
-                    )
-                    .map { rowsUpdated =>
-                      if (rowsUpdated == 1) StatusCodes.NoContent -> None
-                      else
-                        StatusCodes.NotFound -> Option(
-                          ErrorReport(
-                            StatusCodes.NotFound,
-                            s"Unable to update userComment for submission. Submission ${submissionId} could not be found."
-                          )
-                        )
-                    }
-                }
-              }
-            }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment) {
-          (workspaceNamespace, workspaceName, submissionId) =>
-            delete {
-              complete {
-                submissionsServiceConstructor(ctx)
-                  .abortSubmission(WorkspaceName(workspaceNamespace, workspaceName), submissionId)
-                  .map { count =>
-                    if (count == 1) StatusCodes.NoContent -> None
+                  .map { rowsUpdated =>
+                    if (rowsUpdated == 1) StatusCodes.NoContent -> None
                     else
                       StatusCodes.NotFound -> Option(
-                        s"Unable to abort submission. Submission ${submissionId} could not be found."
+                        ErrorReport(
+                          StatusCodes.NotFound,
+                          s"Unable to update userComment for submission. Submission ${submissionId} could not be found."
+                        )
                       )
                   }
               }
             }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment / "configuration") {
-          (workspaceNamespace, workspaceName, submissionId) =>
-            get {
-              complete {
-                submissionsServiceConstructor(ctx).getSubmissionMethodConfiguration(WorkspaceName(workspaceNamespace,
-                                                                                                  workspaceName
-                                                                                    ),
-                                                                                    submissionId
-                )
-              }
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "submissions" / Segment) {
+        (workspaceNamespace, workspaceName, submissionId) =>
+          delete {
+            complete {
+              submissionsServiceConstructor(ctx)
+                .abortSubmission(WorkspaceName(workspaceNamespace, workspaceName), submissionId)
+                .map { count =>
+                  if (count == 1) StatusCodes.NoContent -> None
+                  else
+                    StatusCodes.NotFound -> Option(
+                      s"Unable to abort submission. Submission ${submissionId} could not be found."
+                    )
+                }
             }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment) {
-          (workspaceNamespace, workspaceName, submissionId, workflowId) =>
-            get {
-              parameters("includeKey".as[String].*,
-                         "excludeKey".as[String].*,
-                         "expandSubWorkflows".as[Boolean] ? false
-              ) { (includes, excludes, expandSubWorkflows) =>
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "submissions" / Segment / "configuration") {
+        (workspaceNamespace, workspaceName, submissionId) =>
+          get {
+            complete {
+              submissionsServiceConstructor(ctx).getSubmissionMethodConfiguration(WorkspaceName(workspaceNamespace,
+                                                                                                workspaceName
+                                                                                  ),
+                                                                                  submissionId
+              )
+            }
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment) {
+        (workspaceNamespace, workspaceName, submissionId, workflowId) =>
+          get {
+            parameters("includeKey".as[String].*, "excludeKey".as[String].*, "expandSubWorkflows".as[Boolean] ? false) {
+              (includes, excludes, expandSubWorkflows) =>
                 complete {
                   submissionsServiceConstructor(ctx).workflowMetadata(WorkspaceName(workspaceNamespace, workspaceName),
                                                                       submissionId,
@@ -158,43 +155,42 @@ trait SubmissionApiService extends UserInfoDirectives {
                                                                       )
                   )
                 }
-              }
             }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment / "outputs") {
-          (workspaceNamespace, workspaceName, submissionId, workflowId) =>
-            get {
-              complete {
-                submissionsServiceConstructor(ctx).workflowOutputs(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                   submissionId,
-                                                                   workflowId
-                )
-              }
-            }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment / "cost") {
-          (workspaceNamespace, workspaceName, submissionId, workflowId) =>
-            get {
-              complete {
-                submissionsServiceConstructor(ctx).workflowCost(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                submissionId,
-                                                                workflowId
-                )
-              }
-            }
-        } ~
-        path("workflows" / Segment / "genomics" / Segments) { (workflowId, operationId) =>
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment / "outputs") {
+        (workspaceNamespace, workspaceName, submissionId, workflowId) =>
           get {
             complete {
-              submissionsServiceConstructor(ctx).getGenomicsOperationV2(workflowId, operationId).map {
-                case Some(jsobj) =>
-                  implicit val printer = PrettyPrinter
-                  StatusCodes.OK -> jsobj
-                case None => StatusCodes.NotFound -> JsString(s"jobId ${operationId.mkString("/")} not found.")
-              }
+              submissionsServiceConstructor(ctx).workflowOutputs(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                 submissionId,
+                                                                 workflowId
+              )
+            }
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment / "cost") {
+        (workspaceNamespace, workspaceName, submissionId, workflowId) =>
+          get {
+            complete {
+              submissionsServiceConstructor(ctx).workflowCost(WorkspaceName(workspaceNamespace, workspaceName),
+                                                              submissionId,
+                                                              workflowId
+              )
+            }
+          }
+      } ~
+      path("workflows" / Segment / "genomics" / Segments) { (workflowId, operationId) =>
+        get {
+          complete {
+            submissionsServiceConstructor(ctx).getGenomicsOperationV2(workflowId, operationId).map {
+              case Some(jsobj) =>
+                implicit val printer = PrettyPrinter
+                StatusCodes.OK -> jsobj
+              case None => StatusCodes.NotFound -> JsString(s"jobId ${operationId.mkString("/")} not found.")
             }
           }
         }
-    }
+      }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/UserApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/UserApiService.scala
@@ -25,56 +25,55 @@ trait UserApiService extends UserInfoDirectives {
 
   // standard /api routes begin here
 
-  def userRoutes(otelContext: Context = Context.root()): server.Route =
-    requireUserInfo(Option(otelContext)) { userInfo =>
-      val ctx = RawlsRequestContext(userInfo, Option(otelContext))
-      pathPrefix("user" / "billing") {
-        pathEnd {
-          get {
-            complete {
-              userServiceConstructor(ctx).listBillingProjects()
-            }
+  def userRoutes(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
+    val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+    pathPrefix("user" / "billing") {
+      pathEnd {
+        get {
+          complete {
+            userServiceConstructor(ctx).listBillingProjects()
           }
-        } ~
-          path(Segment) { projectName =>
-            get {
-              complete {
-                import spray.json._
-                userServiceConstructor(ctx).getBillingProjectStatus(RawlsBillingProjectName(projectName)).map {
-                  case Some(status) => StatusCodes.OK -> Option(status).toJson
-                  case _            => StatusCodes.NotFound -> Option(StatusCodes.NotFound.defaultMessage).toJson
-                }
-              }
-            }
-          } ~
-          path(Segment) { projectName =>
-            delete {
-              complete {
-                userServiceConstructor(ctx)
-                  .deleteBillingProject(RawlsBillingProjectName(projectName))
-                  .map(_ => StatusCodes.NoContent)
-              }
-            }
-          }
+        }
       } ~
-        path("user" / "role" / "admin") {
+        path(Segment) { projectName =>
           get {
             complete {
-              userServiceConstructor(ctx).isAdmin(userInfo.userEmail).map {
-                case true  => StatusCodes.OK
-                case false => StatusCodes.NotFound
+              import spray.json._
+              userServiceConstructor(ctx).getBillingProjectStatus(RawlsBillingProjectName(projectName)).map {
+                case Some(status) => StatusCodes.OK -> Option(status).toJson
+                case _            => StatusCodes.NotFound -> Option(StatusCodes.NotFound.defaultMessage).toJson
               }
             }
           }
         } ~
-        path("user" / "billingAccounts") {
-          get {
-            parameters("firecloudHasAccess".as[Boolean].optional) { firecloudHasAccess =>
-              complete {
-                userServiceConstructor(ctx).listBillingAccounts(firecloudHasAccess)
-              }
+        path(Segment) { projectName =>
+          delete {
+            complete {
+              userServiceConstructor(ctx)
+                .deleteBillingProject(RawlsBillingProjectName(projectName))
+                .map(_ => StatusCodes.NoContent)
             }
           }
         }
-    }
+    } ~
+      path("user" / "role" / "admin") {
+        get {
+          complete {
+            userServiceConstructor(ctx).isAdmin(userInfo.userEmail).map {
+              case true  => StatusCodes.OK
+              case false => StatusCodes.NotFound
+            }
+          }
+        }
+      } ~
+      path("user" / "billingAccounts") {
+        get {
+          parameters("firecloudHasAccess".as[Boolean].optional) { firecloudHasAccess =>
+            complete {
+              userServiceConstructor(ctx).listBillingAccounts(firecloudHasAccess)
+            }
+          }
+        }
+      }
+  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -26,235 +26,233 @@ trait WorkspaceApiService extends UserInfoDirectives {
   val workspaceServiceConstructor: RawlsRequestContext => WorkspaceService
   val multiCloudWorkspaceServiceConstructor: RawlsRequestContext => MultiCloudWorkspaceService
 
-  def workspaceRoutes(otelContext: Context = Context.root()): server.Route = {
-    requireUserInfo(Option(otelContext)) { userInfo =>
-      val ctx = RawlsRequestContext(userInfo, Option(otelContext))
-      path("workspaces") {
-        post {
-          entity(as[WorkspaceRequest]) { workspace =>
-            addLocationHeader(workspace.path) {
+  def workspaceRoutes(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
+    val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+    path("workspaces") {
+      post {
+        entity(as[WorkspaceRequest]) { workspace =>
+          addLocationHeader(workspace.path) {
+            complete {
+              val workspaceService = workspaceServiceConstructor(ctx)
+              val mcWorkspaceService = multiCloudWorkspaceServiceConstructor(ctx)
+              mcWorkspaceService
+                .createMultiCloudOrRawlsWorkspace(workspace, workspaceService)
+                .map(w => StatusCodes.Created -> w)
+            }
+          }
+        }
+      } ~
+        get {
+          parameterSeq { allParams =>
+            parameter("stringAttributeMaxLength".as[Int].withDefault(-1)) { stringAttributeMaxLength =>
               complete {
-                val workspaceService = workspaceServiceConstructor(ctx)
-                val mcWorkspaceService = multiCloudWorkspaceServiceConstructor(ctx)
-                mcWorkspaceService
-                  .createMultiCloudOrRawlsWorkspace(workspace, workspaceService)
-                  .map(w => StatusCodes.Created -> w)
+                workspaceServiceConstructor(ctx).listWorkspaces(
+                  WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
+                  stringAttributeMaxLength
+                )
               }
+            }
+          }
+        }
+    } ~
+      path("workspaces" / "tags") {
+        parameters(Symbol("q").?, "limit".as[Int].optional) { (queryString, limit) =>
+          get {
+            complete {
+              workspaceServiceConstructor(ctx).getTags(queryString, limit)
+            }
+          }
+        }
+      } ~
+      path("workspaces" / "id" / Segment) { workspaceId =>
+        get {
+          parameters("userProject".optional) { userProject =>
+            parameterSeq { allParams =>
+              complete {
+                workspaceServiceConstructor(ctx).getWorkspaceById(workspaceId,
+                                                                  WorkspaceFieldSpecs.fromQueryParams(allParams,
+                                                                                                      "fields"
+                                                                  ),
+                                                                  userProject.map(GoogleProjectId)
+                )
+              }
+            }
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment) { (workspaceNamespace, workspaceName) =>
+        patch {
+          entity(as[Array[AttributeUpdateOperation]]) { operations =>
+            complete {
+              workspaceServiceConstructor(ctx).updateWorkspace(WorkspaceName(workspaceNamespace, workspaceName),
+                                                               operations
+              )
             }
           }
         } ~
           get {
-            parameterSeq { allParams =>
-              parameter("stringAttributeMaxLength".as[Int].withDefault(-1)) { stringAttributeMaxLength =>
+            parameters("userProject".optional) { userProject =>
+              parameterSeq { allParams =>
                 complete {
-                  workspaceServiceConstructor(ctx).listWorkspaces(
-                    WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
-                    stringAttributeMaxLength
+                  workspaceServiceConstructor(ctx).getWorkspace(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                WorkspaceFieldSpecs.fromQueryParams(allParams,
+                                                                                                    "fields"
+                                                                ),
+                                                                userProject.map(GoogleProjectId)
+                  )
+                }
+              }
+            }
+          } ~
+          delete {
+            complete {
+              val workspaceService = workspaceServiceConstructor(ctx)
+              val mcWorkspaceService = multiCloudWorkspaceServiceConstructor(ctx)
+              mcWorkspaceService
+                .deleteMultiCloudOrRawlsWorkspace(WorkspaceName(workspaceNamespace, workspaceName), workspaceService)
+                .map(maybeBucketName => StatusCodes.Accepted -> workspaceDeleteMessage(maybeBucketName))
+            }
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "accessInstructions") { (workspaceNamespace, workspaceName) =>
+        get {
+          complete {
+            workspaceServiceConstructor(ctx).getAccessInstructions(WorkspaceName(workspaceNamespace, workspaceName))
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "bucketOptions") { (workspaceNamespace, workspaceName) =>
+        get {
+          parameters("userProject".optional) { userProject =>
+            complete {
+              workspaceServiceConstructor(ctx).getBucketOptions(
+                WorkspaceName(workspaceNamespace, workspaceName),
+                userProject.map(GoogleProjectId)
+              )
+            }
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "clone") { (sourceNamespace, sourceWorkspace) =>
+        post {
+          entity(as[WorkspaceRequest]) { destWorkspace =>
+            addLocationHeader(destWorkspace.toWorkspaceName.path) {
+              complete {
+                multiCloudWorkspaceServiceConstructor(ctx)
+                  .cloneMultiCloudWorkspace(
+                    workspaceServiceConstructor(ctx),
+                    WorkspaceName(sourceNamespace, sourceWorkspace),
+                    destWorkspace
+                  )
+                  .map(w => StatusCodes.Created -> w)
+              }
+            }
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "acl") { (workspaceNamespace, workspaceName) =>
+        get {
+          complete {
+            workspaceServiceConstructor(ctx).getACL(WorkspaceName(workspaceNamespace, workspaceName))
+          }
+        } ~
+          patch {
+            parameter(Symbol("inviteUsersNotFound").?) { inviteUsersNotFound: Option[String] =>
+              entity(as[Set[WorkspaceACLUpdate]]) { aclUpdate =>
+                val inviteUsersNotFoundValue = inviteUsersNotFound match {
+                  case Some(str) if str.isEmpty => false
+                  case Some(str)                => str.toBoolean
+                  case None                     => false
+                }
+
+                complete {
+                  workspaceServiceConstructor(ctx).updateACL(WorkspaceName(workspaceNamespace, workspaceName),
+                                                             aclUpdate,
+                                                             inviteUsersNotFoundValue
                   )
                 }
               }
             }
           }
       } ~
-        path("workspaces" / "tags") {
-          parameters(Symbol("q").?, "limit".as[Int].optional) { (queryString, limit) =>
-            get {
-              complete {
-                workspaceServiceConstructor(ctx).getTags(queryString, limit)
-              }
-            }
+      path("workspaces" / Segment / Segment / "checkBucketReadAccess") { (workspaceNamespace, workspaceName) =>
+        get {
+          complete {
+            workspaceServiceConstructor(ctx)
+              .checkWorkspaceCloudPermissions(WorkspaceName(workspaceNamespace, workspaceName))
+              .map(_ => StatusCodes.OK)
           }
-        } ~
-        path("workspaces" / "id" / Segment) { workspaceId =>
-          get {
-            parameters("userProject".optional) { userProject =>
-              parameterSeq { allParams =>
-                complete {
-                  workspaceServiceConstructor(ctx).getWorkspaceById(workspaceId,
-                                                                    WorkspaceFieldSpecs.fromQueryParams(allParams,
-                                                                                                        "fields"
-                                                                    ),
-                                                                    userProject.map(GoogleProjectId)
-                  )
-                }
-              }
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment) { (workspaceNamespace, workspaceName) =>
-          patch {
-            entity(as[Array[AttributeUpdateOperation]]) { operations =>
-              complete {
-                workspaceServiceConstructor(ctx).updateWorkspace(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                 operations
-                )
-              }
-            }
-          } ~
-            get {
-              parameters("userProject".optional) { userProject =>
-                parameterSeq { allParams =>
-                  complete {
-                    workspaceServiceConstructor(ctx).getWorkspace(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                  WorkspaceFieldSpecs.fromQueryParams(allParams,
-                                                                                                      "fields"
-                                                                  ),
-                                                                  userProject.map(GoogleProjectId)
-                    )
-                  }
-                }
-              }
-            } ~
-            delete {
-              complete {
-                val workspaceService = workspaceServiceConstructor(ctx)
-                val mcWorkspaceService = multiCloudWorkspaceServiceConstructor(ctx)
-                mcWorkspaceService
-                  .deleteMultiCloudOrRawlsWorkspace(WorkspaceName(workspaceNamespace, workspaceName), workspaceService)
-                  .map(maybeBucketName => StatusCodes.Accepted -> workspaceDeleteMessage(maybeBucketName))
-              }
-            }
-        } ~
-        path("workspaces" / Segment / Segment / "accessInstructions") { (workspaceNamespace, workspaceName) =>
-          get {
-            complete {
-              workspaceServiceConstructor(ctx).getAccessInstructions(WorkspaceName(workspaceNamespace, workspaceName))
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "bucketOptions") { (workspaceNamespace, workspaceName) =>
-          get {
-            parameters("userProject".optional) { userProject =>
-              complete {
-                workspaceServiceConstructor(ctx).getBucketOptions(
-                  WorkspaceName(workspaceNamespace, workspaceName),
-                  userProject.map(GoogleProjectId)
-                )
-              }
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "clone") { (sourceNamespace, sourceWorkspace) =>
-          post {
-            entity(as[WorkspaceRequest]) { destWorkspace =>
-              addLocationHeader(destWorkspace.toWorkspaceName.path) {
-                complete {
-                  multiCloudWorkspaceServiceConstructor(ctx)
-                    .cloneMultiCloudWorkspace(
-                      workspaceServiceConstructor(ctx),
-                      WorkspaceName(sourceNamespace, sourceWorkspace),
-                      destWorkspace
-                    )
-                    .map(w => StatusCodes.Created -> w)
-                }
-              }
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "acl") { (workspaceNamespace, workspaceName) =>
-          get {
-            complete {
-              workspaceServiceConstructor(ctx).getACL(WorkspaceName(workspaceNamespace, workspaceName))
-            }
-          } ~
-            patch {
-              parameter(Symbol("inviteUsersNotFound").?) { inviteUsersNotFound: Option[String] =>
-                entity(as[Set[WorkspaceACLUpdate]]) { aclUpdate =>
-                  val inviteUsersNotFoundValue = inviteUsersNotFound match {
-                    case Some(str) if str.isEmpty => false
-                    case Some(str)                => str.toBoolean
-                    case None                     => false
-                  }
-
-                  complete {
-                    workspaceServiceConstructor(ctx).updateACL(WorkspaceName(workspaceNamespace, workspaceName),
-                                                               aclUpdate,
-                                                               inviteUsersNotFoundValue
-                    )
-                  }
-                }
-              }
-            }
-        } ~
-        path("workspaces" / Segment / Segment / "checkBucketReadAccess") { (workspaceNamespace, workspaceName) =>
-          get {
-            complete {
-              workspaceServiceConstructor(ctx)
-                .checkWorkspaceCloudPermissions(WorkspaceName(workspaceNamespace, workspaceName))
-                .map(_ => StatusCodes.OK)
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "checkIamActionWithLock" / Segment) {
-          (workspaceNamespace, workspaceName, requiredAction) =>
-            get {
-              complete {
-                workspaceServiceConstructor(ctx)
-                  .checkSamActionWithLock(WorkspaceName(workspaceNamespace, workspaceName),
-                                          SamResourceAction(requiredAction)
-                  )
-                  .map {
-                    case true  => StatusCodes.NoContent
-                    case false => StatusCodes.Forbidden
-                  }
-              }
-            }
-        } ~
-        path("workspaces" / Segment / Segment / "fileTransfers") { (workspaceNamespace, workspaceName) =>
-          get {
-            complete {
-              workspaceServiceConstructor(ctx)
-                .listPendingFileTransfersForWorkspace(WorkspaceName(workspaceNamespace, workspaceName))
-                .map(pendingTransfers => StatusCodes.OK -> pendingTransfers)
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "lock") { (workspaceNamespace, workspaceName) =>
-          put {
-            complete {
-              workspaceServiceConstructor(ctx)
-                .lockWorkspace(WorkspaceName(workspaceNamespace, workspaceName))
-                .map(_ => StatusCodes.NoContent)
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "unlock") { (workspaceNamespace, workspaceName) =>
-          put {
-            complete {
-              workspaceServiceConstructor(ctx)
-                .unlockWorkspace(WorkspaceName(workspaceNamespace, workspaceName))
-                .map(_ => StatusCodes.NoContent)
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "sendChangeNotification") { (namespace, name) =>
-          post {
-            complete {
-              workspaceServiceConstructor(ctx).sendChangeNotifications(WorkspaceName(namespace, name))
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "enableRequesterPaysForLinkedServiceAccounts") {
-          (workspaceNamespace, workspaceName) =>
-            put {
-              complete {
-                workspaceServiceConstructor(ctx)
-                  .enableRequesterPaysForLinkedSAs(WorkspaceName(workspaceNamespace, workspaceName))
-                  .map(_ => StatusCodes.NoContent)
-              }
-            }
-        } ~
-        path("workspaces" / Segment / Segment / "disableRequesterPaysForLinkedServiceAccounts") {
-          (workspaceNamespace, workspaceName) =>
-            put {
-              complete {
-                workspaceServiceConstructor(ctx)
-                  .disableRequesterPaysForLinkedSAs(WorkspaceName(workspaceNamespace, workspaceName))
-                  .map(_ => StatusCodes.NoContent)
-              }
-            }
         }
-    }
+      } ~
+      path("workspaces" / Segment / Segment / "checkIamActionWithLock" / Segment) {
+        (workspaceNamespace, workspaceName, requiredAction) =>
+          get {
+            complete {
+              workspaceServiceConstructor(ctx)
+                .checkSamActionWithLock(WorkspaceName(workspaceNamespace, workspaceName),
+                                        SamResourceAction(requiredAction)
+                )
+                .map {
+                  case true  => StatusCodes.NoContent
+                  case false => StatusCodes.Forbidden
+                }
+            }
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "fileTransfers") { (workspaceNamespace, workspaceName) =>
+        get {
+          complete {
+            workspaceServiceConstructor(ctx)
+              .listPendingFileTransfersForWorkspace(WorkspaceName(workspaceNamespace, workspaceName))
+              .map(pendingTransfers => StatusCodes.OK -> pendingTransfers)
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "lock") { (workspaceNamespace, workspaceName) =>
+        put {
+          complete {
+            workspaceServiceConstructor(ctx)
+              .lockWorkspace(WorkspaceName(workspaceNamespace, workspaceName))
+              .map(_ => StatusCodes.NoContent)
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "unlock") { (workspaceNamespace, workspaceName) =>
+        put {
+          complete {
+            workspaceServiceConstructor(ctx)
+              .unlockWorkspace(WorkspaceName(workspaceNamespace, workspaceName))
+              .map(_ => StatusCodes.NoContent)
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "sendChangeNotification") { (namespace, name) =>
+        post {
+          complete {
+            workspaceServiceConstructor(ctx).sendChangeNotifications(WorkspaceName(namespace, name))
+          }
+        }
+      } ~
+      path("workspaces" / Segment / Segment / "enableRequesterPaysForLinkedServiceAccounts") {
+        (workspaceNamespace, workspaceName) =>
+          put {
+            complete {
+              workspaceServiceConstructor(ctx)
+                .enableRequesterPaysForLinkedSAs(WorkspaceName(workspaceNamespace, workspaceName))
+                .map(_ => StatusCodes.NoContent)
+            }
+          }
+      } ~
+      path("workspaces" / Segment / Segment / "disableRequesterPaysForLinkedServiceAccounts") {
+        (workspaceNamespace, workspaceName) =>
+          put {
+            complete {
+              workspaceServiceConstructor(ctx)
+                .disableRequesterPaysForLinkedSAs(WorkspaceName(workspaceNamespace, workspaceName))
+                .map(_ => StatusCodes.NoContent)
+            }
+          }
+      }
   }
 
   private def workspaceDeleteMessage(maybeGoogleBucket: Option[String]): String =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceV2.scala
@@ -25,155 +25,154 @@ trait WorkspaceApiServiceV2 extends UserInfoDirectives {
   val bucketMigrationServiceConstructor: RawlsRequestContext => BucketMigrationService
   val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService
 
-  def workspaceRoutesV2(otelContext: Context = Context.root()): server.Route =
-    requireUserInfo(Option(otelContext)) { userInfo =>
-      val ctx = RawlsRequestContext(userInfo, Option(otelContext))
-      pathPrefix("workspaces" / "v2") {
-        pathPrefix(Segment / Segment) { (namespace, name) =>
-          val workspaceName = WorkspaceName(namespace, name)
+  def workspaceRoutesV2(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
+    val ctx = RawlsRequestContext(userInfo, Option(otelContext))
+    pathPrefix("workspaces" / "v2") {
+      pathPrefix(Segment / Segment) { (namespace, name) =>
+        val workspaceName = WorkspaceName(namespace, name)
 
-          pathPrefix("clone") {
-            post {
-              entity(as[WorkspaceRequest]) { destWorkspace =>
-                addLocationHeader(destWorkspace.toWorkspaceName.path) {
+        pathPrefix("clone") {
+          post {
+            entity(as[WorkspaceRequest]) { destWorkspace =>
+              addLocationHeader(destWorkspace.toWorkspaceName.path) {
+                complete {
+                  multiCloudWorkspaceServiceConstructor(ctx)
+                    .cloneMultiCloudWorkspaceAsync(
+                      workspaceServiceConstructor(ctx),
+                      workspaceName,
+                      destWorkspace
+                    )
+                    .map(w => StatusCodes.Created -> w)
+                }
+              }
+            }
+          }
+        } ~
+          pathPrefix("bucketUsage") {
+            get {
+              complete {
+                workspaceServiceConstructor(ctx).getBucketUsageV2(workspaceName)
+              }
+            }
+          } ~
+          pathEndOrSingleSlash {
+            delete {
+              complete {
+                val workspaceService = workspaceServiceConstructor(ctx)
+                val mcWorkspaceService = multiCloudWorkspaceServiceConstructor(ctx)
+                mcWorkspaceService
+                  .deleteMultiCloudOrRawlsWorkspaceV2(workspaceName, workspaceService)
+                  .map(result => StatusCodes.Accepted -> JsObject(Map("result" -> result.toJson)))
+
+              }
+            }
+          } ~
+          pathPrefix("bucketMigration") {
+            pathEndOrSingleSlash {
+              get {
+                complete {
+                  bucketMigrationServiceConstructor(ctx)
+                    .getBucketMigrationAttemptsForWorkspace(workspaceName)
+                    .map(ms => StatusCodes.OK -> ms)
+                }
+              } ~
+                post {
                   complete {
-                    multiCloudWorkspaceServiceConstructor(ctx)
-                      .cloneMultiCloudWorkspaceAsync(
-                        workspaceServiceConstructor(ctx),
-                        workspaceName,
-                        destWorkspace
-                      )
-                      .map(w => StatusCodes.Created -> w)
+                    bucketMigrationServiceConstructor(ctx)
+                      .migrateWorkspaceBucket(workspaceName)
+                      .map(StatusCodes.Created -> _)
+                  }
+                }
+            } ~
+              path("progress") {
+                get {
+                  complete {
+                    bucketMigrationServiceConstructor(ctx)
+                      .getBucketMigrationProgressForWorkspace(workspaceName)
+                      .map(StatusCodes.OK -> _)
+                  }
+                }
+              }
+          } ~
+          pathPrefix("settings") {
+            pathEndOrSingleSlash {
+              get {
+                complete {
+                  workspaceSettingServiceConstructor(ctx)
+                    .getWorkspaceSettings(workspaceName)
+                    .map(StatusCodes.OK -> _)
+                }
+              } ~
+                put {
+                  entity(as[List[WorkspaceSetting]]) { settings =>
+                    complete {
+                      workspaceSettingServiceConstructor(ctx)
+                        .setWorkspaceSettings(workspaceName, settings)
+                        .map(StatusCodes.OK -> _)
+                    }
+                  }
+                }
+            }
+          } ~
+          pathPrefix("authDomain") {
+            pathEndOrSingleSlash {
+              patch {
+                entity(as[List[String]]) { newAuthDomainGroups =>
+                  complete {
+                    workspaceServiceConstructor(ctx)
+                      .addAuthDomainGroups(workspaceName, newAuthDomainGroups.toSet)
+                      .map(_ => StatusCodes.NoContent)
                   }
                 }
               }
             }
           } ~
-            pathPrefix("bucketUsage") {
+          pathPrefix("billingProject") {
+            pathEndOrSingleSlash {
+              patch {
+                entity(as[WorkspaceRequestUpdateBilling]) { updateRequest =>
+                  complete {
+                    workspaceServiceConstructor(ctx)
+                      .updateWorkspaceBillingProject(workspaceName, updateRequest.newBillingProjectName)
+                      .map(_ => StatusCodes.OK)
+                  }
+                }
+              }
+            }
+          }
+      } ~
+        pathPrefix("bucketMigration") {
+          pathEndOrSingleSlash {
+            post {
+              entity(as[List[WorkspaceName]]) { workspaceNames =>
+                complete {
+                  bucketMigrationServiceConstructor(ctx)
+                    .migrateAllWorkspaceBuckets(workspaceNames)
+                    .map(StatusCodes.Created -> _)
+                }
+              }
+            } ~
               get {
                 complete {
-                  workspaceServiceConstructor(ctx).getBucketUsageV2(workspaceName)
+                  bucketMigrationServiceConstructor(ctx).getEligibleOrMigratingWorkspaces
+                    .map(StatusCodes.OK -> _)
                 }
               }
-            } ~
-            pathEndOrSingleSlash {
-              delete {
-                complete {
-                  val workspaceService = workspaceServiceConstructor(ctx)
-                  val mcWorkspaceService = multiCloudWorkspaceServiceConstructor(ctx)
-                  mcWorkspaceService
-                    .deleteMultiCloudOrRawlsWorkspaceV2(workspaceName, workspaceService)
-                    .map(result => StatusCodes.Accepted -> JsObject(Map("result" -> result.toJson)))
-
-                }
-              }
-            } ~
-            pathPrefix("bucketMigration") {
+          } ~
+            pathPrefix("getProgress") {
               pathEndOrSingleSlash {
-                get {
-                  complete {
-                    bucketMigrationServiceConstructor(ctx)
-                      .getBucketMigrationAttemptsForWorkspace(workspaceName)
-                      .map(ms => StatusCodes.OK -> ms)
-                  }
-                } ~
-                  post {
+                post {
+                  entity(as[List[WorkspaceName]]) { workspaceNames =>
                     complete {
                       bucketMigrationServiceConstructor(ctx)
-                        .migrateWorkspaceBucket(workspaceName)
-                        .map(StatusCodes.Created -> _)
-                    }
-                  }
-              } ~
-                path("progress") {
-                  get {
-                    complete {
-                      bucketMigrationServiceConstructor(ctx)
-                        .getBucketMigrationProgressForWorkspace(workspaceName)
+                        .getBucketMigrationProgressForWorkspaces(workspaceNames)
                         .map(StatusCodes.OK -> _)
-                    }
-                  }
-                }
-            } ~
-            pathPrefix("settings") {
-              pathEndOrSingleSlash {
-                get {
-                  complete {
-                    workspaceSettingServiceConstructor(ctx)
-                      .getWorkspaceSettings(workspaceName)
-                      .map(StatusCodes.OK -> _)
-                  }
-                } ~
-                  put {
-                    entity(as[List[WorkspaceSetting]]) { settings =>
-                      complete {
-                        workspaceSettingServiceConstructor(ctx)
-                          .setWorkspaceSettings(workspaceName, settings)
-                          .map(StatusCodes.OK -> _)
-                      }
-                    }
-                  }
-              }
-            } ~
-            pathPrefix("authDomain") {
-              pathEndOrSingleSlash {
-                patch {
-                  entity(as[List[String]]) { newAuthDomainGroups =>
-                    complete {
-                      workspaceServiceConstructor(ctx)
-                        .addAuthDomainGroups(workspaceName, newAuthDomainGroups.toSet)
-                        .map(_ => StatusCodes.NoContent)
-                    }
-                  }
-                }
-              }
-            } ~
-            pathPrefix("billingProject") {
-              pathEndOrSingleSlash {
-                patch {
-                  entity(as[WorkspaceRequestUpdateBilling]) { updateRequest =>
-                    complete {
-                      workspaceServiceConstructor(ctx)
-                        .updateWorkspaceBillingProject(workspaceName, updateRequest.newBillingProjectName)
-                        .map(_ => StatusCodes.OK)
                     }
                   }
                 }
               }
             }
-        } ~
-          pathPrefix("bucketMigration") {
-            pathEndOrSingleSlash {
-              post {
-                entity(as[List[WorkspaceName]]) { workspaceNames =>
-                  complete {
-                    bucketMigrationServiceConstructor(ctx)
-                      .migrateAllWorkspaceBuckets(workspaceNames)
-                      .map(StatusCodes.Created -> _)
-                  }
-                }
-              } ~
-                get {
-                  complete {
-                    bucketMigrationServiceConstructor(ctx).getEligibleOrMigratingWorkspaces
-                      .map(StatusCodes.OK -> _)
-                  }
-                }
-            } ~
-              pathPrefix("getProgress") {
-                pathEndOrSingleSlash {
-                  post {
-                    entity(as[List[WorkspaceName]]) { workspaceNames =>
-                      complete {
-                        bucketMigrationServiceConstructor(ctx)
-                          .getBucketMigrationProgressForWorkspaces(workspaceNames)
-                          .map(StatusCodes.OK -> _)
-                      }
-                    }
-                  }
-                }
-              }
-          }
-      }
+        }
     }
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -62,7 +62,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
 
     withStatsD {
       Get("/admin/submissions") ~>
-        sealRoute(captureRequestMetrics(traceRequests(services.adminRoutes))) ~>
+        sealRoute(captureRequestMetrics(traceRequests(services.adminRoutes(userInfo = userInfo)))) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -81,7 +81,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
   it should "return 200 when listing active submissions on deleted entities" in withConstantTestDataApiServices {
     services =>
       Post(s"${constantData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(constantData.indiv1))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -89,7 +89,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
         }
 
       Get(s"/admin/submissions") ~>
-        sealRoute(services.adminRoutes()) ~>
+        sealRoute(services.adminRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -131,7 +131,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
     Delete(
       s"/admin/submissions/${testData.wsName.namespace}/${testData.wsName.name}/${testData.submissionTerminateTest.submissionId}"
     ) ~>
-      sealRoute(services.adminRoutes()) ~>
+      sealRoute(services.adminRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent)(status)
       }
@@ -139,7 +139,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
 
   it should "return 404 when aborting a bogus active submission" in withTestDataApiServices { services =>
     Delete(s"/admin/submissions/${testData.wsName.namespace}/${testData.wsName.name}/fake") ~>
-      sealRoute(services.adminRoutes()) ~>
+      sealRoute(services.adminRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound)(status)
       }
@@ -185,7 +185,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
     }
 
     Get("/admin/submissions/queueStatusByUser") ~>
-      sealRoute(services.adminRoutes()) ~>
+      sealRoute(services.adminRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -223,7 +223,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
     val flagApiUrl = s"/admin/workspaces/${constantData.workspace.namespace}/${constantData.workspace.name}/flags"
     // workspace should start with zero flags
     Get(flagApiUrl) ~>
-      sealRoute(services.adminRoutes()) ~>
+      sealRoute(services.adminRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         assertResult(List.empty[String])(responseAs[List[String]])
@@ -241,7 +241,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
     flagAttempts foreach { flags =>
       withClue(s"when attempting to put feature flags $flags ... ") {
         Put(flagApiUrl, flags) ~>
-          sealRoute(services.adminRoutes()) ~>
+          sealRoute(services.adminRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.OK)(status)
             responseAs[List[String]] should contain theSameElementsAs flags
@@ -250,7 +250,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
 
       withClue(s"when attempting to get feature flags, expecting $flags ... ") {
         Get(flagApiUrl) ~>
-          sealRoute(services.adminRoutes()) ~>
+          sealRoute(services.adminRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.OK)(status)
             responseAs[List[String]] should contain theSameElementsAs flags
@@ -267,7 +267,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
 
     val idApiUrl = s"/admin/workspaces/${constantData.workspace.namespace}/${constantData.workspace.name}/id"
     Get(idApiUrl) ~>
-      sealRoute(service.adminRoutes()) ~>
+      sealRoute(service.adminRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String])(status)
         println(responseAs[String])
@@ -284,7 +284,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
     val idApiUrl = s"/admin/workspaces/${constantData.workspace.namespace}/$nonExistentWorkspace/id"
 
     Get(idApiUrl) ~>
-      sealRoute(service.adminRoutes()) ~>
+      sealRoute(service.adminRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound)(status)
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -62,7 +62,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
 
     withStatsD {
       Get("/admin/submissions") ~>
-        sealRoute(captureRequestMetrics(traceRequests(services.adminRoutes(userInfo = userInfo)))) ~>
+        sealRoute(captureRequestMetrics(traceRequests(_ => services.adminRoutes(userInfo = userInfo)))) ~>
         check {
           assertResult(StatusCodes.OK) {
             status

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -477,18 +477,18 @@ trait ApiServiceSpec
     val sealedInstrumentedRoutes: Route = captureRequestMetrics {
       traceRequests { otelContext =>
         sealRoute(
-          workspaceRoutesV2(otelContext) ~
-            workspaceRoutes(otelContext) ~
-            entityRoutes(otelContext) ~
-            methodConfigRoutes(otelContext) ~
-            submissionRoutes(otelContext) ~
-            adminRoutes(otelContext) ~
-            userRoutes(otelContext) ~
-            billingRoutesV2(otelContext) ~
-            billingRoutes(otelContext) ~
+          workspaceRoutesV2(otelContext, userInfo) ~
+            workspaceRoutes(otelContext, userInfo) ~
+            entityRoutes(otelContext, userInfo) ~
+            methodConfigRoutes(otelContext, userInfo) ~
+            submissionRoutes(otelContext, userInfo) ~
+            adminRoutes(otelContext, userInfo) ~
+            userRoutes(otelContext, userInfo) ~
+            billingRoutesV2(otelContext, userInfo) ~
+            billingRoutes(otelContext, userInfo) ~
             notificationsRoutes ~
-            servicePerimeterRoutes(otelContext) ~
-            snapshotRoutes(otelContext) ~
+            servicePerimeterRoutes(otelContext, userInfo) ~
+            snapshotRoutes(otelContext, userInfo) ~
             statusRoute
         )
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceSpec.scala
@@ -357,7 +357,7 @@ class BillingApiServiceSpec extends ApiServiceSpec with MockitoSugar {
       ).thenReturn(Future.successful(true))
 
       Put(s"/servicePerimeters/${encodedServicePerimeterName}/projects/${projectName.value}") ~>
-        sealRoute(services.servicePerimeterRoutes()) ~>
+        sealRoute(services.servicePerimeterRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -389,7 +389,7 @@ class BillingApiServiceSpec extends ApiServiceSpec with MockitoSugar {
       ).thenReturn(Future.successful(false))
 
       Put(s"/servicePerimeters/${encodedServicePerimeterName}/projects/${projectName.value}") ~>
-        sealRoute(services.servicePerimeterRoutes()) ~>
+        sealRoute(services.servicePerimeterRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Forbidden) {
             status
@@ -413,7 +413,7 @@ class BillingApiServiceSpec extends ApiServiceSpec with MockitoSugar {
       ).thenReturn(Future.successful(false))
 
       Put(s"/servicePerimeters/${encodedServicePerimeterName}/projects/${projectName.value}") ~>
-        sealRoute(services.servicePerimeterRoutes()) ~>
+        sealRoute(services.servicePerimeterRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceSpec.scala
@@ -82,7 +82,7 @@ class BillingApiServiceSpec extends ApiServiceSpec with MockitoSugar {
       val project = billingProjectFromName("new_project")
 
       Put(s"/billing/${project.projectName.value}/user/${testData.userWriter.userEmail.value}") ~>
-        sealRoute(services.billingRoutes()) ~>
+        sealRoute(services.billingRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -90,7 +90,7 @@ class BillingApiServiceSpec extends ApiServiceSpec with MockitoSugar {
         }
 
       Put(s"/billing/${project.projectName.value}/owner/${testData.userWriter.userEmail.value}") ~>
-        sealRoute(services.billingRoutes()) ~>
+        sealRoute(services.billingRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -151,7 +151,7 @@ class BillingApiServiceSpec extends ApiServiceSpec with MockitoSugar {
     )
 
     Put(s"/billing/${project.projectName.value}/user/nobody") ~>
-      sealRoute(services.billingRoutes()) ~>
+      sealRoute(services.billingRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -169,7 +169,7 @@ class BillingApiServiceSpec extends ApiServiceSpec with MockitoSugar {
     ).thenReturn(Future.successful(false))
 
     Put(s"/billing/missing_project/user/${testData.userOwner.userEmail.value}") ~>
-      sealRoute(services.billingRoutes()) ~>
+      sealRoute(services.billingRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Forbidden) {
           status
@@ -208,7 +208,7 @@ class BillingApiServiceSpec extends ApiServiceSpec with MockitoSugar {
     ).thenReturn(Future.successful(false))
 
     Delete(s"/billing/${project.projectName.value}/owner/${testData.userWriter.userEmail.value}") ~>
-      sealRoute(services.billingRoutes()) ~>
+      sealRoute(services.billingRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Forbidden) {
           status
@@ -230,7 +230,7 @@ class BillingApiServiceSpec extends ApiServiceSpec with MockitoSugar {
       ).thenReturn(Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, ""))))
 
       Delete(s"/billing/${project.projectName.value}/user/nobody") ~>
-        sealRoute(services.billingRoutes()) ~>
+        sealRoute(services.billingRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -248,7 +248,7 @@ class BillingApiServiceSpec extends ApiServiceSpec with MockitoSugar {
         )
       ).thenReturn(Future.successful(false))
       Delete(s"/billing/missing_project/user/${testData.userOwner.userEmail.value}") ~>
-        sealRoute(services.billingRoutes()) ~>
+        sealRoute(services.billingRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Forbidden) {
             status
@@ -290,7 +290,7 @@ class BillingApiServiceSpec extends ApiServiceSpec with MockitoSugar {
     )
 
     Get(s"/billing/${project.projectName.value}/members") ~>
-      sealRoute(services.billingRoutes()) ~>
+      sealRoute(services.billingRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -330,7 +330,7 @@ class BillingApiServiceSpec extends ApiServiceSpec with MockitoSugar {
     )
 
     Get(s"/billing/${project.projectName.value}/members") ~>
-      sealRoute(services.billingRoutes()) ~>
+      sealRoute(services.billingRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -134,7 +134,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       val project = createProject("new_project")
 
       Put(s"/billing/v2/${project.projectName.value}/members/user/${testData.userWriter.userEmail.value}") ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -142,7 +142,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
         }
 
       Put(s"/billing/v2/${project.projectName.value}/members/owner/${testData.userWriter.userEmail.value}") ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -199,7 +199,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       )
 
       Put(s"/billing/v2/${project.projectName.value}/members/user/nobody") ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -217,7 +217,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     ).thenReturn(Future.successful(false))
 
     Put(s"/billing/v2/missing_project/members/user/${testData.userOwner.userEmail.value}") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Forbidden) {
           status
@@ -252,7 +252,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       ).thenReturn(Future.successful(false))
 
       Delete(s"/billing/v2/${project.projectName.value}/members/owner/${testData.userWriter.userEmail.value}") ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Forbidden) {
             status
@@ -274,7 +274,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       ).thenReturn(Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, ""))))
 
       Delete(s"/billing/v2/${project.projectName.value}/members/user/nobody") ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -292,7 +292,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
         )
       ).thenReturn(Future.successful(false))
       Delete(s"/billing/v2/missing_project/members/user/${testData.userOwner.userEmail.value}") ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Forbidden) {
             status
@@ -315,7 +315,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
                                                   None
            )
       ) ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created, responseAs[String]) {
             status
@@ -354,7 +354,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
           None
         )
       ) ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Conflict, responseAs[String]) {
             status
@@ -384,7 +384,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
           Some(true)
         )
       ) ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created, responseAs[String]) {
             status
@@ -412,7 +412,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
         )
 
       Post("/billing/v2", request) ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest, responseAs[String]) {
             status
@@ -432,7 +432,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
                                                None
         )
       ) ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -453,7 +453,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
           None
         )
       ) ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -473,7 +473,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
                                                None
         )
       ) ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -571,7 +571,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       )
 
       Get(s"/billing/v2/${project.projectName.value}/members") ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -612,7 +612,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       )
 
       Get(s"/billing/v2/${project.projectName.value}/members") ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -651,7 +651,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
                                  Set.empty
         )
       ) ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -687,7 +687,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
                                  Set.empty
         )
       ) ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Conflict) {
             status
@@ -727,7 +727,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
                                  Set.empty
         )
       ) ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -757,7 +757,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
                                Set.empty
       )
     ) ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Forbidden) {
           status
@@ -783,7 +783,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     )
 
     Get(s"/billing/v2/${project.projectName.value}") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
           status
@@ -814,7 +814,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     )
 
     Get(s"/billing/v2/${project.projectName.value}") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
           status
@@ -839,7 +839,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       .thenReturn(Future.successful(Set.empty[SamResourceRole]))
 
     Get(s"/billing/v2/$projectName") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound, responseAs[String]) {
           status
@@ -858,7 +858,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     ).thenReturn(Future.successful(Set.empty[SamResourceRole]))
 
     Get(s"/billing/v2/${project.projectName.value}") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound, responseAs[String]) {
           status
@@ -885,7 +885,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       )
 
       Get(s"/billing/v2/id/${project.id}") ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK, responseAs[String]) {
             status
@@ -916,7 +916,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     )
 
     Get(s"/billing/v2/id/${project.id}") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
           status
@@ -942,7 +942,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       .thenReturn(Future.successful(Set.empty[SamResourceRole]))
 
     Get(s"/billing/v2/id/$projectId") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound, responseAs[String]) {
           status
@@ -961,7 +961,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     ).thenReturn(Future.successful(Set.empty[SamResourceRole]))
 
     Get(s"/billing/v2/id/${project.id}") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound, responseAs[String]) {
           status
@@ -982,7 +982,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
         .thenReturn(Future.successful(Set(SamResourceAction(action))))
 
       Get(s"/billing/v2/id/${project.id}/verifyAction/$action") ~>
-        sealRoute(services.billingRoutesV2()) ~> check {
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~> check {
           assertResult(StatusCodes.OK, responseAs[String]) {
             status
           }
@@ -1001,7 +1001,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       .thenReturn(Future.successful(Set(SamResourceAction("notLink"))))
 
     Get(s"/billing/v2/id/${project.id}/verifyAction/$action") ~>
-      sealRoute(services.billingRoutesV2()) ~> check {
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~> check {
         assertResult(StatusCodes.Forbidden, responseAs[String]) {
           status
         }
@@ -1020,14 +1020,14 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       ).thenReturn(Future.successful(Set.empty))
 
       Get(s"/billing/v2/id/${project.id}/verifyAction/$action") ~>
-        sealRoute(services.billingRoutesV2()) ~> check {
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~> check {
           assertResult(StatusCodes.NotFound, responseAs[String]) {
             status
           }
         }
 
       Get(s"/billing/v2/id/${UUID.randomUUID()}/verifyAction/$action") ~>
-        sealRoute(services.billingRoutesV2()) ~> check {
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~> check {
           assertResult(StatusCodes.NotFound, responseAs[String]) {
             status
           }
@@ -1090,7 +1090,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
         .thenReturn(Future.successful())
 
       Delete(s"/billing/v2/${project.projectName.value}") ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent, responseAs[String]) {
             status
@@ -1134,7 +1134,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       .thenReturn(Future.successful())
 
     Delete(s"/billing/v2/${project.projectName.value}") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent, responseAs[String]) {
           status
@@ -1186,7 +1186,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       .thenReturn(Future.successful())
 
     Delete(s"/billing/v2/${project.projectName.value}") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest, responseAs[String]) {
           status
@@ -1206,7 +1206,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     ).thenReturn(Future.successful(false))
 
     Delete(s"/billing/v2/${project.projectName.value}") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Forbidden, responseAs[String]) {
           status
@@ -1298,7 +1298,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       }
     }
     Get(s"/billing/v2") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
           status
@@ -1328,7 +1328,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       Put(s"/billing/v2/${project.projectName.value}/billingAccount",
           UpdateRawlsBillingAccountRequest(services.gcsDAO.accessibleBillingAccountName)
       ) ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK, responseAs[String]) {
             status
@@ -1355,7 +1355,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     Put(s"/billing/v2/${project.projectName.value}/billingAccount",
         UpdateRawlsBillingAccountRequest(services.gcsDAO.inaccessibleBillingAccountName)
     ) ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest, responseAs[String]) {
           status
@@ -1381,7 +1381,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
         )
       )
       Delete(s"/billing/v2/${project.projectName.value}/billingAccount") ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK, responseAs[String]) {
             status
@@ -1421,7 +1421,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
         val project = createProject("project")
 
         Get(s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-03-06&endDate=2022-03-07") ~>
-          sealRoute(services.billingRoutesV2()) ~>
+          sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.OK, responseAs[String]) {
               status
@@ -1479,7 +1479,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       Get(
         s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-03-06&endDate=2022-03-07&aggregationKey=Workspace~Daily&aggregationKey=Category&aggregationKey=Category~Category"
       ) ~>
-        sealRoute(services.billingRoutesV2()) ~>
+        sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK, responseAs[String]) {
             status
@@ -1499,7 +1499,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     val project = createProject("project")
 
     Get(s"/billing/v2/${project.projectName.value}/spendReport?startDate=nothing&endDate=20-020-123556") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest, responseAs[String]) {
           status
@@ -1513,7 +1513,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     Get(
       s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-02-03&endDate=2022-02-04&aggregationKey=Fake&aggregationKey=Workspace~bad"
     ) ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest, responseAs[String]) {
           status
@@ -1527,7 +1527,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     Get(
       s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-02-03&endDate=2022-02-04&aggregationKey=Category-Workspace"
     ) ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest, responseAs[String]) {
           status
@@ -1541,7 +1541,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     Get(
       s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-02-03&endDate=2022-02-04&aggregationKey=aggregationKey=Category~Workspace~Daily"
     ) ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest, responseAs[String]) {
           status
@@ -1553,7 +1553,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     val project = createProject("project")
 
     Get(s"/billing/v2/${project.projectName.value}/spendReport") ~>
-      sealRoute(services.billingRoutesV2()) ~>
+      sealRoute(services.billingRoutesV2(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound, responseAs[String]) {
           status

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceProviderEquivalenceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceProviderEquivalenceSpec.scala
@@ -224,7 +224,7 @@ class EntityApiServiceProviderEquivalenceSpec extends ApiServiceSpec with SprayJ
     Seq(legacyWs, compactWs) foreach { ws =>
       withClue(s"POST batchUpsert for workspace ${ws.toWorkspaceName}") {
         Post(s"/workspaces/${ws.namespace}/${ws.name}/entities/batchUpsert", httpJson(payload)) ~>
-          withHandlers(services.entityRoutes()) ~>
+          withHandlers(services.entityRoutes(userInfo = userInfo)) ~>
           check {
             status shouldBe StatusCodes.NoContent
           }
@@ -254,7 +254,7 @@ class EntityApiServiceProviderEquivalenceSpec extends ApiServiceSpec with SprayJ
     // List entities in both workspaces
     def listEntities(ws: Workspace): Seq[Entity] =
       Get(s"/workspaces/${ws.namespace}/${ws.name}/entities/myType") ~>
-        withHandlers(services.entityRoutes()) ~>
+        withHandlers(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           status shouldBe StatusCodes.OK
           responseAs[Seq[Entity]]
@@ -292,7 +292,7 @@ class EntityApiServiceProviderEquivalenceSpec extends ApiServiceSpec with SprayJ
   private def createEntity(ws: Workspace, entity: Entity, services: TestApiService): Entity =
     withClue(s"createEntity helper for workspace ${ws.toWorkspaceName}") {
       Post(s"/workspaces/${ws.namespace}/${ws.name}/entities", httpJson(entity)) ~>
-        withHandlers(services.entityRoutes()) ~>
+        withHandlers(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           status shouldBe StatusCodes.Created
           val created = responseAs[Entity]
@@ -305,7 +305,7 @@ class EntityApiServiceProviderEquivalenceSpec extends ApiServiceSpec with SprayJ
   private def getEntity(ws: Workspace, entityType: String, entityName: String, services: TestApiService): Entity =
     withClue(s"getEntity helper for workspace ${ws.toWorkspaceName}") {
       Get(s"/workspaces/${ws.namespace}/${ws.name}/entities/$entityType/$entityName") ~>
-        withHandlers(services.entityRoutes()) ~>
+        withHandlers(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           status shouldBe StatusCodes.OK
           val retrieved = responseAs[Entity]
@@ -317,7 +317,7 @@ class EntityApiServiceProviderEquivalenceSpec extends ApiServiceSpec with SprayJ
   private def getEntityTypeMetadata(ws: Workspace, services: TestApiService): Map[String, EntityTypeMetadata] =
     withClue(s"getEntityTypeMetadata helper for workspace ${ws.toWorkspaceName}") {
       Get(s"/workspaces/${ws.namespace}/${ws.name}/entities") ~>
-        withHandlers(services.entityRoutes()) ~>
+        withHandlers(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           status shouldBe StatusCodes.OK
           val retrieved = responseAs[Map[String, EntityTypeMetadata]]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -147,7 +147,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   "EntityApi" should "return 404 on Entity CRUD when workspace does not exist" in withTestDataApiServices { services =>
     Post(s"${testData.workspace.copy(name = "DNE").path}/entities", httpJson(testData.sample2)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -187,14 +187,14 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString("bang")): AttributeUpdateOperation)
       )
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
           status
         }
       }
     Get(testData.workspace.path) ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
       }
@@ -222,14 +222,14 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val entityCopyDefinition = EntityCopyDefinition(sourceWorkspace, testData.wsName, "Sample", Seq("z1"))
 
     Post("/workspaces", httpJson(workspaceSrcRequest)) ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
         }
 
         Post(s"${workspaceSrcRequest.path}/entities", httpJson(z1)) ~>
-          sealRoute(services.entityRoutes()) ~>
+          sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.Created) {
               status
@@ -242,19 +242,19 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             val sourceWorkspace = WorkspaceName(workspaceSrcRequest.namespace, workspaceSrcRequest.name)
             val entityCopyDefinition = EntityCopyDefinition(sourceWorkspace, testData.wsName, "Sample", Seq("z1"))
             Post("/workspaces/entities/copy", httpJson(entityCopyDefinition)) ~>
-              sealRoute(services.entityRoutes()) ~>
+              sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
               check {
                 assertResult(StatusCodes.Created) {
                   status
                 }
               }
             Get(workspaceSrcRequest.path) ~>
-              sealRoute(services.workspaceRoutes()) ~>
+              sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
               check {
                 assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
               }
             Get(testData.wsName.path) ~>
-              sealRoute(services.workspaceRoutes()) ~>
+              sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
               check {
                 assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
               }
@@ -274,7 +274,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("baz")))
     )
     Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -291,7 +291,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
       }
     Get(testData.workspace.path) ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
       }
@@ -300,7 +300,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "allow an entity of the max content size to be consumed by batchUpsert" in withTestDataApiServices {
     services =>
       Post(s"${testData.workspace.path}/entities/batchUpsert", entityOfSize(services.batchUpsertMaxBytes)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           // under the hood this will throw a 500. that's expected because the entity name is larger than the DB allows.
           // all we care about for this test is that we do not hit a Payload Too Large error
@@ -311,7 +311,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "not allow an entity larger than the max content size to be consumed by batchUpsert" in withTestDataApiServices {
     services =>
       Post(s"${testData.workspace.path}/entities/batchUpsert", entityOfSize(services.batchUpsertMaxBytes + 1)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.PayloadTooLarge) {
             status
@@ -326,7 +326,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("bar")))
     )
     Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -343,7 +343,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
       }
     Get(testData.workspace.path) ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
       }
@@ -353,7 +353,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val newSample = Entity("sampleNew", "sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
 
     Post(s"${testData.workspace.path}/entities", httpJson(newSample)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -381,7 +381,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val newSample = Entity("sample.new", "sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
 
     Post(s"${testData.workspace.path}/entities", httpJson(newSample)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -409,7 +409,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val newSample = Entity("", "sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
 
     Post(s"${testData.workspace.path}/entities", httpJson(newSample)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -421,7 +421,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val newSample = Entity("   ", "sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
 
     Post(s"${testData.workspace.path}/entities", httpJson(newSample)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -433,7 +433,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val newSample = Entity("*!$!*", "sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
 
     Post(s"${testData.workspace.path}/entities", httpJson(newSample)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -443,7 +443,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "return 409 conflict on create entity when entity exists" in withTestDataApiServices { services =>
     Post(s"${testData.workspace.path}/entities", httpJson(testData.sample2)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Conflict) {
           status
@@ -458,7 +458,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           Entity("sampleNew", "sample", Map(AttributeName(namespace, "attribute") -> AttributeString("foo")))
 
         Post(s"${testData.workspace.path}/entities", httpJson(newSample)) ~>
-          sealRoute(services.entityRoutes()) ~>
+          sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.Created) {
               status
@@ -473,7 +473,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           Entity("sampleNew", "sample", Map(AttributeName(namespace, "attribute") -> AttributeString("foo")))
 
         Post(s"${testData.workspace.path}/entities", httpJson(newSample)) ~>
-          sealRoute(services.entityRoutes()) ~>
+          sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.Forbidden) {
               status
@@ -503,7 +503,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val e = Entity("foo", "bar", Map.empty)
 
     Post(s"${testData.workspace.path}/entities", httpJson(e)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -513,7 +513,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val (entityCount1, attributeCount1) = countEntitiesAttrs(testData.workspace)
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -540,7 +540,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val e2 = Entity("e2", "Generic", Map(AttributeName.withDefaultNS("link") -> e1.toReference))
 
     Post(s"${testData.workspace.path}/entities", httpJson(e1)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -548,7 +548,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Post(s"${testData.workspace.path}/entities", httpJson(e2)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -556,7 +556,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e1, e2))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -588,7 +588,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       val e3 = Entity("e3", "Generic", Map(AttributeName.withDefaultNS("link") -> e2.toReference))
 
       Post(s"${testData.workspace.path}/entities", httpJson(e1)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -596,7 +596,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
       Post(s"${testData.workspace.path}/entities", httpJson(e2)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -604,7 +604,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
       Post(s"${testData.workspace.path}/entities", httpJson(e3)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -618,7 +618,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       val new_e1 = e1.copy(attributes = Map(AttributeName.withDefaultNS("link") -> e3.toReference))
 
       Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -629,7 +629,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
       Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e1, e2, e3))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -662,7 +662,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val e2 = Entity("e2", "Generic", Map(AttributeName.withDefaultNS("link") -> e1.toReference))
 
     Post(s"${testData.workspace.path}/entities", httpJson(e1)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -670,7 +670,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Post(s"${testData.workspace.path}/entities", httpJson(e2)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -678,7 +678,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e1))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Conflict) {
           status
@@ -713,7 +713,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       val e3 = Entity("e3", "Generic", Map(AttributeName.withDefaultNS("link") -> e2.toReference))
 
       Post(s"${testData.workspace.path}/entities", httpJson(e1)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -721,7 +721,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
       Post(s"${testData.workspace.path}/entities", httpJson(e2)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -729,7 +729,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
       Post(s"${testData.workspace.path}/entities", httpJson(e3)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -743,7 +743,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       val new_e1 = e1.copy(attributes = Map(AttributeName.withDefaultNS("link") -> e3.toReference))
 
       Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -754,7 +754,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
       Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e1))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Conflict) {
             status
@@ -788,7 +788,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val request = EntityDeleteRequest(testData.sample2.copy(name = "DNE1"), testData.sample2.copy(name = "DNE2"))
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(request)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -811,7 +811,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val request = EntityDeleteRequest(testData.sample2, testData.sample2.copy(name = "DNE"))
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(request)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -835,7 +835,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       val request = EntityDeleteRequest()
 
       Post(s"${testData.workspace.path}/entities/delete", httpJson(request)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -870,7 +870,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       val (activeEntityCountBefore, activeAttributeCountBefore) = countActiveEntitiesAttrs(testData.workspace)
 
       Delete(s"${testData.workspace.path}/entityTypes/typeToDelete") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -911,7 +911,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val (activeEntityCountBefore, activeAttributeCountBefore) = countActiveEntitiesAttrs(testData.workspace)
 
     Delete(s"${testData.workspace.path}/entityTypes/typeToDelete") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Conflict) {
           status
@@ -948,7 +948,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val sample = Entity("ABCD", "Sample", attrs1)
 
     Post(s"${testData.workspace.path}/entities", httpJson(sample)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -965,7 +965,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val oldId = dbId(sample)
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(sample))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -975,7 +975,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val sampleNewAttrs = sample.copy(attributes = attrs2)
 
     Post(s"${testData.workspace.path}/entities", httpJson(sampleNewAttrs)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -993,7 +993,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     assert(oldId != newId)
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(sampleNewAttrs))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -1003,7 +1003,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val sampleAttrs3 = sample.copy(attributes = attrs3)
 
     Post(s"${testData.workspace.path}/entities", httpJson(sampleAttrs3)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -1031,7 +1031,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                Seq(RemoveListMember(AttributeName.withDefaultNS("bingo"), AttributeString("a")))
         )
       Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -1044,7 +1044,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "return 204 when batch upserting nothing" in withTestDataApiServices { services =>
     Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq.empty[EntityUpdateDefinition])) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -1059,7 +1059,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo")))
     )
     Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -1079,7 +1079,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       val e = Entity("foo", "bar", Map.empty)
 
       Post(s"${testData.workspace.path}/entities", httpJson(e)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -1089,7 +1089,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       val oldId = dbId(e)
 
       Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -1107,7 +1107,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       val updatedEntity =
         e.copy(attributes = Map(AttributeName.withDefaultNS("newAttribute") -> AttributeString("baz")))
       Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -1135,7 +1135,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("baz")))
       )
       Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -1176,7 +1176,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val update2 = EntityUpdateDefinition(newEntity.name, newEntity.entityType, Seq.empty)
     val blep = httpJson(Seq(update1, update2))
     Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -1210,7 +1210,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeEntityReference("bar", "bing")))
       )
       Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -1236,7 +1236,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Seq(AddUpdateAttribute(AttributeName(invalidAttrNamespace, "newAttribute2"), AttributeString("blee")))
       )
       Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Forbidden, responseAs[ErrorReport]) {
             status
@@ -1259,7 +1259,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         )
       )
       Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -1275,7 +1275,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                Seq(RemoveListMember(AttributeName.withDefaultNS("bingo"), AttributeString("a")))
         )
       Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -1293,7 +1293,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo")))
     )
     Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -1308,7 +1308,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val e = Entity("foo", "bar", Map.empty)
 
     Post(s"${testData.workspace.path}/entities", httpJson(e)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -1316,7 +1316,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -1332,7 +1332,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("baz")))
     )
     Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -1351,7 +1351,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("bar")))
       )
       Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -1372,7 +1372,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "return 204 when batch updating nothing" in withTestDataApiServices { services =>
     Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq.empty[EntityUpdateDefinition])) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -1395,7 +1395,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Seq(AddUpdateAttribute(AttributeName(invalidAttrNamespace, "newAttribute2"), AttributeString("blee")))
       )
       Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1, update2))) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Forbidden, responseAs[ErrorReport]) {
             status
@@ -1453,7 +1453,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   )
   it should "return 200 on list entity types" in withConstantTestDataApiServices { services =>
     Get(s"${constantData.workspace.path}/entities") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -1467,7 +1467,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val newSample = Entity("foo", "Sample", Map(AttributeName.withDefaultNS("blah") -> AttributeNumber(123)))
 
     Post(s"${constantData.workspace.path}/entities", httpJson(newSample)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -1475,7 +1475,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(newSample))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -1483,7 +1483,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Get(s"${constantData.workspace.path}/entities") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -1506,7 +1506,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     )
 
     Get(s"${constantData.workspace.path}/entities/Sample") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -1534,7 +1534,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val newSample = Entity("foo", "Sample", Map(AttributeName.withDefaultNS("blah") -> AttributeNumber(123)))
 
     Post(s"${constantData.workspace.path}/entities", httpJson(newSample)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -1542,7 +1542,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Get(s"${constantData.workspace.path}/entities/Sample") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -1555,7 +1555,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(newSample))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -1563,7 +1563,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Get(s"${constantData.workspace.path}/entities/Sample") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -1578,7 +1578,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "return 404 on get non-existing entity" in withTestDataApiServices { services =>
     Get(testData.sample2.copy(name = "DNE").path(testData.workspace)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -1590,7 +1590,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val e = Entity("foo", "bar", Map(AttributeName.withDefaultNS("blah") -> AttributeNumber(123)))
 
     Post(s"${testData.workspace.path}/entities", httpJson(e)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -1598,7 +1598,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Get(e.path(testData.workspace)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -1612,7 +1612,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val oldName = dbName(id)
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -1623,7 +1623,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     assert(oldName != newName)
 
     Get(e.path(testData.workspace)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -1633,7 +1633,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val newEnt = e.copy(name = newName)
 
     Get(newEnt.path(testData.workspace)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -1686,7 +1686,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Patch(testData.sample2.path(testData.workspace),
           httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("bar")): AttributeUpdateOperation))
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
           status
@@ -1706,7 +1706,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString("bang")): AttributeUpdateOperation)
       )
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -1718,7 +1718,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val e = Entity("foo", "bar", Map.empty)
 
     Post(s"${testData.workspace.path}/entities", httpJson(e)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -1726,7 +1726,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -1742,7 +1742,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Seq(AddUpdateAttribute(AttributeName.withDefaultNS("baz"), AttributeString("bang")): AttributeUpdateOperation)
       )
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -1757,7 +1757,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Patch(testData.sample2.path(testData.workspace),
           httpJson(Seq(AddUpdateAttribute(name, attr): AttributeUpdateOperation))
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Forbidden) {
           status
@@ -1775,7 +1775,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Patch(testData.sample2.path(testData.workspace),
           httpJson(Seq(AddUpdateAttribute(name, attr): AttributeUpdateOperation))
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -1790,7 +1790,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Seq(RemoveListMember(AttributeName.withDefaultNS("foo"), AttributeString("adsf")): AttributeUpdateOperation)
       )
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -1804,7 +1804,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Seq(RemoveListMember(AttributeName.withDefaultNS("grip"), AttributeString("adsf")): AttributeUpdateOperation)
       )
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -1818,7 +1818,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Seq(AddListMember(AttributeName.withDefaultNS("somefoo"), AttributeString("adsf")): AttributeUpdateOperation)
       )
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -1834,7 +1834,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           AddListMember(AttributeName.withDefaultNS("somefoo"), AttributeString("adsf")): AttributeUpdateOperation
         )
       ) ~>
-        sealRoute(services.entityRoutes())(rejectionHandler = RawlsApiService.rejectionHandler) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo))(rejectionHandler = RawlsApiService.rejectionHandler) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -1845,7 +1845,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "return 409 on entity rename when rename already exists" in withTestDataApiServices { services =>
     Post(s"${testData.sample2.path(testData.workspace)}/rename", httpJson(EntityName("sample1"))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Conflict) {
           status
@@ -1948,7 +1948,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Post(s"${testData.sample2.copy(name = "foox").path(testData.workspace)}/rename",
          httpJson(EntityName("s2_changed"))
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -1963,7 +1963,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val e = Entity("foo", "bar", Map.empty)
 
     Post(s"${testData.workspace.path}/entities", httpJson(e)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -1971,7 +1971,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -1982,7 +1982,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Post(s"${e.path(testData.workspace)}/rename", httpJson(EntityName("baz"))) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -2047,7 +2047,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "return a 204 when deleting multiple attributes of default namespace" in withDeleteAttributeNameTestDataApiServices {
     services =>
       Delete(s"${testData.workspace.path}/entities/type1?attributeNames=hello,hi") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -2070,7 +2070,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "return a 204 when deleting attributes with a specified default namespace" in withDeleteAttributeNameTestDataApiServices {
     services =>
       Delete(s"${testData.workspace.path}/entities/type1?attributeNames=default:hello") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -2085,7 +2085,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "return a 204 when deleting attributes with a non-default namespace" in withDeleteAttributeNameTestDataApiServices {
     services =>
       Delete(s"${testData.workspace.path}/entities/type1?attributeNames=othernamespace:yo") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
@@ -2104,7 +2104,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "return 400 when deleting entity attribute that does not exist" in withDeleteAttributeNameTestDataApiServices {
     services =>
       Delete(s"${testData.workspace.path}/entities/type1?attributeNames=fakeattribute") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -2115,7 +2115,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "return 400 when deleting entity attributes with no query params" in withDeleteAttributeNameTestDataApiServices {
     services =>
       Delete(s"${testData.workspace.path}/entities/type1") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -2127,7 +2127,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "return 200 on successfully parsing an expression" in withTestDataApiServices { services =>
     Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate", httpJsonStr("this.samples.type")) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -2142,7 +2142,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
          httpJsonStr("""{"example":"foo", "array": [1, 2, 3]}""")
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -2164,7 +2164,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
            httpJsonStr("""{"example":"foo", "array": this.samples.type}""")
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -2189,7 +2189,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
         httpJsonStr("""{"array": this.samples.type, "details": {"values": this.samples.type}}""")
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -2205,7 +2205,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "return 200 on successfully parsing a raw array" in withTestDataApiServices { services =>
     Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate", httpJsonStr("""[1, 2, 3, 4, 5]""")) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -2220,7 +2220,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
          httpJsonStr("""[1, 2, 3, "foo", "bar", true]""")
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -2238,7 +2238,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
            httpJsonStr("""[1, 2, 3, this.samples.type, ["foo", "bar", this.samples.type]]""")
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -2263,7 +2263,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "return 400 on failing to parse an expression" in withTestDataApiServices { services =>
     Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate", httpJsonStr("nonexistent.anything")) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -2276,7 +2276,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
            httpJsonStr("""[1, 2, "foo", invalid.ref]""")
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -2289,7 +2289,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
            httpJsonStr("""{"example": [1, 2], "foo": invalid.ref}""")
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -2301,7 +2301,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
          httpJsonStr("""{"example": [1, 2], "foo": nonexistent.anything}""")
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -2328,7 +2328,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "return 201 for copying entities into a workspace with no conflicts" in withTestDataApiServices { services =>
     Post("/workspaces", httpJson(workspace2Request)) ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -2339,7 +2339,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
         Post(s"${workspace2Request.path}/entities", httpJson(z1)) ~>
-          sealRoute(services.entityRoutes()) ~>
+          sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.Created) {
               status
@@ -2352,7 +2352,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             val sourceWorkspace = WorkspaceName(workspace2Request.namespace, workspace2Request.name)
             val entityCopyDefinition = EntityCopyDefinition(sourceWorkspace, testData.wsName, "Sample", Seq("z1"))
             Post("/workspaces/entities/copy", httpJson(entityCopyDefinition)) ~>
-              sealRoute(services.entityRoutes()) ~>
+              sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
               check {
                 assertResult(StatusCodes.Created) {
                   status
@@ -2369,7 +2369,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val sourceWorkspace = WorkspaceName(testData.workspace.namespace, testData.workspace.name)
     val entityCopyDefinition = EntityCopyDefinition(sourceWorkspace, testData.wsName, "Sample", Seq("sample1"))
     Post("/workspaces/entities/copy", httpJson(entityCopyDefinition)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Conflict) {
           status
@@ -2393,7 +2393,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       EntityCopyDefinition(sourceWorkspace, newWorkspace, testData.sample3.entityType, Seq(testData.sample3.name))
 
     Post("/workspaces", httpJson(newWorkspaceCreate)) ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -2401,7 +2401,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Post("/workspaces/entities/copy", httpJson(copyAliquot1)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -2415,7 +2415,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
     Post("/workspaces/entities/copy", httpJson(copySample3)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Conflict) {
           status
@@ -2531,7 +2531,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
 
       Post("/workspaces/entities/copy?linkExistingEntities=true", httpJson(entityCopyDefinition2)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -2554,7 +2554,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                Option(authDomain)
       )
       Post("/workspaces", x) ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created, responseAs[String]) {
             status
@@ -2562,7 +2562,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
 //    Post(s"${testData.workspaceWithRealm.path}/entities", httpJson(z1)) ~>
-//      sealRoute(services.entityRoutes()) ~>
+//      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
 //      check {
 //        assertResult(StatusCodes.Created) {
 //          status
@@ -2579,7 +2579,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                                     Option(Set(testData.realm2))
       )
       Post(s"/workspaces", httpJson(wrongRealmCloneRequest)) ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -2592,7 +2592,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                                    Seq("z1")
       )
       Post("/workspaces/entities/copy", httpJson(wrongRealmCopyDef)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.UnprocessableEntity) {
             status
@@ -2606,7 +2606,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                 Option(Set.empty)
       )
       Post("/workspaces", x2) ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created, responseAs[String]) {
             status
@@ -2619,7 +2619,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                                 Seq("z1")
       )
       Post("/workspaces/entities/copy", httpJson(noRealmCopyDef)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.UnprocessableEntity) {
             status
@@ -2640,7 +2640,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                Option(authDomain)
       )
       Post("/workspaces", x) ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created, responseAs[String]) {
             status
@@ -2653,7 +2653,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                               Option(authDomain)
       )
       Post(s"/workspaces/${srcWorkspaceName.namespace}/source_ws/clone", httpJson(destCloneRequest)) ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -2664,7 +2664,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
       Post(s"/workspaces/${srcWorkspaceName.namespace}/${srcWorkspaceName.name}/entities", httpJson(z1)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -2675,7 +2675,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
       val copyDef = EntityCopyDefinition(srcWorkspaceName, destWorkspaceName, "Sample", Seq("z1"))
       Post("/workspaces/entities/copy", httpJson(copyDef)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -2695,7 +2695,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                Option(singleAuthDomain)
       )
       Post("/workspaces", x) ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created, responseAs[String]) {
             status
@@ -2708,7 +2708,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                Option(doubleAuthDomain)
       )
       Post("/workspaces", y) ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created, responseAs[String]) {
             status
@@ -2721,7 +2721,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                                    Seq("z1")
       )
       Post("/workspaces/entities/copy", httpJson(wrongRealmCopyDef)) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.UnprocessableEntity) {
             status
@@ -2737,7 +2737,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                            Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"))
     )
     Post(s"${testData.workspace.path}/entities", httpJson(dotSample)) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -2823,7 +2823,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   "entityQuery API" should "return 400 bad request on entity query when page is not a number" in withPaginationTestDataApiServices {
     services =>
       Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?page=asdf") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -2834,7 +2834,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "return 400 bad request on entity query when page size is not a number" in withPaginationTestDataApiServices {
     services =>
       Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=asdfasdf") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -2844,7 +2844,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "return 400 bad request on entity query when page is <= 0" in withPaginationTestDataApiServices { services =>
     Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?page=-1") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -2855,7 +2855,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "return 400 bad request on entity query when page size is <= 0" in withPaginationTestDataApiServices {
     services =>
       Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=-1") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -2866,7 +2866,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "return 400 bad request on entity query when page > page count" in withPaginationTestDataApiServices {
     services =>
       Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?page=10000000") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -2879,7 +2879,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortDirection=asdfasdfasdf"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -2889,7 +2889,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "return 200 OK on entity query for unknown sort field" in withPaginationTestDataApiServices { services =>
     Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=asdfasdfasdf") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -2913,7 +2913,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "return 404 not found on entity query for workspace that does not exist" in withPaginationTestDataApiServices {
     services =>
       Get(s"${paginationTestData.workspace.copy(name = "DNE").path}/entityQuery/${paginationTestData.entityType}") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -2924,7 +2924,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "return 200 OK on entity query when no query params are given" in withPaginationTestDataApiServices {
     services =>
       Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -2948,7 +2948,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "return 200 OK on entity query when there are no entities of given type" in withPaginationTestDataApiServices {
     services =>
       Get(s"${paginationTestData.workspace.path}/entityQuery/blarf") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3013,7 +3013,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   it should "return 200 OK on entity query when all results are filtered" in withPaginationTestDataApiServices {
     services =>
       Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?filterTerms=qqq") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3047,7 +3047,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       runAndWait(entityQuery.save(testData.workspaceNoEntities, Seq(fooEntity, barEntity, fooBarEntity)))
 
       Get(s"${testData.workspaceNoEntities.path}/entityQuery/${fooEntity.entityType}?filterTerms=foo%20bar") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3077,7 +3077,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${testData.workspaceNoEntities.path}/entityQuery/${fooEntity.entityType}?filterTerms=foo%20bar&filterOperator=AND"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3107,7 +3107,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${testData.workspaceNoEntities.path}/entityQuery/${fooEntity.entityType}?filterTerms=foo%20bar&filterOperator=OR"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3122,7 +3122,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val page = 5
     val offset = (page - 1) * defaultQuery.pageSize
     Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?page=$page") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -3147,7 +3147,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val pageSize = 23
     val offset = (defaultQuery.page - 1) * pageSize
     Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -3208,7 +3208,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Get(
       s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=random&sordDirection=asc"
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -3259,7 +3259,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=mixed&pageSize=${paginationTestData.numEntities}"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3282,7 +3282,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=mixedNumeric&pageSize=${paginationTestData.numEntities}"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3304,7 +3304,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Get(
       s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=sparse&pageSize=${paginationTestData.numEntities}"
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -3358,7 +3358,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Get(
       s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=random&sortDirection=desc"
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -3396,7 +3396,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Get(
       s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&filterTerms=$vocab1Term%20$vocab2Term"
     ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -3424,7 +3424,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?filterTerms=foo&columnFilter=bar%3Dbaz"
       ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -3440,7 +3440,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&columnFilter=${paginationTestData.entityType}_id%3D$entityNameFilter"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3474,7 +3474,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&columnFilter=${paginationTestData.entityType}_id%3D$entityNameFilter"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3515,7 +3515,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&columnFilter=$columnFilterAttr%3D$columnFilterTerm"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3570,7 +3570,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&columnFilter=$columnFilterAttr%3D$columnFilterTerm"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3627,7 +3627,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&columnFilter=$columnFilterAttr%3D$columnFilterTerm"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3683,7 +3683,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&sortField=random&columnFilter=$columnFilterAttr%3D$columnFilterTerm"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3742,7 +3742,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?page=$page&columnFilter=$columnFilterAttr%3D$columnFilterTerm"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -3789,7 +3789,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?columnFilter=incorrectFilter"
       ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -3800,7 +3800,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?columnFilter=not:delimited:correctly%3D99"
       ) ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -3886,7 +3886,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     services =>
       // query for all entities
       Get(s"$fieldSelectionApiPath?pageSize=${fieldSelectionTestData.entities.size}") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           status shouldBe StatusCodes.OK
           val resp = responseAs[EntityQueryResponse]
@@ -3900,7 +3900,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     services =>
       // query for first page of results
       Get(s"$fieldSelectionApiPath?pageSize=10") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           status shouldBe StatusCodes.OK
           val resp = responseAs[EntityQueryResponse]
@@ -3913,7 +3913,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     services =>
       // query for second page of results
       Get(s"$fieldSelectionApiPath?pageSize=10&page=2") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           status shouldBe StatusCodes.OK
           val resp = responseAs[EntityQueryResponse]
@@ -3927,7 +3927,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       // query for the second page of results, with a page size that extends us into the third
       // group of entities from fieldSelectionTestData
       Get(s"$fieldSelectionApiPath?pageSize=15&page=2") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           status shouldBe StatusCodes.OK
           val resp = responseAs[EntityQueryResponse]
@@ -3940,7 +3940,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     it should s"return [${fieldsUnderTest.mkString(", ")}] if requested in fields" ignore withFieldSelectionTestDataApiServices {
       services =>
         Get(s"$fieldSelectionApiPath?pageSize=25&page=1&fields=${fieldsUnderTest.mkString(",")}") ~>
-          sealRoute(services.entityRoutes()) ~>
+          sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
           check {
             status shouldBe StatusCodes.OK
             val resp = responseAs[EntityQueryResponse]
@@ -3993,7 +3993,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Get(
           s"$fieldSelectionApiPath?pageSize=${testCase.pageSize}&page=${testCase.page}&fields=${fieldsUnderTest.mkString(",")}"
         ) ~>
-          sealRoute(services.entityRoutes()) ~>
+          sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
           check {
             status shouldBe StatusCodes.OK
             val resp = responseAs[EntityQueryResponse]
@@ -4006,7 +4006,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     services =>
       // get the first page of results, but request a field from the second page
       Get(s"$fieldSelectionApiPath?pageSize=10&page=1&fields=violet") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           status shouldBe StatusCodes.OK
           val resp = responseAs[EntityQueryResponse]
@@ -4018,7 +4018,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     services =>
       // request a totally nonexistent field
       Get(s"$fieldSelectionApiPath?pageSize=10&page=1&fields=nonexistent") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           status shouldBe StatusCodes.OK
           val resp = responseAs[EntityQueryResponse]
@@ -4033,7 +4033,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       Get(
         s"$fieldSelectionApiPath?pageSize=30&page=1&filterTerms=gray&sortField=red&sortDirection=desc&fields=yellow,green,apricot"
       ) ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           status shouldBe StatusCodes.OK
           val resp = responseAs[EntityQueryResponse]
@@ -4046,7 +4046,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     services =>
       // query for all entities
       Get(s"$fieldSelectionApiPath?pageSize=${fieldSelectionTestData.entities.size}&fields=") ~>
-        sealRoute(services.entityRoutes()) ~>
+        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
         check {
           status shouldBe StatusCodes.OK
           val resp = responseAs[EntityQueryResponse]
@@ -4058,7 +4058,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   "Entity type metadata API" should "pass true by default to useCache argument" in withMockedEntityService { services =>
     Get(s"${constantData.workspace.path}/entities") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
           status
@@ -4071,7 +4071,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "respect useCache parameter if set to false" in withMockedEntityService { services =>
     Get(s"${constantData.workspace.path}/entities?useCache=false") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
           status
@@ -4084,7 +4084,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   it should "default to true if useCache set to some value other than 'false'" in withMockedEntityService { services =>
     Get(s"${constantData.workspace.path}/entities?useCache=mysterious") ~>
-      sealRoute(services.entityRoutes()) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
           status

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/GoogleProjectRegistrationApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/GoogleProjectRegistrationApiServiceSpec.scala
@@ -48,7 +48,7 @@ class GoogleProjectRegistrationApiServiceSpec
 
     Get(
       "/googleProjects?billingProjectId=test-billing-project&pageSize=10&offset=0"
-    ) ~> googleProjectRegistrationRoutes() ~> check {
+    ) ~> googleProjectRegistrationRoutes(userInfo = userInfo) ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Seq[GoogleProjectRegistration]] shouldEqual Seq(googleProjectRegistration)
     }
@@ -65,7 +65,7 @@ class GoogleProjectRegistrationApiServiceSpec
     when(mockGoogleProjectRegService.getGoogleProjectById(GoogleProjectId("test-project-id")))
       .thenReturn(Future.successful(Some(googleProjectRegistration)))
 
-    Get("/googleProjects/test-project-id") ~> googleProjectRegistrationRoutes() ~> check {
+    Get("/googleProjects/test-project-id") ~> googleProjectRegistrationRoutes(userInfo = userInfo) ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[GoogleProjectRegistration] shouldEqual googleProjectRegistration
     }
@@ -75,7 +75,7 @@ class GoogleProjectRegistrationApiServiceSpec
     when(mockGoogleProjectRegService.getGoogleProjectById(GoogleProjectId("non-existent-project-id")))
       .thenReturn(Future.successful(None))
 
-    Get("/googleProjects/non-existent-project-id") ~> googleProjectRegistrationRoutes() ~> check {
+    Get("/googleProjects/non-existent-project-id") ~> googleProjectRegistrationRoutes(userInfo = userInfo) ~> check {
       status shouldEqual StatusCodes.NotFound
       responseAs[String] shouldEqual "Google project does not exist or you don't have access."
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiServiceSpec.scala
@@ -123,7 +123,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
         AgoraMethod("dsde", "three_step", 1)
       )
       Post(s"${testData.workspace.path}/methodconfigs", httpJson(newMethodConfig)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -171,7 +171,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
     )
 
     Post(s"${testData.workspace.path}/methodconfigs", httpJson(newMethodConfig)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -227,7 +227,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
       )
 
       Post(s"${testData.workspace.path}/methodconfigs", httpJson(newMethodConfig)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -264,7 +264,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
                                                 AgoraMethod("dsde", "method_doesnt_exist", 1)
       )
       Post(s"${testData.workspace.path}/methodconfigs", httpJson(newMethodConfig)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check { testResult: RouteTestResult =>
           assertResult(StatusCodes.NotFound) {
             status
@@ -294,7 +294,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
       val expectedSuccessOutputs = Seq("lib_ent_out", "lib_ws_out")
       Post(s"${testData.workspace.path}/methodconfigs", httpJson(newMethodConfig)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -328,7 +328,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
     val expectedSuccessOutputs = Set("goodAndBad.goodAndBadTask.good_out", "goodAndBad.goodAndBadTask.bad_out")
 
     Post(s"${testData.workspace.path}/methodconfigs", httpJson(newMethodConfig)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -386,7 +386,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
       def create(mc: MethodConfiguration) =
         Post(s"${testData.workspace.path}/methodconfigs", httpJson(mc)) ~>
-          sealRoute(services.methodConfigRoutes()) ~>
+          sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.Created) {
               status
@@ -407,7 +407,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
       def get(mc: MethodConfiguration) =
         Get(s"${testData.workspace.path}/methodconfigs/${mc.namespace}/${mc.name}") ~>
-          sealRoute(services.methodConfigRoutes()) ~>
+          sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.OK) {
               status
@@ -425,7 +425,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
         )
       )
     ) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -546,14 +546,14 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
           )
         )
       ) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
           }
         }
       Get(testData.workspace.path) ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
         }
@@ -570,7 +570,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
           )
         )
       ) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -595,7 +595,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
   /*
   ignore should "*DISABLED* return 204 method configuration delete" in withTestDataApiServices { services =>
     Delete(testData.agoraMethodConfig.path(testData.workspace)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -609,7 +609,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "return 204 method configuration delete" in withTestDataApiServices { services =>
     Delete(testData.methodConfig3.path(testData.workspace)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -645,7 +645,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
         assertSubsetOf(expected, capturedMetrics)
       }
       Get(testData.workspace.path) ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
         }
@@ -654,7 +654,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
   it should "return 404 method configuration delete, method configuration does not exist" in withTestDataApiServices {
     services =>
       Delete(testData.agoraMethodConfig.copy(name = "DNE").path(testData.workspace)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -695,7 +695,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
       val fooFactor = pair._3
 
       httpMethod(original.path(testData.workspace), httpJson(edited)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             println(original)
@@ -764,7 +764,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
     )
 
     httpMethod(testData.goodAndBadMethodConfig.path(testData.workspace), httpJson(testData.goodAndBadMethodConfig)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -809,7 +809,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
     val expectedFailureOutputs = Map.empty[String, String]
 
     httpMethod(testData.agoraMethodConfig.path(testData.workspace), httpJson(modifiedMethodConfig)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -836,7 +836,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
                                           testData.agoraMethodConfig.inputs + ("param2" -> AttributeString("foo2"))
         )
       Put(testData.agoraMethodConfig.path(testData.workspace), httpJson(modifiedMethodConfig)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -849,7 +849,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
       val modifiedMethodConfig =
         testData.methodConfig2.copy(inputs = testData.agoraMethodConfig.inputs + ("param2" -> AttributeString("foo2")))
       Post(testData.agoraMethodConfig.path(testData.workspace), httpJson(modifiedMethodConfig)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Conflict) {
             status
@@ -885,7 +885,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
     runAndWait(methodConfigurationQuery.create(testData.workspace, mc))
 
     Get(s"${mc.path(testData.workspace)}/validate") ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -933,7 +933,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
       runAndWait(methodConfigurationQuery.create(testData.workspace, mc))
 
       Get(s"${mc.path(testData.workspace)}/validate") ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -949,7 +949,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "return 404 on update method configuration" in withTestDataApiServices { services =>
     Post(s"${testData.workspace.path}/methodconfigs/update}", httpJson(testData.agoraMethodConfig)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -959,7 +959,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "return 201 on copy method Agora configuration" in withTestDataApiServices { services =>
     Post("/methodconfigs/copy", httpJson(testData.methodConfigNamePairCreated)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -977,7 +977,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "return 201 on copy Dockstore method configuration" in withTestDataApiServices { services =>
     Post("/methodconfigs/copy", httpJson(testData.methodConfigNamePairCreatedDockstore)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -996,14 +996,14 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
   it should "update the destination workspace last modified date on copy method configuration" in withTestDataApiServices {
     services =>
       Post("/methodconfigs/copy", httpJson(testData.methodConfigNamePairCreated)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
           }
         }
       Get(testData.workspace.path) ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
         }
@@ -1011,7 +1011,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "return 409 on copy method configuration to existing name" in withTestDataApiServices { services =>
     Post("/methodconfigs/copy", httpJson(testData.methodConfigNamePairConflict)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Conflict) {
           status
@@ -1021,7 +1021,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "return 404 on copy method configuration from bogus source" in withTestDataApiServices { services =>
     Post("/methodconfigs/copy", httpJson(testData.methodConfigNamePairNotFound)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -1031,7 +1031,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "allow copy method configuration with library attributes in outputs" in withTestDataApiServices { services =>
     Post("/methodconfigs/copy", httpJson(testData.methodConfigNamePairFromLibrary)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created) {
           status
@@ -1044,7 +1044,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
   it should "return 200 on copy Agora method configuration to Agora" in withTestDataApiServices { services =>
     withStatsD {
       Post(copyToMethodRepo, httpJson(MethodRepoConfigurationExport("mcns", "mcn", testData.agoraMethodConfigName))) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -1074,7 +1074,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
   it should "return 404 on copy method configuration to method repo if config dne" in withTestDataApiServices {
     services =>
       Post(copyToMethodRepo, httpJson(MethodRepoConfigurationExport("mcns", "mcn", testData.methodConfigName3))) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -1087,7 +1087,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
   it should "foo return 201 on copy method configuration from method repo" in withTestDataApiServices { services =>
     withStatsD {
       Post(copyFromMethodRepo, httpJson(testData.methodRepoGood)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -1117,7 +1117,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
       val existingMethodConfigCopy =
         MethodRepoConfigurationImport("workspace_test", "rawls_test_good", 1, testData.agoraMethodConfigName)
       Post(copyFromMethodRepo, httpJson(existingMethodConfigCopy)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Conflict) {
             status
@@ -1128,7 +1128,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
   it should "return 404 on copy method configuration from bogus source in method repo" in withTestDataApiServices {
     services =>
       Post(copyFromMethodRepo, httpJson(testData.methodRepoMissing)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -1139,7 +1139,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
   it should "return 422 on copy method configuration when method repo payload is missing" in withTestDataApiServices {
     services =>
       Post(copyFromMethodRepo, httpJson(testData.methodRepoEmptyPayload)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.UnprocessableEntity) {
             status
@@ -1168,7 +1168,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
   it should "allow copy method configuration from repo with library attributes in outputs" in withTestDataApiServices {
     services =>
       Post(copyFromMethodRepo, httpJson(testData.methodRepoLibrary)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -1180,7 +1180,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
     services =>
       val method = AgoraMethod("dsde", "three_step", 1)
       Post("/methodconfigs/template", httpJson(method)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           val methodConfiguration = MethodConfiguration(
             "namespace",
@@ -1203,7 +1203,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
     services =>
       val method: MethodRepoMethod = DockstoreMethod("dockstore-method-path", "dockstore-method-version")
       Post("/methodconfigs/template", httpJson(method)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           val methodConfiguration = MethodConfiguration(
             "namespace",
@@ -1227,7 +1227,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
     withStatsD {
       val method = AgoraMethod("dsde", "three_step", 1)
       Post("/methodconfigs/inputsOutputs", httpJson(method)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK)(status)
           val expectedIn = Seq(MethodInput("three_step.cgrep.pattern", "String", false))
@@ -1254,7 +1254,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
     services =>
       val method: MethodRepoMethod = DockstoreMethod("dockstore-method-path", "dockstore-method-version")
       Post("/methodconfigs/inputsOutputs", httpJson(method)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK)(status)
           val expectedIn = Seq(MethodInput("three_step_dockstore.cgrep.pattern", "String", false))
@@ -1272,7 +1272,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
   it should "return 400 for a method inputs and outputs request missing method name" in withTestDataApiServices {
     services =>
       Post("/methodconfigs/inputsOutputs", httpJson(AgoraMethod("dsde", "", 2))) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest)(status)
           val responseString = Unmarshal(response.entity).to[String].futureValue
@@ -1283,7 +1283,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
   it should "return 404 when generating a method config template from a missing method" in withTestDataApiServices {
     services =>
       Post("/methodconfigs/template", httpJson(AgoraMethod("dsde", "three_step", 2))) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound)(status)
         }
@@ -1291,7 +1291,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "return 404 getting method inputs and outputs from a missing method" in withTestDataApiServices { services =>
     Post("/methodconfigs/inputsOutputs", httpJson(AgoraMethod("dsde", "three_step", 2))) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound)(status)
       }
@@ -1339,7 +1339,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "return 200 on get method configuration" in withTestDataApiServices { services =>
     Get(testData.agoraMethodConfig.path(testData.workspace)) ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -1363,7 +1363,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "list method Configurations for Agora by default" in withTestDataApiServices { services =>
     Get(s"${testData.workspace.path}/methodconfigs") ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -1377,7 +1377,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "list method Configurations for Agora with allRepos=false" in withTestDataApiServices { services =>
     Get(s"${testData.workspace.path}/methodconfigs?allRepos=false") ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -1391,7 +1391,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "return Bad Request if you use a bogus value for allRepos" in withTestDataApiServices { services =>
     Get(s"${testData.workspace.path}/methodconfigs?allRepos=banana") ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -1401,7 +1401,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec with TestDriverComponent
 
   it should "list method Configurations for all repos with allRepos=true" in withTestDataApiServices { services =>
     Get(s"${testData.workspace.path}/methodconfigs?allRepos=true") ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
@@ -61,7 +61,7 @@ class PetSASpec extends ApiServiceSpec {
     ) ~> addHeader("OIDC_CLAIM_expires_in", petSA.accessTokenExpiresIn.toString) ~> addHeader("OIDC_CLAIM_email",
                                                                                               petSA.userEmail.value
     ) ~> addHeader("OIDC_CLAIM_user_id", petSA.userSubjectId.value) ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Created, responseAs[String]) {
           status
@@ -88,7 +88,7 @@ class PetSASpec extends ApiServiceSpec {
       "OIDC_CLAIM_user_id",
       testWorkspaces.userSAProjectOwnerUserInfo.userSubjectId.value
     ) ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -137,7 +137,7 @@ class PetSASpec extends ApiServiceSpec {
     ) ~> addHeader("OIDC_CLAIM_email", petSA.userEmail.value) ~> addHeader("OIDC_CLAIM_user_id",
                                                                            petSA.userSubjectId.value
     ) ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -123,7 +123,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   "SnapshotV2ApiService" should "return 201 when creating a reference to a snapshot" in withTestDataApiServices {
     services =>
       Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -143,7 +143,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
           )
         )
       ) ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -154,7 +154,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "return 404 when creating a reference to a snapshot in a workspace that doesn't exist" in withTestDataApiServices {
     services =>
       Post("/workspaces/foo/bar/snapshots/v2", defaultNamedSnapshotJson) ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -164,7 +164,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
 
   it should "return 200 when getting a reference to a snapshot" in withTestDataApiServices { services =>
     Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         val response = responseAs[DataRepoSnapshotResource]
         assertResult(StatusCodes.Created) {
@@ -172,7 +172,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
         }
 
         Get(s"${v2BaseSnapshotsPath}/${response.getMetadata.getResourceId}") ~>
-          sealRoute(services.snapshotRoutes()) ~>
+          sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.OK) {
               status
@@ -184,7 +184,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "return 400 when getting a reference to a snapshot that is not a valid UUID" in withTestDataApiServices {
     services =>
       Get(s"${v2BaseSnapshotsPath}/not-a-valid-uuid") ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -195,7 +195,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "return 404 when getting a reference to a snapshot that doesn't exist" in withTestDataApiServices {
     services =>
       Get(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}") ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -206,7 +206,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "return 404 when getting a reference to a snapshot in a workspace that doesn't exist" in withTestDataApiServices {
     services =>
       Get(s"/workspaces/foo/bar/snapshots/v2/${UUID.randomUUID().toString}") ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -216,7 +216,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
 
   it should "return 200 when getting a reference to a snapshot-by-name" in withTestDataApiServices { services =>
     Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         val response = responseAs[DataRepoSnapshotResource]
         assertResult(StatusCodes.Created) {
@@ -224,7 +224,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
         }
 
         Get(s"${v2BaseSnapshotsPath}/name/${response.getMetadata.getName}") ~>
-          sealRoute(services.snapshotRoutes()) ~>
+          sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.OK) {
               status
@@ -236,7 +236,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "return 404 when getting a reference to a snapshot-by-name that doesn't exist" in withTestDataApiServices {
     services =>
       Get(s"${v2BaseSnapshotsPath}/name/reference-intentionally-does-not-exist") ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -247,7 +247,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "return 404 when getting a reference to a snapshot-by-name in a workspace that doesn't exist" in withTestDataApiServices {
     services =>
       Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           val response = responseAs[DataRepoSnapshotResource]
           assertResult(StatusCodes.Created) {
@@ -255,7 +255,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
           }
 
           Get(s"/workspaces/foo/bar/snapshots/v2/name/${response.getMetadata.getName}") ~>
-            sealRoute(services.snapshotRoutes()) ~>
+            sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
             check {
               assertResult(StatusCodes.NotFound) {
                 status
@@ -268,7 +268,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     testData.userReader.userEmail.value
   ) { services =>
     Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Forbidden) {
           status
@@ -280,7 +280,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     "no-access"
   ) { services =>
     Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -292,7 +292,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     "no-access"
   ) { services =>
     Get(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}") ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -303,7 +303,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "return 200 when a user lists all snapshots in a workspace" in withTestDataApiServices { services =>
     // First, create two data references
     Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         val response = responseAs[DataRepoSnapshotResource]
         assertResult(StatusCodes.Created) {
@@ -319,7 +319,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
             )
           )
         ) ~>
-          sealRoute(services.snapshotRoutes()) ~>
+          sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
           check {
             val response = responseAs[DataRepoSnapshotResource]
             assertResult(StatusCodes.Created) {
@@ -327,7 +327,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
             }
             // Then, list them both
             Get(s"${v2BaseSnapshotsPath}?offset=0&limit=10") ~>
-              sealRoute(services.snapshotRoutes()) ~>
+              sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
               check {
                 val response = responseAs[SnapshotListResponse]
                 assertResult(StatusCodes.OK) {
@@ -350,7 +350,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     "no-access"
   ) { services =>
     Get(s"${v2BaseSnapshotsPath}?offset=0&limit=10") ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -362,7 +362,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     testData.userReader.userEmail.value
   ) { services =>
     Get("/workspaces/test/value/snapshots/v2?offset=0&limit=10") ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -375,7 +375,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       // We hijack the "workspaceTerminatedSubmissions" workspace in the shared testData to represent
       // a workspace that exists in Rawls but returns 404 from Workspace Manager.
       Get(s"${testData.workspaceTerminatedSubmissions.path}/snapshots/v2?offset=0&limit=10") ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           val response = responseAs[SnapshotListResponse]
           assertResult(StatusCodes.OK) {
@@ -389,7 +389,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     // We hijack the "workspaceSubmittedSubmission" workspace in the shared testData to represent
     // a workspace that throws a 418 error.
     Get(s"${testData.workspaceSubmittedSubmission.path}/snapshots/v2?offset=0&limit=10") ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.ImATeapot) {
           response.status
@@ -399,14 +399,14 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
 
   it should "return 204 when a user updates a snapshot" in withTestDataApiServices { services =>
     Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         val response = responseAs[DataRepoSnapshotResource]
         assertResult(StatusCodes.Created, "Unexpected snapshot creation status") {
           status
         }
         Patch(s"${v2BaseSnapshotsPath}/${response.getMetadata.getResourceId}", defaultSnapshotUpdateBodyJson) ~>
-          sealRoute(services.snapshotRoutes()) ~>
+          sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.NoContent, "Unexpected snapshot update response") {
               status
@@ -415,7 +415,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
 
         // verify that it was updated
         Get(s"${v2BaseSnapshotsPath}/${response.getMetadata.getResourceId}") ~>
-          sealRoute(services.snapshotRoutes()) ~>
+          sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
           check {
             val response = responseAs[DataRepoSnapshotResource]
             assertResult(StatusCodes.OK, "Unexpected return code getting updated snapshot") {
@@ -430,7 +430,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "return 400 when a user tries to update a snapshot that is not a valid UUID" in withTestDataApiServices {
     services =>
       Patch(s"${v2BaseSnapshotsPath}/not-a-valid-uuid", defaultSnapshotUpdateBodyJson) ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -442,7 +442,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     "reader-access"
   ) { services =>
     Patch(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}", defaultSnapshotUpdateBodyJson) ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Forbidden) {
           status
@@ -467,7 +467,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       .getMetadata
       .getResourceId
     Patch(s"${v2BaseSnapshotsPath}/${id.toString}", defaultSnapshotUpdateBodyJson) ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -478,7 +478,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "return 404 when a user tries to update a snapshot that doesn't exist" in withTestDataApiServices {
     services =>
       Patch(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}", defaultSnapshotUpdateBodyJson) ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -488,14 +488,14 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
 
   it should "return 204 when a user deletes a snapshot" in withTestDataApiServices { services =>
     Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         val response = responseAs[DataRepoSnapshotResource]
         assertResult(StatusCodes.Created) {
           status
         }
         Delete(s"${v2BaseSnapshotsPath}/${response.getMetadata.getResourceId}") ~>
-          sealRoute(services.snapshotRoutes()) ~>
+          sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.NoContent) {
               status
@@ -504,7 +504,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
 
         // verify that it was deleted
         Delete(s"${v2BaseSnapshotsPath}/${response.getMetadata.getResourceId}") ~>
-          sealRoute(services.snapshotRoutes()) ~>
+          sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.NotFound) {
               status
@@ -516,7 +516,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "return 400 when a user tries to delete a snapshot that is not a valid UUID" in withTestDataApiServices {
     services =>
       Delete(s"${v2BaseSnapshotsPath}/not-a-valid-uuid") ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -528,7 +528,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     "reader-access"
   ) { services =>
     Delete(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}") ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.Forbidden) {
           status
@@ -553,7 +553,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       .getMetadata
       .getResourceId
     Delete(s"${v2BaseSnapshotsPath}/${id.toString}") ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -564,7 +564,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "return 404 when a user tries to delete a snapshot that doesn't exist" in withTestDataApiServices {
     services =>
       Delete(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}") ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.NotFound) {
             status
@@ -575,7 +575,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should
     "return 201 when creating a reference to a snapshot using workspaceId" in withTestDataApiServices { services =>
       Post(v2WorkspaceIdBaseSnapshotsPath, defaultNamedSnapshotJson) ~>
-        sealRoute(services.snapshotRoutes()) ~>
+        sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -585,7 +585,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
 
   it should "return 204 when creating multiple snapshots using workspaceName" in withTestDataApiServices { services =>
     Post(v3BaseSnapshotsPath, List(UUID.randomUUID, UUID.randomUUID)) ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
@@ -595,7 +595,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
 
   it should "return 204 when creating multiple snapshots using workspaceId" in withTestDataApiServices { services =>
     Post(v3WorkspaceIdBaseSnapshotsPath, List(UUID.randomUUID, UUID.randomUUID)) ~>
-      sealRoute(services.snapshotRoutes()) ~>
+      sealRoute(services.snapshotRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiMetadataParamsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiMetadataParamsSpec.scala
@@ -60,7 +60,7 @@ class SubmissionApiMetadataParamsSpec extends ApiServiceSpec {
 
   "SubmissionApi" should "use defaults for metadata params when no querystring" in withTestDataApiServices { services =>
     Get(s"$basePath") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         val actualParams = responseAs[MetadataParams]
         // use MetadataParams' defaults
@@ -74,7 +74,7 @@ class SubmissionApiMetadataParamsSpec extends ApiServiceSpec {
 
   it should "pass expandSubWorkflows=true param" in withTestDataApiServices { services =>
     Get(s"$basePath?expandSubWorkflows=true") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         val actualParams = responseAs[MetadataParams]
         val expectedParams = MetadataParams(expandSubWorkflows = true)
@@ -87,7 +87,7 @@ class SubmissionApiMetadataParamsSpec extends ApiServiceSpec {
 
   it should "pass expandSubWorkflows=false param" in withTestDataApiServices { services =>
     Get(s"$basePath?expandSubWorkflows=false") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         val actualParams = responseAs[MetadataParams]
         // expandSubWorkflows=false duplicates the default but is included here in case the defaults change later
@@ -101,7 +101,7 @@ class SubmissionApiMetadataParamsSpec extends ApiServiceSpec {
 
   it should "pass single includeKey param" in withTestDataApiServices { services =>
     Get(s"$basePath?includeKey=foo") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         val actualParams = responseAs[MetadataParams]
         val expectedParams = MetadataParams(includeKeys = Set("foo"))
@@ -114,7 +114,7 @@ class SubmissionApiMetadataParamsSpec extends ApiServiceSpec {
 
   it should "pass multiple includeKey params" in withTestDataApiServices { services =>
     Get(s"$basePath?includeKey=foo&includeKey=bar") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         val actualParams = responseAs[MetadataParams]
         val expectedParams = MetadataParams(includeKeys = Set("foo", "bar"))
@@ -127,7 +127,7 @@ class SubmissionApiMetadataParamsSpec extends ApiServiceSpec {
 
   it should "pass single excludeKey param" in withTestDataApiServices { services =>
     Get(s"$basePath?excludeKey=baz") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         val actualParams = responseAs[MetadataParams]
         val expectedParams = MetadataParams(excludeKeys = Set("baz"))
@@ -140,7 +140,7 @@ class SubmissionApiMetadataParamsSpec extends ApiServiceSpec {
 
   it should "pass multiple excludeKey params" in withTestDataApiServices { services =>
     Get(s"$basePath?excludeKey=baz&excludeKey=qux") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         val actualParams = responseAs[MetadataParams]
         val expectedParams = MetadataParams(excludeKeys = Set("baz", "qux"))
@@ -153,7 +153,7 @@ class SubmissionApiMetadataParamsSpec extends ApiServiceSpec {
 
   it should "pass all params when they are all specified" in withTestDataApiServices { services =>
     Get(s"$basePath?expandSubWorkflows=true&includeKey=foo&includeKey=bar&excludeKey=baz&excludeKey=qux") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         val actualParams = responseAs[MetadataParams]
         val expectedParams =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -143,7 +143,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
           )
         )
       ) ~>
-        sealRoute(services.submissionRoutes()) ~>
+        sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
         check(assertResult(StatusCodes.NotFound)(status))
   }
 
@@ -160,7 +160,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
         AgoraMethod("dsde", "three_step", 1)
       )
       Post(s"${testData.wsName.path}/methodconfigs", httpJson(methodConf)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check(assertResult(StatusCodes.Created)(status))
       Post(
         s"${testData.wsName.path}/submissions",
@@ -176,7 +176,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
           )
         )
       ) ~>
-        sealRoute(services.submissionRoutes()) ~>
+        sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
         check(assertResult(StatusCodes.NotFound)(status))
   }
 
@@ -189,11 +189,11 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
   ): Submission = {
 
     Get(s"${wsName.path}/methodconfigs/${methodConf.namespace}/${methodConf.name}") ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         if (status == StatusCodes.NotFound) {
           Post(s"${wsName.path}/methodconfigs", httpJson(methodConf)) ~>
-            sealRoute(services.methodConfigRoutes()) ~>
+            sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
             check {
               assertResult(StatusCodes.Created) {
                 status
@@ -218,14 +218,14 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
         workflowFailureMode = workflowFailureMode
       )
       Post(s"${wsName.path}/submissions", httpJson(submissionRq)) ~>
-        sealRoute(services.submissionRoutes()) ~>
+        sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created, responseAs[String]) {
             status
           }
           val submission = responseAs[SubmissionReport]
           Get(s"${wsName.path}/submissions/${submission.submissionId}") ~>
-            sealRoute(services.submissionRoutes()) ~>
+            sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
             check {
               assertResult(StatusCodes.OK) {
                 status
@@ -349,7 +349,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
       val submission = createAndMonitorSubmission(wsName, methodConf, testData.sset1, Option("this.samples"), services)
 
       Get(s"${testData.wsName.path}") ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
         }
@@ -437,7 +437,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
 
     // Listing submissions should return the correct workflow failure mode
     Get(s"${testData.wsName.path}/submissions") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -579,7 +579,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
       val jsonStr = submissionRq.toJson.toString.replace("ContinueWhilePossible", "Bogus")
 
       Post(s"${wsName.path}/methodconfigs", httpJson(methodConf)) ~>
-        sealRoute(services.methodConfigRoutes()) ~>
+        sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created) {
             status
@@ -587,7 +587,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
         }
 
       Post(s"${wsName.path}/submissions", httpJsonStr(jsonStr)) ~>
-        sealRoute(services.submissionRoutes()) ~>
+        sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -614,7 +614,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
 
   it should "return 200 on getting a submission" in withTestDataApiServices { services =>
     Get(s"${testData.wsName.path}/submissions/${testData.costedSubmission1.submissionId}") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
 
@@ -628,12 +628,12 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
 
   it should "return 404 on getting a nonexistent submission" in withTestDataApiServices { services =>
     Get(s"${testData.wsName.path}/submissions/unrealSubmission42") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound)(status)
       }
     Get(s"${testData.wsName.path}/submissions/${UUID.randomUUID}") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound)(status)
       }
@@ -651,7 +651,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
     }
 
     Get(s"${testData.wsName.path}/submissions") ~>
-      sealRoute(services.submissionRoutes()) ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         assertResult(
@@ -902,11 +902,11 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
     )
 
     Get(s"${workspaceName.path}/methodconfigs/${methodConfigurationName.namespace}/${methodConfigurationName.name}") ~>
-      sealRoute(services.methodConfigRoutes()) ~>
+      sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
       check {
         if (status == StatusCodes.NotFound) {
           Post(s"${workspaceName.path}/methodconfigs", httpJson(methodConfiguration)) ~>
-            sealRoute(services.methodConfigRoutes()) ~>
+            sealRoute(services.methodConfigRoutes(userInfo = userInfo)) ~>
             check {
               assertResult(StatusCodes.Created) {
                 status
@@ -965,7 +965,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
                 ).flatten: _*
             )
           ) ~>
-            sealRoute(services.submissionRoutes()) ~>
+            sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
             check {
               val response = responseAs[String]
               status should be(StatusCodes.Created)
@@ -1002,7 +1002,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
               ).flatten: _*
           )
         ) ~>
-          sealRoute(services.submissionRoutes()) ~>
+          sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
           check {
             val response = responseAs[String]
             status should be(StatusCodes.Created)
@@ -1035,7 +1035,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
               ).flatten: _*
           )
         ) ~>
-          sealRoute(services.submissionRoutes()) ~>
+          sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
           check {
             val response = responseAs[String]
             status should be(StatusCodes.Created)
@@ -1058,7 +1058,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
             List("memoryRetryMultiplier" -> "oh gosh, I don't know... maybe seven?".toJson): _*
         )
       ) ~>
-        sealRoute(services.submissionRoutes()) ~>
+        sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
         check {
           val response = responseAs[String]
           status should be(StatusCodes.BadRequest)
@@ -1083,7 +1083,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
             ): _*
         )
       ) ~>
-        sealRoute(services.submissionRoutes()) ~>
+        sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
         check {
           val response = responseAs[String]
           status should be(StatusCodes.BadRequest)
@@ -1138,7 +1138,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
               ).flatten: _*
           )
         ) ~>
-          sealRoute(services.submissionRoutes()) ~>
+          sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
           check {
             val response = responseAs[String]
             status should be(StatusCodes.Created)
@@ -1163,7 +1163,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
             List("userComment" -> invalidUserComment.toJson): _*
         )
       ) ~>
-        sealRoute(services.submissionRoutes()) ~>
+        sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
         check {
           val response = responseAs[String]
           status should be(StatusCodes.BadRequest)
@@ -1184,7 +1184,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
             List("userComment" -> "user comment during submission".toJson): _*
         )
       ) ~>
-        sealRoute(services.submissionRoutes()) ~>
+        sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created, responseAs[String])(status)
           val submission = responseAs[SubmissionReport]
@@ -1196,7 +1196,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
               List("userComment" -> "user comment updated".toJson): _*
             )
           ) ~>
-            sealRoute(services.submissionRoutes()) ~>
+            sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
             check {
               assertResult(StatusCodes.NoContent, responseAs[String]) {
                 status
@@ -1204,7 +1204,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
             }
 
           Get(s"${workspaceName.path}/submissions/${submission.submissionId}") ~>
-            sealRoute(services.submissionRoutes()) ~>
+            sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
             check {
               assertResult(StatusCodes.OK) {
                 status
@@ -1227,13 +1227,13 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
           requiredSubmissionFields(methodConfigurationName, testData.sample1)
         )
       ) ~>
-        sealRoute(services.submissionRoutes()) ~>
+        sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.Created, responseAs[String])(status)
           val submission = responseAs[SubmissionReport]
 
           Get(s"${workspaceName.path}/submissions/${submission.submissionId}") ~>
-            sealRoute(services.submissionRoutes()) ~>
+            sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
             check {
               assertResult(StatusCodes.OK) {
                 status
@@ -1254,7 +1254,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
           List("userComment" -> "user comment updated".toJson): _*
         )
       ) ~>
-        sealRoute(services.submissionRoutes()) ~>
+        sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
         check {
           val response = responseAs[String]
           status should be(StatusCodes.NotFound)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/UserApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/UserApiServiceSpec.scala
@@ -49,7 +49,7 @@ class UserApiServiceSpec extends ApiServiceSpec {
   "UserApi" should "get a valid billing project status" in withTestDataApiServices { services =>
     val projectStatus = RawlsBillingProjectStatus(testData.billingProject.projectName, CreationStatuses.Ready)
     Get(s"/user/billing/${projectStatus.projectName.value}") ~>
-      sealRoute(services.userRoutes()) ~>
+      sealRoute(services.userRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         import org.broadinstitute.dsde.rawls.model.UserAuthJsonSupport.RawlsBillingProjectStatusFormat
@@ -59,7 +59,7 @@ class UserApiServiceSpec extends ApiServiceSpec {
 
   it should "return the list of billing accounts the user has access to" in withTestDataApiServices { services =>
     Get("/user/billingAccounts") ~>
-      sealRoute(services.userRoutes()) ~>
+      sealRoute(services.userRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
 
@@ -74,7 +74,7 @@ class UserApiServiceSpec extends ApiServiceSpec {
   it should "filter billing accounts when firecloudHasAccess is specified as false " in withTestDataApiServices {
     services =>
       Get("/user/billingAccounts?firecloudHasAccess=false") ~>
-        sealRoute(services.userRoutes()) ~>
+        sealRoute(services.userRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK)(status)
 
@@ -88,7 +88,7 @@ class UserApiServiceSpec extends ApiServiceSpec {
   it should "filter billing accounts when firecloudHasAccess is specified as true " in withTestDataApiServices {
     services =>
       Get("/user/billingAccounts?firecloudHasAccess=true") ~>
-        sealRoute(services.userRoutes()) ~>
+        sealRoute(services.userRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK)(status)
 
@@ -101,7 +101,7 @@ class UserApiServiceSpec extends ApiServiceSpec {
 
   it should "fail to get an invalid billing project status" in withTestDataApiServices { services =>
     Get("/user/billing/not-found-project-name") ~>
-      sealRoute(services.userRoutes()) ~>
+      sealRoute(services.userRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound)(status)
       }
@@ -109,7 +109,7 @@ class UserApiServiceSpec extends ApiServiceSpec {
 
   it should "list a user's billing projects ordered a-z" in withTestDataApiServices { services =>
     Get("/user/billing") ~>
-      sealRoute(services.userRoutes()) ~>
+      sealRoute(services.userRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -133,7 +133,7 @@ class UserApiServiceSpec extends ApiServiceSpec {
     runAndWait(workspaceQuery.countByNamespace(testData.billingProject.projectName)) should be > 0
 
     Delete(s"/user/billing/${testData.billingProject.projectName.value}") ~>
-      sealRoute(services.userRoutes()) ~>
+      sealRoute(services.userRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest)(status)
         val responseString = Unmarshal(response.entity).to[String].futureValue
@@ -146,7 +146,7 @@ class UserApiServiceSpec extends ApiServiceSpec {
     runAndWait(workspaceQuery.countByNamespace(testData.testProject1.projectName)) shouldEqual 0
 
     Delete(s"/user/billing/${testData.testProject1.projectName.value}") ~>
-      sealRoute(services.userRoutes()) ~>
+      sealRoute(services.userRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NoContent)(status)
         runAndWait(rawlsBillingProjectQuery.load(testData.testProject1.projectName)) shouldBe empty
@@ -155,7 +155,7 @@ class UserApiServiceSpec extends ApiServiceSpec {
 
   it should "return OK for a user who is an admin" in withTestDataApiServices { services =>
     Get("/user/role/admin") ~>
-      sealRoute(services.userRoutes()) ~>
+      sealRoute(services.userRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
@@ -166,7 +166,7 @@ class UserApiServiceSpec extends ApiServiceSpec {
   it should "return Not Found for a user who is not an admin" in withTestDataApiServices { services =>
     assertResult(())(Await.result(services.gcsDAO.removeAdmin(services.user.userEmail.value), Duration.Inf))
     Get("/user/role/admin") ~>
-      sealRoute(services.userRoutes()) ~>
+      sealRoute(services.userRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
@@ -268,7 +268,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     services =>
       implicit val timeout: Duration = 10.seconds
       Get(testWorkspaces.workspace.path) ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -299,7 +299,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
   "WorkspaceApi, when using fields param" should "include accessLevel when asked to" in withTestWorkspacesApiServices {
     services =>
       Get(testWorkspaces.workspace.path + "?fields=accessLevel") ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK)(status)
           val actual = responseAs[String].parseJson.asJsObject
@@ -310,7 +310,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
 
   it should "include bucketOptions" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=bucketOptions") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -321,7 +321,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
 
   it should "include canCompute" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=canCompute") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -332,7 +332,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
 
   it should "include canShare" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=canShare") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -343,7 +343,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
 
   it should "include catalog" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=catalog") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -354,7 +354,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
 
   it should "include owners" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=owners") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -365,7 +365,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
 
   it should "include workspace.attributes" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=workspace.attributes") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -381,7 +381,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
 
   it should "include individual keys inside workspace.attributes" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=workspace.attributes.description") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -397,7 +397,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
 
   it should "include workspace.authorizationDomain" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=workspace.authorizationDomain") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -417,7 +417,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
 
   it should "include workspaceSubmissionStats" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=workspaceSubmissionStats") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -439,7 +439,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     it should s"include $workspaceKey subkey of workspace when specifying the top-level key" in withTestWorkspacesApiServices {
       services =>
         Get(testWorkspaces.workspace.path + "?fields=workspace") ~>
-          sealRoute(services.workspaceRoutes()) ~>
+          sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
           check {
             assertResult(StatusCodes.OK)(status)
             val actual = responseAs[String].parseJson.asJsObject
@@ -451,7 +451,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
 
   it should "include multiple keys simultaneously when asked to" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=canShare,workspace.attributes,accessLevel") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -469,7 +469,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
   // this test targets a specific bug that arose during development; worth keeping in.
   it should "include workspace.attributes even when attributes are empty" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace2.path + "?fields=workspace.attributes") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -480,7 +480,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
 
   it should "handle duplicate values just fine" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=accessLevel,accessLevel") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -493,7 +493,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Get(
       testWorkspaces.workspace.path + "?fields=workspace.attributes.description,workspace.attributes.tag:tags,workspace.attributes.library:orsp"
     ) ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
@@ -511,7 +511,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
   it should s"return 400 Bad Request for unknown fields value in querystring" in withTestWorkspacesApiServices {
     services =>
       Get(testWorkspaces.workspace.path + "?fields=accessLevel,IntentionallyBadValueForUnitTest,AnotherBadOne") ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -526,7 +526,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
   it should s"return 400 Bad Request if fields param is specified multiple times" in withTestWorkspacesApiServices {
     services =>
       Get(testWorkspaces.workspace.path + "?fields=accessLevel&fields=canShare,workspace.attributes") ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.BadRequest) {
             status
@@ -545,7 +545,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
       Get(
         s"/workspaces/id/${testWorkspaces.workspace.workspaceId}" + "?fields=canShare,workspace.attributes,accessLevel"
       ) ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK)(status)
           val actual = responseAs[String].parseJson.asJsObject

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiListOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiListOptionsSpec.scala
@@ -217,7 +217,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
   "WorkspaceApi list-workspaces with fields param" should "return full response if no fields param" in withTestWorkspacesApiServices {
     services =>
       Get("/workspaces") ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -266,7 +266,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
   it should "return full response if querystring exists but no fields param" in withTestWorkspacesApiServices {
     services =>
       Get("/workspaces?thisisnotfields=noitsnot") ~>
-        sealRoute(services.workspaceRoutes()) ~>
+        sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status
@@ -312,7 +312,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
 
   it should "filter response to a single key" in withTestWorkspacesApiServices { services =>
     Get("/workspaces?fields=accessLevel") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson
@@ -326,7 +326,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
 
   it should "filter response to multiple keys" in withTestWorkspacesApiServices { services =>
     Get("/workspaces?fields=accessLevel,public") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson
@@ -346,7 +346,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
 
   it should "filter response to nested keys" in withTestWorkspacesApiServices { services =>
     Get("/workspaces?fields=workspaceSubmissionStats,workspace.workspaceId,workspace.bucketName") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson
@@ -378,7 +378,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
 
   it should "filter response to entire subtrees" in withTestWorkspacesApiServices { services =>
     Get("/workspaces?fields=public,workspace.attributes") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson
@@ -408,7 +408,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
 
   it should "filter response to individual attributes" in withTestWorkspacesApiServices { services =>
     Get("/workspaces?fields=public,workspace.attributes.description") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson
@@ -437,7 +437,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
   it should "throw error with unrecognized field value" in withTestWorkspacesApiServices { services =>
     // NB: "workspaceType" is valid for get-workspace but not list-workspaces.
     Get("/workspaces?fields=accessLevel,workspaceType,somethingNotRecognized") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest)(status)
         val actual = responseAs[ErrorReport]
@@ -449,7 +449,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
 
   it should "throw error if field param specified multiple times" in withTestWorkspacesApiServices { services =>
     Get("/workspaces?fields=accessLevel&fields=public") ~>
-      sealRoute(services.workspaceRoutes()) ~>
+      sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.BadRequest)(status)
         val actual = responseAs[ErrorReport]


### PR DESCRIPTION
Ticket: CORE-551

Akka routing works by evaluating each route in the order they are defined; as soon as one route matches that route is executed. This means Akka might evaluate - and reject - many routes before it finds the one that matches.

Rawls' high-level route order is defined in RawlsApiService. A snippet:
```scala
    workspaceRoutesV2(otelContext) ~
      workspaceRoutes(otelContext) ~
      entityRoutes(otelContext) ~
      methodConfigRoutes(otelContext) ~
      submissionRoutes(otelContext) ~
      adminRoutes(otelContext) ~
      userRoutes(otelContext) ~
      billingRoutesV2(otelContext) ~
      billingRoutes(otelContext) ~
      notificationsRoutes ~
      servicePerimeterRoutes(otelContext) ~
      snapshotRoutes(otelContext) ~
      googleProjectRegistrationRoutes(otelContext)
```

Given this order, all routes in `workspaceRoutesV2` will be evaluated, then `workspaceRoutes`, then `entityRoutes`, and so on.

The problem addressed in this PR is that each of these route classes contained an invocation of `requireUserInfo()` before defining their inner routes; this requires `requireUserInfo()` to be executed before those inner routes can be evaluated. Thus, Akka executed `requireUserInfo()` once for `workspaceRoutesV2`, a second time for `workspaceRoutes`, a third time for `entityRoutes`, and so on, until it found a matching route.

`requireUserInfo` is lightweight if the caller is a human. But, if the caller is a service account, it makes a REST API call to Sam.

The snapshot routes, defined second-to-last in the order, required _*12*_ invocations of `requireUserInfo()` before its routes were evaluated. When called as a service account, this required 12 duplicate API calls to Sam for every snapshot API. This is illustrated by the details in our tracing; note the 12 calls to `/register/user/v2/self/info`:
![Screenshot 26-06-2025 at 12 53](https://github.com/user-attachments/assets/6e9e6e2e-4064-45a0-8e85-8e93c553701c)

---

_Reviewer: I suggest starting with RawlsApiService.scala, then moving on to review the rest of the code._


