### PR TITLE
CORE-600: clean up permission methods

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -96,7 +96,7 @@ trait WorkspaceSupport {
 
   // WorkspaceContext helpers
 
-  def getWorkspaceContext(
+  private def getWorkspaceContext(
     workspaceName: WorkspaceName,
     attributeSpecs: Option[WorkspaceAttributeSpecs] = None
   ): Future[Workspace] =
@@ -128,8 +128,8 @@ trait WorkspaceSupport {
       _ <- checkLock(workspace, requiredAction)
     } yield workspace
 
-  def getV2WorkspaceContextByWorkspaceId(workspaceId: String,
-                                         attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+  private def getV2WorkspaceContextByWorkspaceId(workspaceId: String,
+                                                 attributeSpecs: Option[WorkspaceAttributeSpecs] = None
   ): Future[Workspace] = for {
     _ <- userEnabledCheck
     workspaceUuid = Try(UUID.fromString(workspaceId)) match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -96,20 +96,6 @@ trait WorkspaceSupport {
 
   // WorkspaceContext helpers
 
-  // function name may be misleading. This returns the workspace context and checks the user's permission,
-  // but does not return the permissions.
-  // TODO CORE-501: this is only used by MultiCloudWorkspaceService. Can this be removed?
-  def getWorkspaceContextAndPermissions(workspaceName: WorkspaceName,
-                                        requiredAction: SamResourceAction,
-                                        attributeSpecs: Option[WorkspaceAttributeSpecs] = None
-  ): Future[Workspace] =
-    for {
-      _ <- userEnabledCheck
-      workspace <- getWorkspaceContext(workspaceName, attributeSpecs)
-      _ <- accessCheck(workspace, requiredAction)
-      _ <- checkLock(workspace, requiredAction)
-    } yield workspace
-
   def getWorkspaceContext(
     workspaceName: WorkspaceName,
     attributeSpecs: Option[WorkspaceAttributeSpecs] = None

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -43,21 +43,6 @@ trait WorkspaceSupport {
         }
     }
 
-  def accessCheck(workspaceId: String, requiredAction: SamResourceAction): Future[Unit] =
-    samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, requiredAction, ctx) flatMap { hasRequiredLevel =>
-      if (hasRequiredLevel) {
-        Future.successful(())
-      } else if (requiredAction == SamWorkspaceActions.read) {
-        Future.failed(NoSuchWorkspaceException(workspaceId))
-      } else {
-        samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.read, ctx) flatMap {
-          canRead =>
-            if (canRead) Future.failed(WorkspaceAccessDeniedException(workspaceId))
-            else Future.failed(NoSuchWorkspaceException(workspaceId))
-        }
-      }
-    }
-
   def checkLock(workspace: Workspace, requiredAction: SamResourceAction): Future[Unit] = {
     val actionsBlockedByLock =
       Set(SamWorkspaceActions.write, SamWorkspaceActions.compute, SamWorkspaceActions.delete)
@@ -121,6 +106,21 @@ trait WorkspaceSupport {
   }
 
   // private internal methods
+
+  private def accessCheck(workspaceId: String, requiredAction: SamResourceAction): Future[Unit] =
+    samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, requiredAction, ctx) flatMap { hasRequiredLevel =>
+      if (hasRequiredLevel) {
+        Future.successful(())
+      } else if (requiredAction == SamWorkspaceActions.read) {
+        Future.failed(NoSuchWorkspaceException(workspaceId))
+      } else {
+        samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.read, ctx) flatMap {
+          canRead =>
+            if (canRead) Future.failed(WorkspaceAccessDeniedException(workspaceId))
+            else Future.failed(NoSuchWorkspaceException(workspaceId))
+        }
+      }
+    }
 
   private def userEnabledCheck: Future[Unit] =
     samDAO.getUserStatus(ctx) flatMap {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -26,12 +26,6 @@ trait WorkspaceSupport {
   implicit protected val executionContext: ExecutionContext
 
   // Access/permission helpers
-  private def userEnabledCheck: Future[Unit] =
-    samDAO.getUserStatus(ctx) flatMap {
-      case Some(user) if user.enabled => Future.successful()
-      case _ => Future.failed(new UserDisabledException(StatusCodes.Unauthorized, "Unauthorized"))
-    }
-
   def accessCheck(workspace: Workspace, requiredAction: SamResourceAction): Future[Unit] =
     samDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, requiredAction, ctx) flatMap {
       hasRequiredLevel =>
@@ -93,15 +87,6 @@ trait WorkspaceSupport {
 
   // WorkspaceContext helpers
 
-  private def getWorkspaceContext(
-    workspaceName: WorkspaceName,
-    attributeSpecs: Option[WorkspaceAttributeSpecs] = None
-  ): Future[Workspace] =
-    workspaceRepository.getWorkspace(workspaceName, attributeSpecs).map {
-      case Some(workspace) => workspace
-      case None            => throw NoSuchWorkspaceException(workspaceName)
-    }
-
   def getV2WorkspaceContextAndPermissions(
     workspaceName: WorkspaceName,
     requiredAction: SamResourceAction,
@@ -125,6 +110,24 @@ trait WorkspaceSupport {
       _ <- checkLock(workspace, requiredAction)
     } yield workspace
 
+  def getV2WorkspaceContext(workspaceName: WorkspaceName,
+                            attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+  ): Future[Workspace] = for {
+    _ <- userEnabledCheck
+    workspaceContext <- workspaceRepository.getWorkspace(workspaceName, attributeSpecs)
+  } yield workspaceContext match {
+    case Some(workspace) => workspace
+    case None            => throw NoSuchWorkspaceException(workspaceName)
+  }
+
+  // private internal methods
+
+  private def userEnabledCheck: Future[Unit] =
+    samDAO.getUserStatus(ctx) flatMap {
+      case Some(user) if user.enabled => Future.successful()
+      case _ => Future.failed(new UserDisabledException(StatusCodes.Unauthorized, "Unauthorized"))
+    }
+
   private def getV2WorkspaceContextByWorkspaceId(workspaceId: String,
                                                  attributeSpecs: Option[WorkspaceAttributeSpecs] = None
   ): Future[Workspace] = for {
@@ -140,14 +143,13 @@ trait WorkspaceSupport {
     case None            => throw NoSuchWorkspaceException(workspaceId)
   }
 
-  def getV2WorkspaceContext(workspaceName: WorkspaceName,
-                            attributeSpecs: Option[WorkspaceAttributeSpecs] = None
-  ): Future[Workspace] = for {
-    _ <- userEnabledCheck
-    workspaceContext <- workspaceRepository.getWorkspace(workspaceName, attributeSpecs)
-  } yield workspaceContext match {
-    case Some(workspace) => workspace
-    case None            => throw NoSuchWorkspaceException(workspaceName)
-  }
+  private def getWorkspaceContext(
+    workspaceName: WorkspaceName,
+    attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+  ): Future[Workspace] =
+    workspaceRepository.getWorkspace(workspaceName, attributeSpecs).map {
+      case Some(workspace) => workspace
+      case None            => throw NoSuchWorkspaceException(workspaceName)
+    }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -1,15 +1,12 @@
 package org.broadinstitute.dsde.rawls.util
 
 import akka.http.scaladsl.model.StatusCodes
-import cats.implicits.{catsSyntaxApplyOps, toFoldableOps}
-import cats.ApplicativeThrow
 import org.broadinstitute.dsde.rawls._
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
   RawlsRequestContext,
   SamResourceAction,
-  SamResourceTypeName,
   SamResourceTypeNames,
   SamWorkspaceActions,
   Workspace,


### PR DESCRIPTION
Ticket: CORE-600

Pre-factoring for CORE-600, just a little cleanup:
* remove `getWorkspaceContextAndPermissions`, which is unused now that `MultiCloudWorkspaceService` is gone
* tighten visibility in WorkspaceSupport by making some methods private
* reorganize private methods to the bottom of the class

_Reviewer: these changes may be easier to see if you review commit-by-commit_