### PR TITLE
[CORE-580] Enable Compact Data Table Migration from Workspace Settings

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -73,7 +73,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
-import scala.language.{higherKinds, postfixOps}
+import scala.language.postfixOps
 
 object Boot extends IOApp with LazyLogging {
   override def run(
@@ -365,23 +365,26 @@ object Boot extends IOApp with LazyLogging {
 
       val workspaceSettingRepository = new WorkspaceSettingRepository(slickDataSource)
 
-      val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService =
-        new WorkspaceSettingService(_,
-                                    workspaceSettingRepository,
-                                    workspaceRepository,
-                                    gcsDAO,
-                                    samDAO,
-                                    appDependencies.googleStorageService
-        )(implicitly, IORuntime.global)
-
-      val entityServiceConstructor: RawlsRequestContext => EntityService = EntityService.constructor(
+      // Define both constructors using lazy evaluation to break the circular dependency
+      lazy val entityServiceConstructor: RawlsRequestContext => EntityService = EntityService.constructor(
         slickDataSource,
         samDAO,
         workbenchMetricBaseName = metricsPrefix,
         entityManager,
         appConfigManager.conf.getInt("entities.pageSizeLimit"),
-        Option(workspaceSettingServiceConstructor)
+        Some(workspaceSettingServiceConstructor)
       )
+
+      lazy val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService =
+        (ctx: RawlsRequestContext) =>
+          new WorkspaceSettingService(ctx,
+                                      workspaceSettingRepository,
+                                      workspaceRepository,
+                                      gcsDAO,
+                                      samDAO,
+                                      appDependencies.googleStorageService,
+                                      entityServiceConstructor(ctx)
+          )(implicitly, IORuntime.global)
 
       val workspaceServiceConstructor: RawlsRequestContext => WorkspaceService = WorkspaceService.constructor(
         slickDataSource,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.rawls.entities.base.{AuditLoggingEntityProvider, 
 import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.entities.local.{LocalEntityProvider, LocalEntityProviderBuilder}
 import org.broadinstitute.dsde.rawls.entities.compact.{CompactEntityProvider, CompactEntityProviderBuilder}
+import org.broadinstitute.dsde.rawls.model.CompactDataTablesState.DONE
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.CompactDataTables
 import org.broadinstitute.dsde.rawls.model.{CloudPlatform, CompactDataTablesSetting, ErrorReport, WorkspaceType}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceSettingRepository
@@ -64,7 +65,7 @@ class EntityManager(providerBuilders: Set[EntityProviderBuilder[_ <: EntityProvi
       workspaceSettingRepository.getWorkspaceSettingOfType(requestArguments.workspace.workspaceIdAsUUID,
                                                            CompactDataTables
       ) map {
-        case Some(qs: CompactDataTablesSetting) => qs.config.enabled
+        case Some(qs: CompactDataTablesSetting) => qs.config.enabled || qs.config.state == DONE
         case _                                  => false
       }
     val targetTagFuture = compactDataTables map {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -586,6 +586,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
   def quicksilverMigration(workspaceName: WorkspaceName,
                            cleanup: Boolean = false,
                            batchSize: Int = 50000,
+                           enableSetting: Boolean = true,
                            updateSettings: Boolean = true
   ): Future[QuicksilverMigrationResult] =
     traceFutureWithParent("EntityService.quicksilverMigration", ctx) { s =>
@@ -604,75 +605,82 @@ class EntityService(protected val ctx: RawlsRequestContext,
         settings <- traceFutureWithParent("getWorkspaceSettings", s) { _ =>
           workspaceSettingService.getWorkspaceSettings(workspaceName)
         }
-        _ = if (
-          settings
-            .find(_.isInstanceOf[CompactDataTablesSetting])
-            .asInstanceOf[Option[CompactDataTablesSetting]]
-            .exists(_.config.enabled)
-        ) {
+        alreadyEnabled = settings
+          .find(_.isInstanceOf[CompactDataTablesSetting])
+          .asInstanceOf[Option[CompactDataTablesSetting]]
+          .exists(_.config.enabled)
+
+        _ = if (alreadyEnabled && enableSetting) {
           throw new RawlsExceptionWithErrorReport(ErrorReport("Quicksilver already enabled for this workspace"))
         }
 
-        // start a transaction; here's where we do a bunch of writes
-        userResult <- dataSource.inTransaction { dataAccess =>
-          val shardId: String = dataAccess.determineShard(workspaceId)
-
-          val stopwatch = StopWatch.createStarted()
-
-          logger.info(
-            s"Quicksilver migration $workspaceId: starting (${stopwatch.formatTime()}) ..."
-          )
-
-          withIncreasedSortMemory(dataAccess) {
-            for {
-              // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
-              // for each batch. later queries will use those boundaries to migrate entities in batches, which
-              // prevents the temp tables from growing too large.
-              batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
-              // niceties for logging
-              indexedBoundaries = batchBoundaries.zipWithIndex
-
-              // for each batch, migrate the entities in that batch
-              updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
-                quicksilverMigrateBatch(workspaceId,
-                                        shardId,
-                                        boundary,
-                                        dataAccess,
-                                        idx,
-                                        indexedBoundaries.size,
-                                        stopwatch,
-                                        s
-                )
-              })
-              numEntitiesUpdated = updateCounts.sum
-
-              (numAttributesDeleted, numEntitiesDeleted) <-
-                if (cleanup) {
-                  // hard delete legacy data if requested
-                  hardDeleteLegacyData(workspaceId, shardId, dataAccess)
-                } else {
-                  // otherwise, just log that we did not delete legacy data
-                  DBIO.successful((0, 0))
-                }
-
-              _ = logger.info(
-                s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
-              )
-            } yield QuicksilverMigrationResult(numEntitiesUpdated, numEntitiesDeleted, numAttributesDeleted)
-          }
-
+        _ = if (alreadyEnabled && !enableSetting) {
+          throw new RawlsExceptionWithErrorReport(ErrorReport("Quicksilver cannot be disabled for this workspace"))
         }
+
+        // start a transaction; here's where we do a bunch of writes
+        userResult <-
+          if (!alreadyEnabled && enableSetting) {
+            dataSource.inTransaction { dataAccess =>
+              val shardId: String = dataAccess.determineShard(workspaceId)
+
+              val stopwatch = StopWatch.createStarted()
+
+              logger.info(
+                s"Quicksilver migration $workspaceId: starting (${stopwatch.formatTime()}) ..."
+              )
+
+              withIncreasedSortMemory(dataAccess) {
+                for {
+                  // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
+                  // for each batch. later queries will use those boundaries to migrate entities in batches, which
+                  // prevents the temp tables from growing too large.
+                  batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
+                  // niceties for logging
+                  indexedBoundaries = batchBoundaries.zipWithIndex
+
+                  // for each batch, migrate the entities in that batch
+                  updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
+                    quicksilverMigrateBatch(workspaceId,
+                                            shardId,
+                                            boundary,
+                                            dataAccess,
+                                            idx,
+                                            indexedBoundaries.size,
+                                            stopwatch,
+                                            s
+                    )
+                  })
+                  numEntitiesUpdated = updateCounts.sum
+
+                  (numAttributesDeleted, numEntitiesDeleted) <-
+                    if (cleanup) {
+                      // hard delete legacy data if requested
+                      hardDeleteLegacyData(workspaceId, shardId, dataAccess)
+                    } else {
+                      // otherwise, just log that we did not delete legacy data
+                      DBIO.successful((0, 0))
+                    }
+
+                  _ = logger.info(
+                    s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
+                  )
+                } yield QuicksilverMigrationResult(numEntitiesUpdated, numEntitiesDeleted, numAttributesDeleted)
+              }
+            }
+          } else
+            Future.successful(QuicksilverMigrationResult(0, 0, 0))
 
         // finally, change the workspace to be quicksilver-enabled
         _ <- traceFutureWithParent("setWorkspaceSettings", s) { _ =>
-          if (!updateSettings) {
+          if (!updateSettings)
             // if this is a settings migration, we don't want to set the setting again
             Future.successful(())
-          } else
-            // otherwise, set the CompactDataTablesSetting to enabled
+          else
+            // otherwise, set the CompactDataTablesSetting
             workspaceSettingService.setWorkspaceSettings(
               workspaceName,
-              List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
+              List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = enableSetting)))
             )
         }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -35,8 +35,6 @@ import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, Json
 import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceSettingService}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValidationUtils}
 import slick.dbio.{DBIO, DBIOAction, Effect, NoStream}
-import spray.json.DefaultJsonProtocol.jsonFormat3
-import spray.json.RootJsonFormat
 
 import java.sql.SQLException
 import java.util.UUID
@@ -581,7 +579,10 @@ class EntityService(protected val ctx: RawlsRequestContext,
     * The migration relies on temp tables; the batchSize setting ensures the temp tables do not grow too large.
     *
     * @param workspaceName the name of the workspace to migrate
+    * @param cleanup if true, legacy attributes and entities will be hard-deleted after migration;
     * @param batchSize the number of entities to migrate in a single batch; defaults to 50,000
+    * @param enableSetting if true, the CompactDataTables setting will be enabled after migration;
+    * @param updateSettings if true, ensure to update setting after migration;
     */
   def quicksilverMigration(workspaceName: WorkspaceName,
                            cleanup: Boolean = false,
@@ -591,7 +592,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
   ): Future[QuicksilverMigrationResult] =
     traceFutureWithParent("EntityService.quicksilverMigration", ctx) { s =>
       for {
-        // verify owner of workspace.
+        // verify the owner of the workspace
         workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", s) { _ =>
           getV2WorkspaceContextAndPermissions(workspaceName,
                                               SamWorkspaceActions.own,
@@ -600,92 +601,170 @@ class EntityService(protected val ctx: RawlsRequestContext,
         }
         workspaceId = workspaceContext.workspaceIdAsUUID
 
-        // confirm if this is already a quicksilver workspace by checking settings
+        // check workspace settings and validate migration state
         workspaceSettingService = workspaceSettingServiceConstructor.get.apply(ctx)
         settings <- traceFutureWithParent("getWorkspaceSettings", s) { _ =>
           workspaceSettingService.getWorkspaceSettings(workspaceName)
         }
-        alreadyEnabled = settings
-          .find(_.isInstanceOf[CompactDataTablesSetting])
-          .asInstanceOf[Option[CompactDataTablesSetting]]
-          .exists(_.config.enabled)
+        alreadyEnabled = isQuicksilverEnabled(settings)
+        isMigrating = isQuicksilverMigrating(settings)
 
-        _ = if (alreadyEnabled && enableSetting) {
-          throw new RawlsExceptionWithErrorReport(ErrorReport("Quicksilver already enabled for this workspace"))
-        }
+        // validate current state
+        _ <- validateMigrationState(enableSetting, alreadyEnabled, isMigrating)
 
-        _ = if (alreadyEnabled && !enableSetting) {
-          throw new RawlsExceptionWithErrorReport(ErrorReport("Quicksilver cannot be disabled for this workspace"))
-        }
-
-        // start a transaction; here's where we do a bunch of writes
+        // perform migration if needed
+        shouldMigrate = !alreadyEnabled && enableSetting && !isMigrating
         userResult <-
-          if (!alreadyEnabled && enableSetting) {
-            dataSource.inTransaction { dataAccess =>
-              val shardId: String = dataAccess.determineShard(workspaceId)
-
-              val stopwatch = StopWatch.createStarted()
-
-              logger.info(
-                s"Quicksilver migration $workspaceId: starting (${stopwatch.formatTime()}) ..."
-              )
-
-              withIncreasedSortMemory(dataAccess) {
-                for {
-                  // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
-                  // for each batch. later queries will use those boundaries to migrate entities in batches, which
-                  // prevents the temp tables from growing too large.
-                  batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
-                  // niceties for logging
-                  indexedBoundaries = batchBoundaries.zipWithIndex
-
-                  // for each batch, migrate the entities in that batch
-                  updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
-                    quicksilverMigrateBatch(workspaceId,
-                                            shardId,
-                                            boundary,
-                                            dataAccess,
-                                            idx,
-                                            indexedBoundaries.size,
-                                            stopwatch,
-                                            s
-                    )
-                  })
-                  numEntitiesUpdated = updateCounts.sum
-
-                  (numAttributesDeleted, numEntitiesDeleted) <-
-                    if (cleanup) {
-                      // hard delete legacy data if requested
-                      hardDeleteLegacyData(workspaceId, shardId, dataAccess)
-                    } else {
-                      // otherwise, just log that we did not delete legacy data
-                      DBIO.successful((0, 0))
-                    }
-
-                  _ = logger.info(
-                    s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
-                  )
-                } yield QuicksilverMigrationResult(numEntitiesUpdated, numEntitiesDeleted, numAttributesDeleted)
-              }
-            }
-          } else
+          if (shouldMigrate) {
+            performActualMigration(workspaceName, workspaceId, enableSetting, cleanup, batchSize, s)
+          } else {
             Future.successful(QuicksilverMigrationResult(0, 0, 0))
+          }
 
-        // finally, change the workspace to be quicksilver-enabled
-        _ <- traceFutureWithParent("setWorkspaceSettings", s) { _ =>
-          if (!updateSettings)
-            // if this is a settings migration, we don't want to set the setting again
+        // update settings
+        _ <-
+          if (updateSettings) {
+            val targetState = if (enableSetting) CompactDataTablesState.DONE else CompactDataTablesState.NONE
+            setCompactDataTablesState(workspaceName, enableSetting, targetState, s)
+          } else {
             Future.successful(())
-          else
-            // otherwise, set the CompactDataTablesSetting
-            workspaceSettingService.setWorkspaceSettings(
-              workspaceName,
-              List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = enableSetting)))
-            )
-        }
+          }
 
-        // return a count of entities updated
       } yield userResult
+    }
+
+  /**
+   * Check if Quicksilver (CompactDataTables) is enabled for the workspace.
+   * @param settings the list of workspace settings to check
+   * @return
+   */
+  private def isQuicksilverEnabled(settings: List[WorkspaceSetting]): Boolean =
+    settings.exists {
+      case setting: CompactDataTablesSetting =>
+        setting.config.enabled || setting.config.state == CompactDataTablesState.DONE
+      case _ => false
+    }
+
+  /**
+   * Check if Quicksilver (CompactDataTables) is currently migrating for the workspace.
+   * @param settings the list of workspace settings to check
+   * @return
+   */
+  private def isQuicksilverMigrating(settings: List[WorkspaceSetting]): Boolean =
+    settings.exists {
+      case setting: CompactDataTablesSetting => setting.config.state == CompactDataTablesState.MIGRATING
+      case _                                 => false
+    }
+
+  /**
+   * Validate the current migration state of the workspace.
+   * @param enableSetting if true, the migration is being enabled; if false, it is being disabled.
+   * @param alreadyEnabled if true, CompactDataTablesSetting is already enabled for the workspace.
+   * @param isMigrating if true, CompactDataTablesSetting is currently migrating for the workspace.
+   * @return
+   */
+  private def validateMigrationState(enableSetting: Boolean,
+                                     alreadyEnabled: Boolean,
+                                     isMigrating: Boolean
+  ): Future[Unit] =
+    if (alreadyEnabled && enableSetting) {
+      Future.failed(new RawlsExceptionWithErrorReport(ErrorReport("Quicksilver already enabled for this workspace")))
+    } else if (alreadyEnabled && !enableSetting) {
+      Future.failed(new RawlsExceptionWithErrorReport(ErrorReport("Quicksilver cannot be disabled for this workspace")))
+    } else if (isMigrating) {
+      Future.failed(
+        new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, "Quicksilver migration already in progress for this workspace")
+        )
+      )
+    } else {
+      Future.successful(())
+    }
+
+  /**
+     * Perform the actual migration of entity data from legacy to compact format.
+     * This method handles the migration in batches, updates the workspace settings,
+     * and performs cleanup if requested.
+     */
+  private def performActualMigration(workspaceName: WorkspaceName,
+                                     workspaceId: UUID,
+                                     enableSetting: Boolean,
+                                     cleanup: Boolean,
+                                     batchSize: Int,
+                                     parentContext: RawlsRequestContext
+  ): Future[QuicksilverMigrationResult] =
+
+    setCompactDataTablesState(workspaceName, enableSetting, CompactDataTablesState.MIGRATING, parentContext)
+      .flatMap { _ =>
+        dataSource.inTransaction { dataAccess =>
+          val shardId: String = dataAccess.determineShard(workspaceId)
+          val stopwatch = StopWatch.createStarted()
+
+          logger.info(s"Quicksilver migration $workspaceId: starting (${stopwatch.formatTime()}) ...")
+
+          withIncreasedSortMemory(dataAccess) {
+            for {
+              batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
+              indexedBoundaries = batchBoundaries.zipWithIndex
+
+              updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
+                quicksilverMigrateBatch(workspaceId,
+                                        shardId,
+                                        boundary,
+                                        dataAccess,
+                                        idx,
+                                        indexedBoundaries.size,
+                                        stopwatch,
+                                        parentContext
+                )
+              })
+              numEntitiesUpdated = updateCounts.sum
+
+              (numAttributesDeleted, numEntitiesDeleted) <-
+                if (cleanup) {
+                  hardDeleteLegacyData(workspaceId, shardId, dataAccess)
+                } else {
+                  DBIO.successful((0, 0))
+                }
+
+              _ = logger.info(
+                s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
+              )
+            } yield QuicksilverMigrationResult(numEntitiesUpdated, numEntitiesDeleted, numAttributesDeleted)
+          }
+        }
+      }
+      .recoverWith { case ex =>
+        setCompactDataTablesState(workspaceName, !enableSetting, CompactDataTablesState.ERROR, parentContext)
+          .flatMap(_ => Future.failed(ex))
+      }
+
+  /**
+   * Set the CompactDataTables setting for a workspace.
+   * This method is used to enable or disable the CompactDataTables feature and set its state.
+   */
+  private def setCompactDataTablesState(workspaceName: WorkspaceName,
+                                        enabled: Boolean,
+                                        state: CompactDataTablesState,
+                                        parentContext: RawlsRequestContext
+  ): Future[Unit] =
+    workspaceSettingServiceConstructor match {
+      case Some(serviceConstructor) =>
+        val workspaceSettingService = serviceConstructor(ctx)
+        traceFutureWithParent("setWorkspaceSettings", parentContext) { _ =>
+          workspaceSettingService
+            .setWorkspaceSettings(
+              workspaceName,
+              List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = enabled, state = state)))
+            )
+            .map(_ => ())
+        }
+      case None =>
+        Future.failed(
+          new RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.InternalServerError, "Workspace setting service not available")
+          )
+        )
     }
 
   private def hardDeleteLegacyData(workspaceId: UUID,
@@ -810,5 +889,4 @@ class EntityService(protected val ctx: RawlsRequestContext,
         )
       }
   }
-
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -585,7 +585,8 @@ class EntityService(protected val ctx: RawlsRequestContext,
     */
   def quicksilverMigration(workspaceName: WorkspaceName,
                            cleanup: Boolean = false,
-                           batchSize: Int = 50000
+                           batchSize: Int = 50000,
+                           updateSettings: Boolean = true
   ): Future[QuicksilverMigrationResult] =
     traceFutureWithParent("EntityService.quicksilverMigration", ctx) { s =>
       for {
@@ -664,10 +665,15 @@ class EntityService(protected val ctx: RawlsRequestContext,
 
         // finally, change the workspace to be quicksilver-enabled
         _ <- traceFutureWithParent("setWorkspaceSettings", s) { _ =>
-          workspaceSettingService.setWorkspaceSettings(
-            workspaceName,
-            List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
-          )
+          if (!updateSettings) {
+            // if this is a settings migration, we don't want to set the setting again
+            Future.successful(())
+          } else
+            // otherwise, set the CompactDataTablesSetting to enabled
+            workspaceSettingService.setWorkspaceSettings(
+              workspaceName,
+              List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
+            )
         }
 
         // return a count of entities updated

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -127,12 +127,7 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
           case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) => None
           case UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(_))         => None
           case PubliclyReadableSetting(PubliclyReadableConfig(_))                             => None
-          case CompactDataTablesSetting(CompactDataTablesConfig(enabled)) =>
-            if (!enabled) {
-              Some(validationErrorReport(setting.settingType, "this setting cannot be disabled once enabled"))
-            } else {
-              None
-            }
+          case CompactDataTablesSetting(CompactDataTablesConfig(_))                           => None
         }
       }
 
@@ -204,8 +199,8 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
         case PubliclyReadableSetting(PubliclyReadableConfig(enabled)) =>
           applyPublicReadableSetting(workspace, enabled)
 
-        case CompactDataTablesSetting(CompactDataTablesConfig(_)) =>
-          applyCompactDataTablesSetting(workspace)
+        case CompactDataTablesSetting(CompactDataTablesConfig(enabled)) =>
+          applyCompactDataTablesSetting(WorkspaceName(workspace.namespace, workspace.name), enabled)
 
         // SeparateSubmissionFinalOutputsSetting, UseCromwellGcpBatchBackendSetting, and CompactDataTablesSetting
         // are not bucket settings, so we do not need to apply anything here
@@ -280,12 +275,10 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
   /**
    * Call to handle entity attributes migration when compact data tables setting enabled.
    */
-  private def applyCompactDataTablesSetting(workspace: Workspace): Future[Unit] =
+  private def applyCompactDataTablesSetting(workspaceName: WorkspaceName, enabled: Boolean): Future[Unit] =
     Future {
       entityService
-        .quicksilverMigration(workspaceName = WorkspaceName(workspace.namespace, workspace.name),
-                              updateSettings = false
-        )
+        .quicksilverMigration(workspaceName = workspaceName, enableSetting = enabled, updateSettings = false)
         .map(_ => ())
         .recover { case e: Exception =>
           throw new RawlsExceptionWithErrorReport(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -11,6 +11,7 @@ import com.google.cloud.storage.BucketInfo.{LifecycleRule, SoftDeletePolicy}
 import com.google.cloud.storage.Storage
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
+import org.broadinstitute.dsde.rawls.entities.EntityService
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig._
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.WorkspaceSettingType
 import org.broadinstitute.dsde.rawls.model.{
@@ -34,7 +35,6 @@ import org.broadinstitute.dsde.rawls.model.{
 import org.broadinstitute.dsde.rawls.util.WorkspaceSupport
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.google2.{GoogleStorageService, StorageRole}
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 
 import java.time.Duration
@@ -47,7 +47,8 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
                               val workspaceRepository: WorkspaceRepository,
                               gcsDAO: GoogleServicesDAO,
                               val samDAO: SamDAO,
-                              googleStorageService: GoogleStorageService[IO]
+                              googleStorageService: GoogleStorageService[IO],
+                              entityService: EntityService
 )(implicit protected val executionContext: ExecutionContext, ioRuntime: IORuntime)
     extends WorkspaceSupport
     with LazyLogging {
@@ -126,7 +127,12 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
           case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) => None
           case UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(_))         => None
           case PubliclyReadableSetting(PubliclyReadableConfig(_))                             => None
-          case CompactDataTablesSetting(CompactDataTablesConfig(_))                           => None
+          case CompactDataTablesSetting(CompactDataTablesConfig(enabled)) =>
+            if (!enabled) {
+              Some(validationErrorReport(setting.settingType, "this setting cannot be disabled once enabled"))
+            } else {
+              None
+            }
         }
       }
 
@@ -142,7 +148,7 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
       * and return None. If the setting fails to apply, remove the failed setting from the database
       * and return the setting type with an error report. If the setting is not supported, throw an
       * exception. We make more trips to the database here than necessary, but we support a small
-      * number of setting types and it's easier to reason about this way.
+      * number of setting types, and it's easier to reason about this way.
       */
     def applySetting(workspace: Workspace,
                      setting: WorkspaceSetting
@@ -198,11 +204,11 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
         case PubliclyReadableSetting(PubliclyReadableConfig(enabled)) =>
           applyPublicReadableSetting(workspace, enabled)
 
+        case CompactDataTablesSetting(CompactDataTablesConfig(_)) =>
+          applyCompactDataTablesSetting(workspace)
+
         // SeparateSubmissionFinalOutputsSetting, UseCromwellGcpBatchBackendSetting, and CompactDataTablesSetting
         // are not bucket settings, so we do not need to apply anything here
-
-        case CompactDataTablesSetting(CompactDataTablesConfig(_)) =>
-          Future.successful(())
 
         case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) =>
           Future.successful(())
@@ -232,7 +238,7 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
   }
 
   /**
-   * Calls sam to update the reader policy then update the buckets IAM to add or remove the allUsers group
+   * Calls sam to update the reader policy then update the bucket's IAM to add or remove the allUsers group
    */
   private def applyPublicReadableSetting(workspace: Workspace, enabled: Boolean): Future[Unit] =
     for {
@@ -270,4 +276,17 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
         }
       _ <- iamPolicyAction.compile.drain.unsafeToFuture()
     } yield ()
+
+  /**
+   * Call to handle entity attributes migration when compact data tables setting enabled.
+   */
+  private def applyCompactDataTablesSetting(workspace: Workspace): Future[Unit] =
+    entityService
+      .quicksilverMigration(workspaceName = WorkspaceName(workspace.namespace, workspace.name), updateSettings = false)
+      .map(_ => ())
+      .recover { case e: Exception =>
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.InternalServerError, s"Quicksilver migration failed: ${e.getMessage}")
+        )
+      }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -281,12 +281,16 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
    * Call to handle entity attributes migration when compact data tables setting enabled.
    */
   private def applyCompactDataTablesSetting(workspace: Workspace): Future[Unit] =
-    entityService
-      .quicksilverMigration(workspaceName = WorkspaceName(workspace.namespace, workspace.name), updateSettings = false)
-      .map(_ => ())
-      .recover { case e: Exception =>
-        throw new RawlsExceptionWithErrorReport(
-          ErrorReport(StatusCodes.InternalServerError, s"Quicksilver migration failed: ${e.getMessage}")
+    Future {
+      entityService
+        .quicksilverMigration(workspaceName = WorkspaceName(workspace.namespace, workspace.name),
+                              updateSettings = false
         )
-      }
+        .map(_ => ())
+        .recover { case e: Exception =>
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.InternalServerError, s"Quicksilver migration failed: ${e.getMessage}")
+          )
+        }
+    }.flatten
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -127,7 +127,7 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
           case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) => None
           case UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(_))         => None
           case PubliclyReadableSetting(PubliclyReadableConfig(_))                             => None
-          case CompactDataTablesSetting(CompactDataTablesConfig(_))                           => None
+          case CompactDataTablesSetting(CompactDataTablesConfig(_, _))                        => None
         }
       }
 
@@ -199,7 +199,7 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
         case PubliclyReadableSetting(PubliclyReadableConfig(enabled)) =>
           applyPublicReadableSetting(workspace, enabled)
 
-        case CompactDataTablesSetting(CompactDataTablesConfig(enabled)) =>
+        case CompactDataTablesSetting(CompactDataTablesConfig(enabled, _)) =>
           applyCompactDataTablesSetting(WorkspaceName(workspace.namespace, workspace.name), enabled)
 
         // SeparateSubmissionFinalOutputsSetting, UseCromwellGcpBatchBackendSetting, and CompactDataTablesSetting

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -103,7 +103,8 @@ class EntityServiceCompactMigrationSpec
         new WorkspaceRepository(dataSource),
         new MockGoogleServicesDAO("groupsPrefix"),
         samDAO,
-        googleStorageService
+        googleStorageService,
+        entityService
       )(executionContext, global)
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -273,15 +273,16 @@ trait ApiServiceSpec
       new RequesterPaysSetupServiceImpl(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
 
     override val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService =
-      new WorkspaceSettingService(
-        _,
-        new WorkspaceSettingRepository(slickDataSource),
-        new WorkspaceRepository(slickDataSource),
-        gcsDAO,
-        samDAO,
-        mock[GoogleStorageService[IO]],
-        mock[EntityService]
-      )
+      ctx =>
+        new WorkspaceSettingService(
+          ctx,
+          new WorkspaceSettingRepository(slickDataSource),
+          new WorkspaceRepository(slickDataSource),
+          gcsDAO,
+          samDAO,
+          mock[GoogleStorageService[IO]],
+          entityServiceConstructor(ctx)
+        )
 
     val entityManager = EntityManager.defaultEntityManager(
       dataSource,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -273,12 +273,14 @@ trait ApiServiceSpec
       new RequesterPaysSetupServiceImpl(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
 
     override val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService =
-      new WorkspaceSettingService(_,
-                                  new WorkspaceSettingRepository(slickDataSource),
-                                  new WorkspaceRepository(slickDataSource),
-                                  gcsDAO,
-                                  samDAO,
-                                  mock[GoogleStorageService[IO]]
+      new WorkspaceSettingService(
+        _,
+        new WorkspaceSettingRepository(slickDataSource),
+        new WorkspaceRepository(slickDataSource),
+        gcsDAO,
+        samDAO,
+        mock[GoogleStorageService[IO]],
+        mock[EntityService]
       )
 
     val entityManager = EntityManager.defaultEntityManager(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -8,13 +8,16 @@ import cats.effect.unsafe.implicits.global
 import com.google.cloud.Identity
 import com.google.cloud.storage.BucketInfo.{LifecycleRule, SoftDeletePolicy}
 import com.google.cloud.storage.BucketInfo.LifecycleRule.{LifecycleAction, LifecycleCondition}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.QuicksilverMigrationResult
 import org.broadinstitute.dsde.rawls.{
   NoSuchWorkspaceException,
   RawlsExceptionWithErrorReport,
   WorkspaceAccessDeniedException
 }
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
+import org.broadinstitute.dsde.rawls.entities.EntityService
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
+  CompactDataTablesConfig,
   GcpBucketLifecycleAction,
   GcpBucketLifecycleCondition,
   GcpBucketLifecycleConfig,
@@ -43,6 +46,7 @@ import org.broadinstitute.dsde.rawls.model.{
   UseCromwellGcpBatchBackendSetting,
   UserInfo,
   Workspace,
+  WorkspaceName,
   WorkspaceSettingTypes
 }
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
@@ -79,14 +83,16 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     workspaceRepository: WorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS),
     gcsDAO: GoogleServicesDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
     samDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS),
-    googleStorageService: GoogleStorageService[IO] = mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS)
+    googleStorageService: GoogleStorageService[IO] = mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS),
+    entityService: EntityService = mock[EntityService](RETURNS_SMART_NULLS)
   ): WorkspaceSettingService =
     new WorkspaceSettingService(ctx,
                                 workspaceSettingRepository,
                                 workspaceRepository,
                                 gcsDAO,
                                 samDAO,
-                                googleStorageService
+                                googleStorageService,
+                                entityService
     )
 
   val workspace: Workspace = Workspace(
@@ -725,6 +731,23 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     assert(exception.errorReport.causes.exists(_.message.matches("Invalid GcpBucketSoftDelete.*retention duration.*")))
   }
 
+  it should "not allow disabling CompactDataTables setting once enabled" in {
+    val disableCompactDataTablesSetting = CompactDataTablesSetting(CompactDataTablesConfig(false))
+
+    val service = workspaceSettingServiceConstructor()
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(service.setWorkspaceSettings(workspace.toWorkspaceName, List(disableCompactDataTablesSetting)),
+                   Duration.Inf
+      )
+    }
+    exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
+    exception.errorReport.message should include("Invalid settings requested.")
+    exception.errorReport.causes should contain theSameElementsAs List(
+      ErrorReport("Invalid CompactDataTables configuration: this setting cannot be disabled once enabled.")
+    )
+  }
+
   "publicly readable setting" should "set public in sam and add all users to bucket" in {
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
@@ -966,5 +989,127 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     result.successes shouldEqual List.empty
     result.failures.keys should contain theSameElementsAs List(WorkspaceSettingTypes.PubliclyReadable)
     result.failures(WorkspaceSettingTypes.PubliclyReadable).statusCode shouldBe Some(StatusCodes.Forbidden)
+  }
+
+  "Compact Data Tables setting" should "allow enabling CompactDataTables setting" in {
+    val workspaceId = workspace.workspaceIdAsUUID
+    val workspaceName = workspace.toWorkspaceName
+    val enableCompactDataTablesSetting = CompactDataTablesSetting(CompactDataTablesConfig(true))
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
+
+    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
+    when(workspaceSettingRepository.getWorkspaceSettings(workspaceId)).thenReturn(Future.successful(List.empty))
+    when(
+      workspaceSettingRepository.createWorkspaceSettingsRecords(workspaceId,
+                                                                List(enableCompactDataTablesSetting),
+                                                                defaultRequestContext.userInfo.userSubjectId
+      )
+    ).thenReturn(Future.successful(List(enableCompactDataTablesSetting)))
+    when(
+      workspaceSettingRepository.markWorkspaceSettingApplied(workspaceId, enableCompactDataTablesSetting.settingType)
+    )
+      .thenReturn(Future.successful(1))
+
+    val samDAO = mock[SamDAO]
+    when(samDAO.getUserStatus(any()))
+      .thenReturn(Future.successful(Option(SamUserStatusResponse("fake_user_id", "user@example.com", true))))
+    when(
+      samDAO.userHasAction(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceId.toString),
+        ArgumentMatchers.eq(SamWorkspaceActions.writeSettings),
+        any()
+      )
+    ).thenReturn(Future.successful(true))
+
+    val entityService = mock[EntityService]
+    when(
+      entityService.quicksilverMigration(workspaceName = WorkspaceName(workspace.namespace, workspace.name),
+                                         updateSettings = false
+      )
+    )
+      .thenReturn(Future.successful(QuicksilverMigrationResult(2, 2, 2)))
+    when(
+      entityService.quicksilverMigration(
+        ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
+        any[Boolean],
+        any[Int],
+        ArgumentMatchers.eq(false)
+      )
+    ).thenReturn(Future.successful(QuicksilverMigrationResult(2, 2, 2)))
+
+    val service =
+      workspaceSettingServiceConstructor(samDAO = samDAO,
+                                         workspaceRepository = workspaceRepository,
+                                         workspaceSettingRepository = workspaceSettingRepository,
+                                         entityService = entityService
+      )
+
+    val res =
+      Await.result(service.setWorkspaceSettings(workspaceName, List(enableCompactDataTablesSetting)), Duration.Inf)
+    res.successes should contain theSameElementsAs List(enableCompactDataTablesSetting)
+    res.failures shouldEqual Map.empty
+    verify(entityService).quicksilverMigration(
+      ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
+      any[Boolean],
+      any[Int],
+      ArgumentMatchers.eq(false)
+    )
+  }
+
+  it should "handle quicksilver migration failure for CompactDataTables setting" in {
+    val workspaceId = workspace.workspaceIdAsUUID
+    val workspaceName = workspace.toWorkspaceName
+    val enableCompactDataTablesSetting = CompactDataTablesSetting(CompactDataTablesConfig(true))
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
+
+    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
+    when(workspaceSettingRepository.getWorkspaceSettings(workspaceId)).thenReturn(Future.successful(List.empty))
+    when(
+      workspaceSettingRepository.createWorkspaceSettingsRecords(workspaceId,
+                                                                List(enableCompactDataTablesSetting),
+                                                                defaultRequestContext.userInfo.userSubjectId
+      )
+    ).thenReturn(Future.successful(List(enableCompactDataTablesSetting)))
+    when(workspaceSettingRepository.removePendingSetting(workspaceId, enableCompactDataTablesSetting.settingType))
+      .thenReturn(Future.successful(1))
+
+    val samDAO = mock[SamDAO]
+    when(samDAO.getUserStatus(any()))
+      .thenReturn(Future.successful(Option(SamUserStatusResponse("fake_user_id", "user@example.com", true))))
+    when(
+      samDAO.userHasAction(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceId.toString),
+        ArgumentMatchers.eq(SamWorkspaceActions.writeSettings),
+        any()
+      )
+    ).thenReturn(Future.successful(true))
+
+    val entityService = mock[EntityService]
+    when(
+      entityService.quicksilverMigration(workspaceName = WorkspaceName(workspace.namespace, workspace.name),
+                                         updateSettings = false
+      )
+    )
+      .thenReturn(Future.failed(new Exception("Migration failed")))
+
+    val service =
+      workspaceSettingServiceConstructor(samDAO = samDAO,
+                                         workspaceRepository = workspaceRepository,
+                                         workspaceSettingRepository = workspaceSettingRepository,
+                                         entityService = entityService
+      )
+
+    val res =
+      Await.result(service.setWorkspaceSettings(workspaceName, List(enableCompactDataTablesSetting)), Duration.Inf)
+    res.successes shouldEqual List.empty
+    res.failures(WorkspaceSettingTypes.CompactDataTables).message should include("Migration failed")
+
+    verify(workspaceSettingRepository).removePendingSetting(workspaceId, enableCompactDataTablesSetting.settingType)
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -731,23 +731,6 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     assert(exception.errorReport.causes.exists(_.message.matches("Invalid GcpBucketSoftDelete.*retention duration.*")))
   }
 
-  it should "not allow disabling CompactDataTables setting once enabled" in {
-    val disableCompactDataTablesSetting = CompactDataTablesSetting(CompactDataTablesConfig(false))
-
-    val service = workspaceSettingServiceConstructor()
-
-    val exception = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.setWorkspaceSettings(workspace.toWorkspaceName, List(disableCompactDataTablesSetting)),
-                   Duration.Inf
-      )
-    }
-    exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
-    exception.errorReport.message should include("Invalid settings requested.")
-    exception.errorReport.causes should contain theSameElementsAs List(
-      ErrorReport("Invalid CompactDataTables configuration: this setting cannot be disabled once enabled.")
-    )
-  }
-
   "publicly readable setting" should "set public in sam and add all users to bucket" in {
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
@@ -1036,6 +1019,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
         ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
         any[Boolean],
         any[Int],
+        ArgumentMatchers.eq(true),
         ArgumentMatchers.eq(false)
       )
     ).thenReturn(Future.successful(QuicksilverMigrationResult(2, 2, 2)))
@@ -1055,6 +1039,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
       ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
       any[Boolean],
       any[Int],
+      ArgumentMatchers.eq(true),
       ArgumentMatchers.eq(false)
     )
   }
@@ -1092,11 +1077,14 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
 
     val entityService = mock[EntityService]
     when(
-      entityService.quicksilverMigration(workspaceName = WorkspaceName(workspace.namespace, workspace.name),
-                                         updateSettings = false
+      entityService.quicksilverMigration(
+        workspaceName = ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
+        updateSettings = ArgumentMatchers.eq(false),
+        batchSize = any[Int](),
+        cleanup = any[Boolean](),
+        enableSetting = any[Boolean]()
       )
-    )
-      .thenReturn(Future.failed(new Exception("Migration failed")))
+    ).thenReturn(Future.failed(new Exception("Migration failed")))
 
     val service =
       workspaceSettingServiceConstructor(samDAO = samDAO,

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -671,7 +671,24 @@ object WorkspaceSettingConfig {
 
   case class PubliclyReadableConfig(enabled: Boolean) extends WorkspaceSettingConfig
 
-  case class CompactDataTablesConfig(enabled: Boolean) extends WorkspaceSettingConfig
+  case class CompactDataTablesConfig(enabled: Boolean, state: CompactDataTablesState = CompactDataTablesState.NONE)
+      extends WorkspaceSettingConfig
+}
+
+sealed trait CompactDataTablesState
+object CompactDataTablesState {
+  case object NONE extends CompactDataTablesState
+  case object MIGRATING extends CompactDataTablesState
+  case object DONE extends CompactDataTablesState
+  case object ERROR extends CompactDataTablesState
+
+  def withName(name: String): CompactDataTablesState = name.toUpperCase match {
+    case "NONE"      => NONE
+    case "MIGRATING" => MIGRATING
+    case "DONE"      => DONE
+    case "ERROR"     => ERROR
+    case _           => throw new RawlsException(s"invalid CompactDataTablesState [$name]")
+  }
 }
 
 case class WorkspaceSettingResponse(successes: List[WorkspaceSetting], failures: Map[WorkspaceSettingType, ErrorReport])
@@ -1298,7 +1315,16 @@ class WorkspaceJsonSupport extends JsonSupport {
     PubliclyReadableConfig.apply
   )
 
-  implicit val CompactDataTablesConfigFormat: RootJsonFormat[CompactDataTablesConfig] = jsonFormat1(
+  implicit object CompactDataTablesStateFormat extends RootJsonFormat[CompactDataTablesState] {
+    override def write(state: CompactDataTablesState): JsValue = JsString(state.toString)
+
+    override def read(json: JsValue): CompactDataTablesState = json match {
+      case JsString(name) => CompactDataTablesState.withName(name)
+      case _              => throw DeserializationException("unexpected CompactDataTablesState")
+    }
+  }
+
+  implicit val CompactDataTablesConfigFormat: RootJsonFormat[CompactDataTablesConfig] = jsonFormat2(
     CompactDataTablesConfig.apply
   )
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-580

Enable Compact Data Table Migration when `CompactDataTables` Setting is Enabled

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
