### PR TITLE
[AN-665] Update Canary Test Workspace

### DIFF
--- a/.github/workflows/workflows-simple-canary-prod-test.yaml
+++ b/.github/workflows/workflows-simple-canary-prod-test.yaml
@@ -22,7 +22,7 @@ jobs:
           inputs: '{
             "run-name": "workflows-simple-canary-prod-test-${{ github.run_id }}-${{ github.run_attempt }}",
             "workspace-namespace": "broad-firecloud-dsde",
-            "workspace-name": "CanaryTest",
+            "workspace-name": "CanaryTest2025",
             "method-namespace": "wdl-testing",
             "method-name": "hello-world",
             "entity-type": "participant",


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AN-665

Current [simple-canary workspace](https://app.terra.bio/#workspaces/broad-firecloud-dsde/CanaryTest) has lot of submissions and is slow to load, making it hard to look at failures. We made [a clone of the original one](https://app.terra.bio/#workspaces/broad-firecloud-dsde/CanaryTest2025) and need to update the GHA accordingly.

Had a successful run on this branch: https://github.com/broadinstitute/rawls/actions/runs/16198391245

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
