### PR TITLE
CORE-600: use getV2WorkspaceContextAndPermissions in enableRequesterPaysForLinkedSAs

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -43,15 +43,6 @@ trait WorkspaceSupport {
         }
     }
 
-  def checkLock(workspace: Workspace, requiredAction: SamResourceAction): Future[Unit] = {
-    val actionsBlockedByLock =
-      Set(SamWorkspaceActions.write, SamWorkspaceActions.compute, SamWorkspaceActions.delete)
-    if (actionsBlockedByLock.contains(requiredAction) && workspace.isLocked)
-      Future.failed(LockedWorkspaceException(workspace.toWorkspaceName))
-    else
-      Future.successful(())
-  }
-
   // can't use withClonedAuthDomain because the Auth Domain -> no Auth Domain logic is different
   def authDomainCheck(sourceWorkspaceADs: Set[String], destWorkspaceADs: Set[String]): Boolean =
     // if the source has any auth domains, the dest must also *at least* have those auth domains
@@ -114,6 +105,15 @@ trait WorkspaceSupport {
         }
       }
     }
+
+  private def checkLock(workspace: Workspace, requiredAction: SamResourceAction): Future[Unit] = {
+    val actionsBlockedByLock =
+      Set(SamWorkspaceActions.write, SamWorkspaceActions.compute, SamWorkspaceActions.delete)
+    if (actionsBlockedByLock.contains(requiredAction) && workspace.isLocked)
+      Future.failed(LockedWorkspaceException(workspace.toWorkspaceName))
+    else
+      Future.successful(())
+  }
 
   private def userEnabledCheck: Future[Unit] =
     samDAO.getUserStatus(ctx) flatMap {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1756,15 +1756,7 @@ class WorkspaceService(
 
   def enableRequesterPaysForLinkedSAs(workspaceName: WorkspaceName): Future[Unit] =
     for {
-      maybeWorkspace <- dataSource.inTransaction(dataAccess =>
-        dataAccess.workspaceQuery.findV2WorkspaceByName(workspaceName)
-      )
-      workspace <- maybeWorkspace match {
-        case None            => Future.failed(NoSuchWorkspaceException(workspaceName))
-        case Some(workspace) => Future.successful(workspace)
-      }
-      _ <- accessCheck(workspace, SamWorkspaceActions.compute)
-      _ <- checkLock(workspace, SamWorkspaceActions.compute)
+      workspace <- getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.compute)
       _ <- requesterPaysSetupService.grantRequesterPaysToLinkedSAs(ctx.userInfo, workspace)
     } yield {}
 


### PR DESCRIPTION
Ticket: CORE-600

Hopefully the final refactor for CORE-600.

This rewrites `WorkspaceService.enableRequesterPaysForLinkedSAs` to use `getV2WorkspaceContextAndPermissions` instead of calling the individual steps of `getV2WorkspaceContextAndPermissions` directly.

Previously, `WorkspaceService.enableRequesterPaysForLinkedSAs` was implemented as:
1. findV2WorkspaceByName
2. accessCheck
3. checkLock

Now, it calls `getV2WorkspaceContextAndPermissions`, which is implemented as:
1. userEnabledCheck
2. findV2WorkspaceByName
3. accessCheck
4. checkLock

So, this adds an extra call to `userEnabledCheck`, but it consolidates and centralizes on `getV2WorkspaceContextAndPermissions` which is what pretty much every other API calls.