### PR TITLE
CORE-587: Quicksilver search by name

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -1142,9 +1142,12 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     sql" from ENTITY e where e.workspace_id = $workspaceId and e.entity_type = $entityType and e.deleted = 0"
 
   private def filterTermsCondition(filterTerms: Seq[String], operator: FilterOperator) = {
-    // note the lower casing for case insensitive search
+    // note the lower casing for case-insensitive search in JSON_SEARCH;
+    // this is not necessary for the name search since the name column uses a case-insensitive collation
     val filterClauses = filterTerms.map { filterTerm =>
-      sql"""JSON_SEARCH(lower(e.attributes -> '#${CompactEntitySerialization.slickAttrsPath}'), 'one', ${'%' + filterTerm.toLowerCase + '%'})"""
+      sql"""(e.name like ${'%' + filterTerm + '%'}
+              or JSON_SEARCH(lower(e.attributes -> '#${CompactEntitySerialization.slickAttrsPath}'), 'one', ${'%' + filterTerm.toLowerCase + '%'})
+            )"""
     }
     concatSqlActions(
       sql" and (",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -2478,7 +2478,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val testAttrName2 = AttributeName.withDefaultNS("bar")
     // this test searches on entity names, so the names configured here are important
     val entity1 =
-      Entity("do-findme1",
+      Entity("do-FindMe1",
              entityType1,
              Map(testAttrName1 -> AttributeString("asdffoo"), testAttrName2 -> AttributeString("bar"))
       )
@@ -2493,7 +2493,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
              Map(testAttrName1 -> AttributeString(UUID.randomUUID().toString), testAttrName2 -> AttributeString("bar"))
       )
     val entity4 =
-      Entity("do-findme2",
+      Entity("do-FindMe2",
              entityType1,
              Map(testAttrName1 -> AttributeString("foo"), testAttrName2 -> AttributeString("barasdf"))
       )
@@ -2511,10 +2511,10 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
                     10,
                     Attributable.nameReservedAttribute,
                     SortDirections.Ascending,
-                    Some("findme"),
+                    Some("FINDME"),
                     FilterOperators.And
         ),
-        Seq("findme")
+        Seq("FINDME")
       )
     )
     actual should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(_.name)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -2471,6 +2471,55 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       )
   }
 
+  it should "return the entities with filter terms matching on the entity name" in withMinimalTestDatabase { _ =>
+    val entityType1 = "entityType1"
+    val entityType2 = "entityType2"
+    val testAttrName1 = AttributeName.withDefaultNS("foo")
+    val testAttrName2 = AttributeName.withDefaultNS("bar")
+    // this test searches on entity names, so the names configured here are important
+    val entity1 =
+      Entity("do-findme1",
+             entityType1,
+             Map(testAttrName1 -> AttributeString("asdffoo"), testAttrName2 -> AttributeString("bar"))
+      )
+    val entity2 =
+      Entity("some-other-unfindable-value",
+             entityType2,
+             Map(testAttrName1 -> AttributeString("foo"), testAttrName2 -> AttributeString("bar"))
+      )
+    val entity3 =
+      Entity("another-unfindable-value",
+             entityType1,
+             Map(testAttrName1 -> AttributeString(UUID.randomUUID().toString), testAttrName2 -> AttributeString("bar"))
+      )
+    val entity4 =
+      Entity("do-findme2",
+             entityType1,
+             Map(testAttrName1 -> AttributeString("foo"), testAttrName2 -> AttributeString("barasdf"))
+      )
+    insertAndGet(entity1) // should get counted
+    insertAndGet(entity2) // different entityType
+    insertAndGet(entity3) // different attribute value
+    insertAndGet(entity4) // should get counted
+    insertAndGet(entity4, minimalTestData.workspace2.workspaceIdAsUUID) // different workspace
+
+    val actual = runAndWait(
+      q.queryEntitiesWithFilterTerms(
+        wsid,
+        entityType1,
+        EntityQuery(1,
+                    10,
+                    Attributable.nameReservedAttribute,
+                    SortDirections.Ascending,
+                    Some("findme"),
+                    FilterOperators.And
+        ),
+        Seq("findme")
+      )
+    )
+    actual should contain theSameElementsInOrderAs List(entity1, entity4).sortBy(_.name)
+  }
+
   it should "respect desired fields" in withMinimalTestDatabase { _ =>
     testDesiredFields(Some("foo"), None) { (entityType, entityQuery) =>
       q.queryEntitiesWithFilterTerms(


### PR DESCRIPTION
Ticket: CORE-587

When using the all-column search - i.e. the `filterTerms` parameter - allow searching on entity names as well as other columns.