### PR TITLE
AN-655: update swat test for lifesciences API removal

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
@@ -177,6 +177,7 @@ class WorkspaceApiSpec
             "dataproc.serviceAgent",
             "owner",
             "editor",
+            "batch.serviceAgent",
             "pubsub.serviceAgent"
           )
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
@@ -177,7 +177,6 @@ class WorkspaceApiSpec
             "dataproc.serviceAgent",
             "owner",
             "editor",
-            "lifesciences.serviceAgent",
             "pubsub.serviceAgent"
           )
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
@@ -177,7 +177,6 @@ class WorkspaceApiSpec
             "dataproc.serviceAgent",
             "owner",
             "editor",
-            "batch.serviceAgent",
             "pubsub.serviceAgent"
           )
 


### PR DESCRIPTION
Ticket: AN-655

The lifesciences API is going away, replaced by the batch API. As of https://github.com/broadinstitute/terra-helmfile/pull/6190, new workspaces do not have the lifesciences API. This updates swatomation tests with this expectation.
