### PR TITLE
CORE-501: create-workspace is now GCP only

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -34,10 +34,16 @@ trait WorkspaceApiService extends UserInfoDirectives {
           addLocationHeader(workspace.path) {
             complete {
               val workspaceService = workspaceServiceConstructor(ctx)
-              val mcWorkspaceService = multiCloudWorkspaceServiceConstructor(ctx)
-              mcWorkspaceService
-                .createMultiCloudOrRawlsWorkspace(workspace, workspaceService)
-                .map(w => StatusCodes.Created -> w)
+              workspaceService
+                .createWorkspace(workspace, ctx)
+                .map(w =>
+                  StatusCodes.Created -> WorkspaceDetails.fromWorkspaceAndOptions(
+                    w,
+                    Some(workspace.authorizationDomain.getOrElse(Set.empty)),
+                    useAttributes = true,
+                    Some(WorkspaceCloudPlatform.Gcp)
+                  )
+                )
             }
           }
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -218,6 +218,10 @@ class WorkspaceService(
           ErrorReport(StatusCodes.BadRequest, "Unsupported billing project: Azure billing projects are not supported")
         )
       }
+      // ensure the user has the create_workspace permission on the billing project
+      _ <- traceFutureWithParent("requireCreateWorkspaceAccess", parentContext) { childContext =>
+        requireCreateWorkspaceAction(billingProject.projectName, childContext)
+      }
       // explicit policies in the request are not supported on GCP workspaces. instead, we derive the policies from other fields in the request
       _ <- failIfPoliciesIncluded(workspaceRequest)
       _ <- failUnlessBillingAccountHasAccess(billingProject, parentContext)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -212,6 +212,12 @@ class WorkspaceService(
       billingProject <- traceFutureWithParent("getBillingProjectContext", parentContext)(s =>
         getBillingProjectContext(RawlsBillingProjectName(workspaceRequest.namespace), s)
       )
+      // ensure this creation request is not happening in a leftover Azure billing project
+      _ = if (billingProject.azureManagedAppCoordinates.isDefined) {
+        throw RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, "Unsupported billing project: Azure billing projects are not supported")
+        )
+      }
       // explicit policies in the request are not supported on GCP workspaces. instead, we derive the policies from other fields in the request
       _ <- failIfPoliciesIncluded(workspaceRequest)
       _ <- failUnlessBillingAccountHasAccess(billingProject, parentContext)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceService, WorkspaceService}
 import org.joda.time.DateTime
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -105,7 +106,7 @@ class WorkspaceApiServiceSpec
     verify(workspaceService).listWorkspaces(WorkspaceFieldSpecs(), -1) // empty seq and -1 are the default values
   }
 
-  it should "call MCWorkspaceService.createMultiCloudOrRawlsWorkspace to create a workspace" in {
+  it should "call WorkspaceService.createWorkspace to create a workspace" in {
     val workspaceService = mock[WorkspaceService]
     val mcWorkspaceService = mock[MultiCloudWorkspaceService]
     val workspace = testData.workspace
@@ -114,9 +115,8 @@ class WorkspaceApiServiceSpec
       name = workspace.name,
       Map.empty
     )
-    val details = WorkspaceDetails(workspace, Set())
-    when(mcWorkspaceService.createMultiCloudOrRawlsWorkspace(newWorkspace, workspaceService))
-      .thenReturn(Future.successful(details))
+    when(workspaceService.createWorkspace(ArgumentMatchers.eq(newWorkspace), any[RawlsRequestContext]))
+      .thenReturn(Future.successful(workspace))
     val service = new MockApiService(
       workspaceServiceConstructor = _ => workspaceService,
       multiCloudWorkspaceServiceConstructor = _ => mcWorkspaceService
@@ -128,7 +128,7 @@ class WorkspaceApiServiceSpec
         val response = responseAs[WorkspaceDetails]
         response.name shouldBe workspace.name
       }
-    verify(mcWorkspaceService).createMultiCloudOrRawlsWorkspace(newWorkspace, workspaceService, null)
+    verify(workspaceService).createWorkspace(ArgumentMatchers.eq(newWorkspace), any[RawlsRequestContext])
   }
 
   private val tagsTestParameters = Table[String, Option[String], Option[Int]](


### PR DESCRIPTION
Ticket: CORE-501

The create-workspace flow is now GCP-only. Creating Azure workspaces is no longer possible.