### PR TITLE
CORE-600: eliminate requireComputePermission method

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -603,8 +603,8 @@ class SubmissionsService(
     val submissionId: UUID = UUID.randomUUID()
 
     for {
-      _ <- requireComputePermission(workspaceName)
       workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write)
+      _ <- accessCheck(workspaceContext, SamWorkspaceActions.compute)
       methodConfigOption <- dataSource.inTransaction { dataAccess =>
         dataAccess.methodConfigurationQuery.get(workspaceContext,
                                                 submissionRequest.methodConfigurationNamespace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -136,13 +136,4 @@ trait WorkspaceSupport {
     case None            => throw NoSuchWorkspaceException(workspaceId)
   }
 
-  private def getWorkspaceContext(
-    workspaceName: WorkspaceName,
-    attributeSpecs: Option[WorkspaceAttributeSpecs] = None
-  ): Future[Workspace] =
-    workspaceRepository.getWorkspace(workspaceName, attributeSpecs).map {
-      case Some(workspace) => workspace
-      case None            => throw NoSuchWorkspaceException(workspaceName)
-    }
-
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -52,13 +52,6 @@ trait WorkspaceSupport {
       Future.successful(())
   }
 
-  def requireComputePermission(workspaceName: WorkspaceName): Future[Unit] =
-    for {
-      _ <- userEnabledCheck
-      workspace <- getWorkspaceContext(workspaceName)
-      _ <- accessCheck(workspace, SamWorkspaceActions.compute)
-    } yield ()
-
   // can't use withClonedAuthDomain because the Auth Domain -> no Auth Domain logic is different
   def authDomainCheck(sourceWorkspaceADs: Set[String], destWorkspaceADs: Set[String]): Boolean =
     // if the source has any auth domains, the dest must also *at least* have those auth domains


### PR DESCRIPTION
Ticket: CORE-600

More prefactoring for CORE-600. This consolidates our permission checks and further reduces the surface area of `WorkspaceSupport` by deleting the `requireComputePermission` method and the private `getWorkspaceContext` method on which it relied.

`requireComputePermission` was used in exactly one place: SubmissionsService. The old code executed:
```scala
      _ <- requireComputePermission(workspaceName)
      workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write)
```

If you drill into the implementations of those two methods, you'll find that it was executing this:
* requireComputePermission(workspaceName)
	* userEnabledCheck
	* workspaceRepository.getWorkspace
	* accessCheck(workspace, SamWorkspaceActions.compute)
* getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write)
	* userEnabledCheck
	* workspaceRepository.getWorkspace
	* accessCheck(workspace, SamWorkspaceActions.write)
	* checkLock

The `userEnabledCheck` (Sam API call) and `workspaceRepository.getWorkspace` (db query) were redundant.

In this PR, I have replaced `requireComputePermission` with its only non-redundant part: a call to `accessCheck(workspace, SamWorkspaceActions.compute)`.

