### PR TITLE
CORE-556: throw error when attempting to delete a workspace with children

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -526,6 +526,19 @@ class WorkspaceService(
         throw RawlsExceptionWithErrorReport(StatusCodes.BadRequest, "Multi Cloud workspaces not supported")
       case WorkspaceType.RawlsWorkspace => ()
     }
+    // disallow deletion of workspaces with children
+    wsResourceChildren <- traceFutureWithParent("listResourceChildren", ctx)(_ =>
+      samDAO.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
+    )
+    _ = if (wsResourceChildren.nonEmpty) {
+      throw RawlsExceptionWithErrorReport(
+        ErrorReport(
+          StatusCodes.BadRequest,
+          s"Workspace ${workspace.toWorkspaceName} cannot be deleted because it contains at least one cloud resource such as an application or cloud environment. " +
+            s"Delete those resources first."
+        )
+      )
+    }
     _ <- requesterPaysSetupService.deleteAllRecordsForWorkspace(workspace)
     workflowsToAbort <- traceFutureWithParent("gatherWorkflowsToAbortAndSetStatusToAborted", ctx)(_ =>
       submissionsRepository.getActiveWorkflowsAndSetStatusToAborted(workspace)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -526,11 +526,12 @@ class WorkspaceService(
         throw RawlsExceptionWithErrorReport(StatusCodes.BadRequest, "Multi Cloud workspaces not supported")
       case WorkspaceType.RawlsWorkspace => ()
     }
-    // disallow deletion of workspaces with children
+    // Disallow deletion of workspaces with any children *other* than its google project.
+    // This method knows how to delete that child google project.
     wsResourceChildren <- traceFutureWithParent("listResourceChildren", ctx)(_ =>
       samDAO.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
     )
-    _ = if (wsResourceChildren.nonEmpty) {
+    _ = if (wsResourceChildren.exists(_.resourceTypeName != SamResourceTypeNames.googleProject.value)) {
       throw RawlsExceptionWithErrorReport(
         ErrorReport(
           StatusCodes.BadRequest,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -1114,6 +1114,31 @@ class WorkspaceServiceSpec
     runAndWait(workspaceQuery.findByName(testData.wsName3)) shouldBe None
   }
 
+  it should "fail if Sam reports children for this workspace" in withTestDataServices { services =>
+    // check that the workspace to be deleted exists
+    assertWorkspaceResult(Option(testData.workspaceNoSubmissions)) {
+      runAndWait(workspaceQuery.findByName(testData.wsName3))
+    }
+
+    when(
+      services.samDAO.listResourceChildren(ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+                                           ArgumentMatchers.eq(testData.workspaceNoSubmissions.workspaceId),
+                                           any[RawlsRequestContext]
+      )
+    ).thenReturn(
+      Future.successful(
+        Seq(SamFullyQualifiedResourceId("fake-id", "notebook-cluster"))
+      ) // Simulate that there are children resources
+    )
+
+    val error = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(services.workspaceService.deleteWorkspace(testData.wsName3), Duration.Inf)
+    }
+    assertResult(Some(StatusCodes.BadRequest)) {
+      error.errorReport.statusCode
+    }
+  }
+
   behavior of "getTags"
 
   it should "return the correct tags from autocomplete" in withTestDataServices { services =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -588,6 +588,12 @@ class WorkspaceServiceUnitTests
     when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.delete, ctx))
       .thenReturn(Future(true))
+    when(sam.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx))
+      .thenReturn(Future(Seq.empty))
+    when(sam.getResourceAuthDomain(SamResourceTypeNames.workspace, workspace.workspaceId, ctx))
+      .thenReturn(Future(Seq()))
+    when(sam.getResourceAuthDomain(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
+      .thenReturn(Future(Seq()))
     when(repo.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
     // delete requester pays records
     when(requesterPaysService.deleteAllRecordsForWorkspace(workspace)).thenReturn(Future(1))
@@ -645,6 +651,8 @@ class WorkspaceServiceUnitTests
     when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.delete, ctx))
       .thenReturn(Future(true))
+    when(sam.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx))
+      .thenReturn(Future(Seq.empty))
     when(repo.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
     // delete requester pays records
     when(requesterPaysService.deleteAllRecordsForWorkspace(workspace)).thenReturn(Future(1))
@@ -703,6 +711,8 @@ class WorkspaceServiceUnitTests
     when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.delete, ctx))
       .thenReturn(Future(true))
+    when(sam.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx))
+      .thenReturn(Future(Seq.empty))
     when(repo.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
     // delete requester pays records
     when(requesterPaysService.deleteAllRecordsForWorkspace(workspace)).thenReturn(Future(1))
@@ -758,6 +768,8 @@ class WorkspaceServiceUnitTests
     when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.delete, ctx))
       .thenReturn(Future(true))
+    when(sam.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx))
+      .thenReturn(Future(Seq.empty))
     when(repo.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
     // delete requester pays records
     when(requesterPaysService.deleteAllRecordsForWorkspace(workspace)).thenReturn(Future(1))
@@ -811,6 +823,8 @@ class WorkspaceServiceUnitTests
     when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.delete, ctx))
       .thenReturn(Future(true))
+    when(sam.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx))
+      .thenReturn(Future(Seq.empty))
     when(repo.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
     // delete requester pays records
     when(requesterPaysService.deleteAllRecordsForWorkspace(workspace)).thenReturn(Future(1))
@@ -864,6 +878,8 @@ class WorkspaceServiceUnitTests
     when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.delete, ctx))
       .thenReturn(Future(true))
+    when(sam.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx))
+      .thenReturn(Future(Seq.empty))
     when(repo.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
     // delete requester pays records
     when(requesterPaysService.deleteAllRecordsForWorkspace(workspace)).thenReturn(Future(1))
@@ -921,6 +937,8 @@ class WorkspaceServiceUnitTests
     when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.delete, ctx))
       .thenReturn(Future(true))
+    when(sam.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx))
+      .thenReturn(Future(Seq.empty))
     when(repo.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
     // delete requester pays records
     when(requesterPaysService.deleteAllRecordsForWorkspace(workspace)).thenReturn(Future(1))
@@ -981,6 +999,8 @@ class WorkspaceServiceUnitTests
     when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.delete, ctx))
       .thenReturn(Future(true))
+    when(sam.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx))
+      .thenReturn(Future(Seq.empty))
     when(repo.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
     // delete requester pays records
     when(requesterPaysService.deleteAllRecordsForWorkspace(workspace)).thenReturn(Future(1))
@@ -1048,6 +1068,8 @@ class WorkspaceServiceUnitTests
     when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.delete, ctx))
       .thenReturn(Future(true))
+    when(sam.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx))
+      .thenReturn(Future(Seq.empty))
     when(repo.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
     // delete requester pays records
     when(requesterPaysService.deleteAllRecordsForWorkspace(workspace)).thenReturn(Future(1))


### PR DESCRIPTION
Ticket: CORE-556

When deleting a workspace, check if that workspace's Sam resource has any children. If so, stop trying to delete this workspace.

The goal of this PR is to prevent half-deleted workspaces in which we've deleted parts of the workspace, like the google project, but then fail at the end when trying to delete the Sam resource.