### PR TITLE
CORE-583: allow data cleanup during Quicksilver migration

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -2488,6 +2488,14 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
+        - name: cleanup
+          in: query
+          description: |
+            Should this API fully delete all unnecessary data after the migration?
+            Setting this to true can greatly increase the execution time of this API.
+          schema:
+            type: boolean
+            default: false
       requestBody:
         description: Consent to execute
         content:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityMigration.scala
@@ -185,7 +185,8 @@ trait CompactEntityMigration {
           update ENTITY e
               join CTE tmp
               on e.id = tmp.entity_id
-              set e.attributes = JSON_SET(e.attributes, $slickRefsPath, tmp.refs)
+              set e.attributes = JSON_SET(e.attributes, $slickRefsPath, tmp.refs),
+                  e.all_attribute_values = null
               where e.workspace_id = $workspaceId
               and deleted = 0;""".asUpdate
 
@@ -197,23 +198,19 @@ trait CompactEntityMigration {
   def migrationDropEntityTempTable: ReadWriteAction[Int] =
     sql"""drop temporary table QS_ENTITY_TEMP;""".asUpdate
 
-  /** Delete the all_attribute_values text from a compact ENTITY.
-      * Currently unused, but leaving here in case we change our mind.
-      */
-  @unused
-  def migrationClearAllAttributesString(workspaceId: UUID): ReadWriteAction[Int] =
-    sql"""update ENTITY
-          set all_attribute_values = null
-          where workspace_id = $workspaceId;""".asUpdate
-
   /** Clean up legacy attributes for entities in a given workspace.
-    * Currently unused, but leaving here in case we change our mind.
     */
-  @unused
-  def migrationDeleteLegacyReferences(workspaceId: UUID, shardId: String): ReadWriteAction[Int] =
+  def migrationDeleteLegacyAttributes(workspaceId: UUID, shardId: String): ReadWriteAction[Int] =
     sql"""delete ea
          from ENTITY e, ENTITY_ATTRIBUTE_#$shardId ea
          where ea.owner_id = e.id
          and e.workspace_id = $workspaceId""".asUpdate
+
+  /** Clean up all soft-deleted entities, of all types, in a given workspace.
+   */
+  def migrationHardDeleteEntitiesMarkedForDeletion(workspaceId: UUID): ReadWriteAction[Int] =
+    sql"""delete ignore from ENTITY
+          where workspace_id = $workspaceId
+          and deleted = 1""".asUpdate
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
@@ -4,7 +4,7 @@ import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
 import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeName, Entity, EntityPointer}
-import spray.json.DefaultJsonProtocol.{jsonFormat3, jsonFormat4}
+import spray.json.DefaultJsonProtocol.{jsonFormat3, jsonFormat4, IntJsonFormat}
 import spray.json.RootJsonFormat
 
 import java.sql.Timestamp
@@ -85,4 +85,10 @@ case class EntityTypeAndAttributeKey(
 case class EntityTypeAndCount(
   entityType: String,
   count: Int
+)
+
+case class QuicksilverMigrationResult(
+  numEntitiesUpdated: Int,
+  numEntitiesDeleted: Int,
+  numAttributesDeleted: Int
 )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -7,7 +7,12 @@ import akka.stream.scaladsl.Source
 import com.typesafe.scalalogging.LazyLogging
 import io.opentelemetry.api.common.AttributeKey
 import org.apache.commons.lang3.time.StopWatch
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction, ReadWriteAction}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{
+  DataAccess,
+  QuicksilverMigrationResult,
+  ReadAction,
+  ReadWriteAction
+}
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.base.{AuditLoggingEntityProvider, EntityProvider}
 import org.broadinstitute.dsde.rawls.entities.exceptions.{
@@ -30,6 +35,8 @@ import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, Json
 import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceSettingService}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValidationUtils}
 import slick.dbio.{DBIO, DBIOAction, Effect, NoStream}
+import spray.json.DefaultJsonProtocol.jsonFormat3
+import spray.json.RootJsonFormat
 
 import java.sql.SQLException
 import java.util.UUID
@@ -560,7 +567,10 @@ class EntityService(protected val ctx: RawlsRequestContext,
     * @param workspaceName the name of the workspace to migrate
     * @param batchSize the number of entities to migrate in a single batch; defaults to 50,000
     */
-  def quicksilverMigration(workspaceName: WorkspaceName, batchSize: Int = 50000): Future[Int] =
+  def quicksilverMigration(workspaceName: WorkspaceName,
+                           cleanup: Boolean = false,
+                           batchSize: Int = 50000
+  ): Future[QuicksilverMigrationResult] =
     traceFutureWithParent("EntityService.quicksilverMigration", ctx) { s =>
       for {
         // verify owner of workspace.
@@ -619,21 +629,19 @@ class EntityService(protected val ctx: RawlsRequestContext,
               })
               numEntitiesUpdated = updateCounts.sum
 
-              /** *** don't delete legacy data; we'll do that en masse after everything is migrated
-              *  // delete legacy attributes from the ENTITY_ATTRIBUTE_xx_xx table
-              *  _ = logger.info(s"Quicksilver migration: deleting legacy attributes ...")
-              *  _ <- dataAccess.compactEntityQuery.migrationDeleteLegacyReferences(workspaceContext.workspaceIdAsUUID,
-              *  shardId
-              *  )
-              *  // delete the all_attribute_values column for this workspace
-              *  _ = logger.info(s"Quicksilver migration: clearing all_attribute_values ...")
-              *  _ <- dataAccess.compactEntityQuery.migrationClearAllAttributesString(workspaceContext.workspaceIdAsUUID)
-              * *** */
+              (numAttributesDeleted, numEntitiesDeleted) <-
+                if (cleanup) {
+                  // hard delete legacy data if requested
+                  hardDeleteLegacyData(workspaceId, shardId, dataAccess)
+                } else {
+                  // otherwise, just log that we did not delete legacy data
+                  DBIO.successful((0, 0))
+                }
 
               _ = logger.info(
                 s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
               )
-            } yield numEntitiesUpdated
+            } yield QuicksilverMigrationResult(numEntitiesUpdated, numEntitiesDeleted, numAttributesDeleted)
           }
 
         }
@@ -649,6 +657,20 @@ class EntityService(protected val ctx: RawlsRequestContext,
         // return a count of entities updated
       } yield userResult
     }
+
+  private def hardDeleteLegacyData(workspaceId: UUID,
+                                   shardId: String,
+                                   dataAccess: DataAccess
+  ): ReadWriteAction[(Int, Int)] = {
+    logger.info(s"Quicksilver migration: deleting legacy attributes ...")
+    for {
+      // delete legacy attributes from the ENTITY_ATTRIBUTE_xx_xx table
+      numAttributesDeleted <- dataAccess.compactEntityQuery.migrationDeleteLegacyAttributes(workspaceId, shardId)
+      // delete the all_attribute_values column for this workspace
+      _ = logger.info(s"Quicksilver migration: clearing all_attribute_values ...")
+      numEntitiesDeleted <- dataAccess.compactEntityQuery.migrationHardDeleteEntitiesMarkedForDeletion(workspaceId)
+    } yield (numAttributesDeleted, numEntitiesDeleted) // return count of attributes and entities deleted
+  }
 
   /** Executes a database operation `op` in a session using 8MB of `sort_buffer_size` memory,
     * then resets the sort buffer size back to its original value */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -10,6 +10,7 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import io.opentelemetry.context.Context
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+import org.broadinstitute.dsde.rawls.dataaccess.slick.QuicksilverMigrationResult
 import org.broadinstitute.dsde.rawls.entities.{EntityService, EntityStreamingUtils}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
   AttributeUpdateOperation,
@@ -346,16 +347,18 @@ trait EntityApiService extends UserInfoDirectives {
       } ~
       path("workspaces" / Segment / Segment / "quicksilverMigration") { (workspaceNamespace, workspaceName) =>
         post {
-          entity(as[String]) { postBody =>
-            if (postBody != "I understand that this API will delete all my data tables.") {
-              complete(StatusCodes.BadRequest -> "You must consent to use this API.")
-            } else {
-              complete {
-                entityServiceConstructor(ctx)
-                  .quicksilverMigration(WorkspaceName(workspaceNamespace, workspaceName))
-                  .map { migrationResults =>
-                    StatusCodes.OK -> Map("entitiesUpdated" -> migrationResults)
-                  }
+          // read the "cleanup" query parameter, defaulting to false if not specified
+          parameters("cleanup".as[Boolean].withDefault(false)) { cleanup =>
+            entity(as[String]) { postBody =>
+              if (postBody != "I understand that this API will delete all my data tables.") {
+                complete(StatusCodes.BadRequest -> "You must consent to use this API.")
+              } else {
+                implicit val quicksilverMigrationResultFormat: RootJsonFormat[QuicksilverMigrationResult] =
+                  jsonFormat3(QuicksilverMigrationResult)
+                complete {
+                  entityServiceConstructor(ctx)
+                    .quicksilverMigration(WorkspaceName(workspaceNamespace, workspaceName), cleanup)
+                }
               }
             }
           }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -8,7 +8,7 @@ import cats.effect.unsafe.implicits.global
 import com.typesafe.config.ConfigFactory
 import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
-import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{QuicksilverMigrationResult, TestDriverComponent}
 import org.broadinstitute.dsde.rawls.dataaccess.{
   GoogleBigQueryServiceFactoryImpl,
   MockBigQueryServiceFactory,
@@ -149,10 +149,10 @@ class EntityServiceCompactMigrationSpec
 
         // perform migration - this keeps legacy attributes and adds Quicksilver attributes
         // set a low batch size to ensure we exercise the batching logic
-        val entitiesUpdated =
+        val migrationResult =
           Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName, batchSize = 3), atMost)
 
-        entitiesUpdated shouldBe expectedCount
+        migrationResult shouldBe QuicksilverMigrationResult(expectedCount, 0, 0)
 
         val defaultRequestContext =
           RawlsRequestContext(
@@ -266,10 +266,10 @@ class EntityServiceCompactMigrationSpec
     savedEntity shouldBe entity
 
     // perform migration - this keeps legacy attributes and adds Quicksilver attributes
-    val entitiesUpdated =
+    val migrationResult =
       Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName), atMost)
 
-    entitiesUpdated shouldBe 19 // 18 from the test data, plus the one we just created
+    migrationResult shouldBe QuicksilverMigrationResult(19, 0, 0) // 18 from the test data, plus the one we just created
 
     val compactEntity =
       Await.result(compactProvider.getEntity(entity.entityType, entity.name, defaultRequestContext), atMost)
@@ -356,10 +356,10 @@ class EntityServiceCompactMigrationSpec
     savedEntity shouldBe entity
 
     // perform migration - this keeps legacy attributes and adds Quicksilver attributes
-    val entitiesUpdated =
+    val migrationResult =
       Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName), atMost)
 
-    entitiesUpdated shouldBe 19 // 18 from the test data, plus the one we just created
+    migrationResult shouldBe QuicksilverMigrationResult(19, 0, 0) // 18 from the test data, plus the one we just created
 
     val compactEntity =
       Await.result(compactProvider.getEntity(entity.entityType, entity.name, defaultRequestContext), atMost)
@@ -374,6 +374,41 @@ class EntityServiceCompactMigrationSpec
       }
     }
 
+  }
+
+  it should s"hard delete legacy data when requested" in withTestDataServices { apiService =>
+    val workspace = testData.workspace // has some entities we can use to test references
+
+    val defaultRequestContext =
+      RawlsRequestContext(
+        UserInfo(RawlsUserEmail("test"), OAuth2BearerToken("Bearer 123"), 123, RawlsUserSubjectId("abc"))
+      )
+
+    val requestArguments = EntityRequestArguments(workspace, defaultRequestContext)
+
+    // get providers
+    val localProvider =
+      new LocalEntityProvider(requestArguments,
+                              slickDataSource,
+                              true,
+                              java.time.Duration.ofSeconds(60),
+                              workbenchMetricBaseName
+      )
+
+    // Attempt to soft-delete two existing entities. This will actually only delete indiv2, since indiv1 is referenced
+    // by a submission.
+    val softDeletes = Seq(testData.indiv1.toPointer, testData.indiv2.toPointer)
+    val softDeleteResult = Await.result(localProvider.deleteEntities(softDeletes, defaultRequestContext), atMost)
+    softDeleteResult shouldBe 2
+
+    // perform migration with cleanup - this deletes legacy attributes and hard-deleted soft-deleted entities
+    val migrationResult =
+      Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName, cleanup = true), atMost)
+
+    migrationResult shouldBe QuicksilverMigrationResult(16, 1, 36)
+    // numEntitiesUpdated: test data has 18, but we soft-deleted 2
+    // numEntitiesDeleted: 1 soft-deleted entity were hard-deleted
+    // numAttributesDeleted: we delete all attributes in the workspace, not just the soft-deleted ones
   }
 
 }


### PR DESCRIPTION
Ticket: CORE-583

The Quicksilver migration API now has an optional `cleanup` query parameter. It defaults to false. When true:
* all legacy attributes in the workspace are deleted from the legacy shard tables
* all soft-deleted entities in the workspace are deleted, except for those which have foreign keys pointing at them from submissions, workflows, etc.

Additionally, the migration now always clears the `all_attribute_values` column (regardless of the `cleanup` query param value). 