### PR TITLE
[CORE-593] Switch from jfrog to GAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Build Rawls jar and docker image
 
 Supported Scala versions: 2.13
 
-Running the `publishRelease.sh` script publishes a release of rawls-model, workbench-util and workbench-google to Artifactory.
+Running the `publishRelease.sh` script publishes a release of rawls-model, workbench-util and workbench-google to Google Artifact Registry.
 You should do this manually from the base directory of the repo when you change something in `model/src`, `util/src` or `google/src`.
 
 Note: We have started just using the automatically generated `-SNAP` versions published by [`rawls-build` GitHub action](https://github.com/broadinstitute/terra-github-workflows/actions/workflows/rawls-build.yaml) on every dev build. Here are detailed instructions for finding the name of the jar file:
@@ -142,16 +142,25 @@ Note: We have started just using the automatically generated `-SNAP` versions pu
 To publish a temporary or test version, use `publishSnapshot.sh` like so:
 
 ```sh
-VAULT_TOKEN=$(cat ~/.vault-token) ARTIFACTORY_USERNAME=dsdejenkins ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN broadinstitute/dsde-toolbox:dev vault read -field=password secret/dsp/accts/artifactory/dsdejenkins) core/src/bin/publishSnapshot.sh
+export GOOGLE_CLOUD_PROJECT=dsp-artifact-registry
+export GAR_LOCATION=us-central1
+export GAR_REPOSITORY_ID=libs-snapshot-standard
+gcloud auth login <you>@broadinstitute.org
+core/src/bin/publishSnapshot.sh
 ```
 
 To publish an official release, you can run the following command:
 
 ```sh
-VAULT_TOKEN=$(cat ~/.vault-token) ARTIFACTORY_USERNAME=dsdejenkins ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN broadinstitute/dsde-toolbox:dev vault read -field=password secret/dsp/accts/artifactory/dsdejenkins) core/src/bin/publishRelease.sh
-```
+export GOOGLE_CLOUD_PROJECT=dsp-artifact-registry
+export GAR_LOCATION=us-central1
+export GAR_REPOSITORY_ID=libs-release-standard
+gcloud auth login <you>@broadinstitute.org
+core/src/bin/publishRelease.sh```
 
-You can view what is in the artifactory here: https://broadinstitute.jfrog.io/broadinstitute/webapp/#/home
+You can view what is in the artifact registry here: 
+- releases: https://console.cloud.google.com/artifacts/maven/dsp-artifact-registry/us-central1/libs-release-standard
+- snapshots: https://console.cloud.google.com/artifacts/maven/dsp-artifact-registry/us-central1/libs-snapshot-standard
 
 After publishing:
 * Update [model/CHANGELOG.md](model/CHANGELOG.md) properly

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -3,7 +3,6 @@
 HELP_TEXT="$(cat <<EOF
  Build jar and docker images.
    jar: build jar
-   publish: push jar to artifactory
    -d | --docker : (default: no action) provide either "build" or "push" to
            build or push a docker image.  "push" will also perform build.
    -g | --gcr-registry: If this flag is set, will push to the specified GCR repository.
@@ -13,7 +12,7 @@ HELP_TEXT="$(cat <<EOF
    -h | --help: print help text.
  Examples:
    Jenkins build job should run with all options, for example,
-     ./docker/build.sh jar publish -d push -g "my-gcr-registry" -k "path-to-my-keyfile"
+     ./docker/build.sh jar -d push -g "my-gcr-registry" -k "path-to-my-keyfile"
 \t
 EOF
 )"
@@ -31,7 +30,6 @@ ENV=${ENV:-""}
 SERVICE_ACCT_KEY_FILE=""
 
 MAKE_JAR=false
-PUSH_ARTIFACTORY=false
 RUN_DOCKER=false
 PRINT_HELP=false
 
@@ -44,9 +42,6 @@ while [ "$1" != "" ]; do
     case $1 in
         jar)
             MAKE_JAR=true
-            ;;
-        publish)
-            PUSH_ARTIFACTORY=true
             ;;
         -d | --docker)
             shift
@@ -110,15 +105,6 @@ function make_jar()
     fi
 }
 
-function artifactory_push()
-{
-    VAULT_TOKEN=${VAULT_TOKEN:-$(cat /etc/vault-token-dsde)}
-    ARTIFACTORY_USERNAME=dsdejenkins
-    ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN broadinstitute/dsde-toolbox vault read -field=password secret/dsp/accts/artifactory/dsdejenkins)
-    echo "Publishing to artifactory..."
-    docker run --rm -e GIT_HASH=$GIT_HASH -v $PWD:/$PROJECT -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier -w="/$PROJECT" -e ARTIFACTORY_USERNAME=$ARTIFACTORY_USERNAME -e ARTIFACTORY_PASSWORD=$ARTIFACTORY_PASSWORD sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16 /$PROJECT/core/src/bin/publishSnapshot.sh
-}
-
 function docker_cmd()
 {
     if [ $DOCKER_CMD = "build" ] || [ $DOCKER_CMD = "push" ]; then
@@ -149,10 +135,6 @@ function cleanup()
 
 if $MAKE_JAR; then
     make_jar
-fi
-
-if $PUSH_ARTIFACTORY; then
-    artifactory_push
 fi
 
 if $RUN_DOCKER; then

--- a/project/Artifactory.scala
+++ b/project/Artifactory.scala
@@ -1,5 +1,0 @@
-object Artifactory {
-//  val artifactoryHost = "broadinstitute.jfrog.io"
-//  val artifactory = s"https://$artifactoryHost/broadinstitute/"
-  val googleArtifactoryRegistry = "https://us-central1-maven.pkg.dev/dsp-artifact-registry/"
-}

--- a/project/Artifactory.scala
+++ b/project/Artifactory.scala
@@ -1,5 +1,5 @@
 object Artifactory {
-  val artifactoryHost = "broadinstitute.jfrog.io"
-  val artifactory = s"https://$artifactoryHost/broadinstitute/"
+//  val artifactoryHost = "broadinstitute.jfrog.io"
+//  val artifactory = s"https://$artifactoryHost/broadinstitute/"
   val googleArtifactoryRegistry = "https://us-central1-maven.pkg.dev/dsp-artifact-registry/"
 }

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -1,5 +1,5 @@
-import Artifactory._
-import sbt.Keys._
+//import Artifactory.*
+import sbt.Keys.*
 import sbt._
 
 /**
@@ -7,30 +7,46 @@ import sbt._
   */
 
 object Publishing {
-  private val buildTimestamp = System.currentTimeMillis() / 1000
+//  private val buildTimestamp = System.currentTimeMillis() / 1000
 
-  private def artifactoryResolver(isSnapshot: Boolean): Resolver = {
+  private val garBase = "artifactregistry://us-central1-maven.pkg.dev/dsp-artifact-registry/"
+
+  private def garResolver(): Resolver = {
+    val isSnapshot = sys.props.getOrElse("project.isSnapshot", "false").toBoolean
     val repoType = if (isSnapshot) "snapshot" else "release"
-    val repoUrl =
-      s"${artifactory}libs-$repoType-local;build.timestamp=$buildTimestamp"
-    val repoName = "artifactory-publish"
+    val repoUrl = s"${garBase}libs-$repoType-standard"
+    val repoName = "gar-publish"
     repoName at repoUrl
   }
 
-  private val artifactoryCredentials: Credentials = {
-    val username = sys.env.getOrElse("ARTIFACTORY_USERNAME", "")
-    val password = sys.env.getOrElse("ARTIFACTORY_PASSWORD", "")
-    Credentials("Artifactory Realm", artifactoryHost, username, password)
-  }
+//  private def artifactoryResolver(isSnapshot: Boolean): Resolver = {
+//    val repoType = if (isSnapshot) "snapshot" else "release"
+//    val repoUrl =
+//      s"${artifactory}libs-$repoType-local;build.timestamp=$buildTimestamp"
+//    val repoName = "artifactory-publish"
+//    repoName at repoUrl
+//  }
 
-  val publishSettings: Seq[Setting[_]] =
-    // we only publish to libs-release-local because of a bug in sbt that makes snapshots take
-    // priority over the local package cache. see here: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
-    Seq(
-      publishTo := Option(artifactoryResolver(false)),
-      credentials += artifactoryCredentials,
-      publishConfiguration := publishConfiguration.value.withOverwrite(true)
-    )
+//  private val artifactoryCredentials: Credentials = {
+//    val username = sys.env.getOrElse("ARTIFACTORY_USERNAME", "")
+//    val password = sys.env.getOrElse("ARTIFACTORY_PASSWORD", "")
+//    Credentials("Artifactory Realm", artifactoryHost, username, password)
+//  }
+
+  val publishSettings: Seq[Setting[_]] = Seq(
+    publishTo := Some(garResolver()), // Use release repo
+    Compile / publishArtifact := true,
+    Test / publishArtifact := true
+  )
+
+//  val publishSettings: Seq[Setting[_]] =
+//    // we only publish to libs-release-local because of a bug in sbt that makes snapshots take
+//    // priority over the local package cache. see here: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
+//    Seq(
+//      publishTo := Option(artifactoryResolver(false)),
+//      credentials += artifactoryCredentials,
+//      publishConfiguration := publishConfiguration.value.withOverwrite(true)
+//    )
 
   val noPublishSettings: Seq[Setting[_]] =
     Seq(

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -1,4 +1,3 @@
-//import Artifactory.*
 import sbt.Keys.*
 import sbt._
 
@@ -7,7 +6,6 @@ import sbt._
   */
 
 object Publishing {
-//  private val buildTimestamp = System.currentTimeMillis() / 1000
 
   private val garBase = "artifactregistry://us-central1-maven.pkg.dev/dsp-artifact-registry/"
 
@@ -19,34 +17,11 @@ object Publishing {
     repoName at repoUrl
   }
 
-//  private def artifactoryResolver(isSnapshot: Boolean): Resolver = {
-//    val repoType = if (isSnapshot) "snapshot" else "release"
-//    val repoUrl =
-//      s"${artifactory}libs-$repoType-local;build.timestamp=$buildTimestamp"
-//    val repoName = "artifactory-publish"
-//    repoName at repoUrl
-//  }
-
-//  private val artifactoryCredentials: Credentials = {
-//    val username = sys.env.getOrElse("ARTIFACTORY_USERNAME", "")
-//    val password = sys.env.getOrElse("ARTIFACTORY_PASSWORD", "")
-//    Credentials("Artifactory Realm", artifactoryHost, username, password)
-//  }
-
   val publishSettings: Seq[Setting[_]] = Seq(
     publishTo := Some(garResolver()), // Use release repo
     Compile / publishArtifact := true,
     Test / publishArtifact := true
   )
-
-//  val publishSettings: Seq[Setting[_]] =
-//    // we only publish to libs-release-local because of a bug in sbt that makes snapshots take
-//    // priority over the local package cache. see here: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
-//    Seq(
-//      publishTo := Option(artifactoryResolver(false)),
-//      credentials += artifactoryCredentials,
-//      publishConfiguration := publishConfiguration.value.withOverwrite(true)
-//    )
 
   val noPublishSettings: Seq[Setting[_]] =
     Seq(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,4 +1,3 @@
-import Artifactory._
 import CodeGeneration._
 import Compiling._
 import Dependencies._
@@ -11,8 +10,11 @@ import sbt._
 import sbtassembly.AssemblyPlugin.autoImport._
 import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtFilter
 
+
 //noinspection TypeAnnotation
 object Settings {
+  val googleArtifactoryRegistry = "https://us-central1-maven.pkg.dev/dsp-artifact-registry/"
+
   val proxyResolvers = List(
     "internal-maven-proxy" at googleArtifactoryRegistry + "maven-central"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,4 +10,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 
+addSbtPlugin("org.latestbit" % "sbt-gcs-plugin" % "1.14.0")
+
 addDependencyTreePlugin


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-593

Switches from publishing to jfrog to publishing to GAR.  Github actions are delegated to terra-github-workflows, which publishes to GCR, so the only thing necessary to change here was local/manual publishing.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
