### PR TITLE
CORE-600: eliminate redundant Sam API calls in WorkspaceSupport

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -30,18 +30,17 @@ trait WorkspaceSupport {
   def accessCheck(workspace: Workspace, requiredAction: SamResourceAction): Future[Unit] =
     samDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, requiredAction, ctx) flatMap {
       hasRequiredLevel =>
-        // If this access check is for any action other than read, check if the user has read
-        // so we know what exception to throw. If this access check is for read, we already
-        // know the answer
-        val canReadFuture = if (requiredAction == SamWorkspaceActions.read) {
-          Future(hasRequiredLevel)
-        } else {
-          samDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx)
-        }
-
         if (hasRequiredLevel) {
           Future.successful(())
         } else {
+          // If this access check is for any action other than read, check if the user has read
+          // so we know what exception to throw. If this access check is for read, we already
+          // know the answer
+          val canReadFuture = if (requiredAction == SamWorkspaceActions.read) {
+            Future(hasRequiredLevel)
+          } else {
+            samDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx)
+          }
           canReadFuture flatMap { canRead =>
             if (canRead) Future.failed(WorkspaceAccessDeniedException(workspace.toWorkspaceName))
             else Future.failed(NoSuchWorkspaceException(workspace.toWorkspaceName))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.rawls.model.{
   WorkspaceName
 }
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
+import org.broadinstitute.dsde.workbench.client.sam.ApiException
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
@@ -41,6 +42,15 @@ trait WorkspaceSupport {
             else Future.failed(NoSuchWorkspaceException(workspace.toWorkspaceName))
           }
         }
+    } recoverWith {
+      // samDAO.userHasAction will throw ApiExceptions in cases where the user is disabled or missing;
+      // handle those here.
+      case apiException: ApiException
+          if apiException.getCode == StatusCodes.Unauthorized.intValue
+            && apiException.getMessage.contains("Message: User is disabled.") =>
+        Future.failed(new UserDisabledException(StatusCodes.Unauthorized, "Unauthorized"))
+      case apiException: ApiException if apiException.getCode == StatusCodes.Forbidden.intValue =>
+        Future.failed(new UserDisabledException(StatusCodes.Unauthorized, "Unauthorized"))
     }
 
   // can't use withClonedAuthDomain because the Auth Domain -> no Auth Domain logic is different
@@ -63,8 +73,18 @@ trait WorkspaceSupport {
     ignoreLock: Boolean = false
   ): Future[Workspace] =
     for {
-      workspace <- getV2WorkspaceContext(workspaceName, attributeSpecs)
+      // Does the workspace exist?
+      maybeWorkspace <- workspaceRepository.getWorkspace(workspaceName, attributeSpecs)
+      workspace <- maybeWorkspace match {
+        case Some(workspace) => Future(workspace)
+        case None            =>
+          // The workspace does not exist. Check if the current user is enabled;
+          // throw UserDisabledException if not, otherwise throw NoSuchWorkspaceException.
+          userEnabledCheck map (_ => throw NoSuchWorkspaceException(workspaceName))
+      }
+      // Does the user have the required permissions?
       _ <- accessCheck(workspace, requiredAction)
+      // Is the workspace locked, and is the action blocked by the lock?
       _ <- if (ignoreLock) Future.successful() else checkLock(workspace, requiredAction)
     } yield workspace
 
@@ -74,8 +94,25 @@ trait WorkspaceSupport {
     attributeSpecs: Option[WorkspaceAttributeSpecs] = None
   ): Future[Workspace] =
     for {
-      workspace <- getV2WorkspaceContextByWorkspaceId(workspaceId, attributeSpecs)
+      // Validate input UUID
+      maybeUuid <- Future(Try(UUID.fromString(workspaceId)))
+      workspaceUuid = maybeUuid match {
+        case Success(uid) => uid
+        case Failure(_) =>
+          throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, "invalid UUID"))
+      }
+      // Does the workspace exist?
+      maybeWorkspace <- workspaceRepository.getWorkspace(workspaceUuid, attributeSpecs)
+      workspace <- maybeWorkspace match {
+        case Some(workspace) => Future(workspace)
+        case None            =>
+          // The workspace does not exist. Check if the current user is enabled;
+          // throw UserDisabledException if not, otherwise throw NoSuchWorkspaceException.
+          userEnabledCheck map (_ => throw NoSuchWorkspaceException(workspaceUuid.toString))
+      }
+      // Does the user have the required permissions?
       _ <- accessCheck(workspaceId, requiredAction)
+      // Is the workspace locked, and is the action blocked by the lock?
       _ <- checkLock(workspace, requiredAction)
     } yield workspace
 
@@ -120,20 +157,5 @@ trait WorkspaceSupport {
       case Some(user) if user.enabled => Future.successful()
       case _ => Future.failed(new UserDisabledException(StatusCodes.Unauthorized, "Unauthorized"))
     }
-
-  private def getV2WorkspaceContextByWorkspaceId(workspaceId: String,
-                                                 attributeSpecs: Option[WorkspaceAttributeSpecs] = None
-  ): Future[Workspace] = for {
-    _ <- userEnabledCheck
-    workspaceUuid = Try(UUID.fromString(workspaceId)) match {
-      case Success(uid) => uid
-      case Failure(_) =>
-        throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, "invalid UUID"))
-    }
-    workspaceContext <- workspaceRepository.getWorkspace(workspaceUuid, attributeSpecs)
-  } yield workspaceContext match {
-    case Some(workspace) => workspace
-    case None            => throw NoSuchWorkspaceException(workspaceId)
-  }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -30,14 +30,19 @@ trait WorkspaceSupport {
   def accessCheck(workspace: Workspace, requiredAction: SamResourceAction): Future[Unit] =
     samDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, requiredAction, ctx) flatMap {
       hasRequiredLevel =>
+        // If this access check is for any action other than read, check if the user has read
+        // so we know what exception to throw. If this access check is for read, we already
+        // know the answer
+        val canReadFuture = if (requiredAction == SamWorkspaceActions.read) {
+          Future(hasRequiredLevel)
+        } else {
+          samDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx)
+        }
+
         if (hasRequiredLevel) {
           Future.successful(())
         } else {
-          samDAO.userHasAction(SamResourceTypeNames.workspace,
-                               workspace.workspaceId,
-                               SamWorkspaceActions.read,
-                               ctx
-          ) flatMap { canRead =>
+          canReadFuture flatMap { canRead =>
             if (canRead) Future.failed(WorkspaceAccessDeniedException(workspace.toWorkspaceName))
             else Future.failed(NoSuchWorkspaceException(workspace.toWorkspaceName))
           }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -79,13 +79,7 @@ trait WorkspaceSupport {
     for {
       // Does the workspace exist?
       maybeWorkspace <- workspaceRepository.getWorkspace(workspaceName, attributeSpecs)
-      workspace <- maybeWorkspace match {
-        case Some(workspace) => Future(workspace)
-        case None            =>
-          // The workspace does not exist. Check if the current user is enabled;
-          // throw UserDisabledException if not, otherwise throw NoSuchWorkspaceException.
-          userEnabledCheck map (_ => throw NoSuchWorkspaceException(workspaceName))
-      }
+      workspace <- checkWorkspace(maybeWorkspace, workspaceName.toString)
       // Does the user have the required permissions?
       _ <- accessCheck(workspace, requiredAction)
       // Is the workspace locked, and is the action blocked by the lock?
@@ -107,13 +101,7 @@ trait WorkspaceSupport {
       }
       // Does the workspace exist?
       maybeWorkspace <- workspaceRepository.getWorkspace(workspaceUuid, attributeSpecs)
-      workspace <- maybeWorkspace match {
-        case Some(workspace) => Future(workspace)
-        case None            =>
-          // The workspace does not exist. Check if the current user is enabled;
-          // throw UserDisabledException if not, otherwise throw NoSuchWorkspaceException.
-          userEnabledCheck map (_ => throw NoSuchWorkspaceException(workspaceUuid.toString))
-      }
+      workspace <- checkWorkspace(maybeWorkspace, workspaceUuid.toString)
       // Does the user have the required permissions?
       _ <- accessCheck(workspaceId, requiredAction)
       // Is the workspace locked, and is the action blocked by the lock?
@@ -155,6 +143,15 @@ trait WorkspaceSupport {
     else
       Future.successful(())
   }
+
+  private def checkWorkspace(maybeWorkspace: Option[Workspace], errorIdentifier: String): Future[Workspace] =
+    maybeWorkspace match {
+      case Some(workspace) => Future(workspace)
+      case None            =>
+        // The workspace does not exist. Check if the current user is enabled;
+        // throw UserDisabledException if not, otherwise throw NoSuchWorkspaceException.
+        userEnabledCheck map (_ => throw NoSuchWorkspaceException(errorIdentifier))
+    }
 
   private def userEnabledCheck: Future[Unit] =
     samDAO.getUserStatus(ctx) flatMap {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -54,6 +54,10 @@ trait WorkspaceSupport {
             && apiException.getMessage.contains("Message: User is disabled.") =>
         Future.failed(new UserDisabledException(StatusCodes.Unauthorized, "Unauthorized"))
       case apiException: ApiException if apiException.getCode == StatusCodes.Forbidden.intValue =>
+        // David An 2025-07-11: throwing UserDisabledException here preserves existing behavior
+        // given the changes in https://github.com/broadinstitute/rawls/pull/3401. However,
+        // we may want to throw a different exception at some point; returning UserDisabledException
+        // when the user is forbidden or does not exist is not semantically correct.
         Future.failed(new UserDisabledException(StatusCodes.Unauthorized, "Unauthorized"))
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupportSpec.scala
@@ -25,7 +25,7 @@ import org.broadinstitute.dsde.rawls.model.{
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
 import org.broadinstitute.dsde.workbench.client.sam.ApiException
 import org.joda.time.DateTime
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{times, verify, verifyNoMoreInteractions, when}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.mockito.ArgumentMatchers._
@@ -75,6 +75,17 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
       Await.result(support.getV2WorkspaceContextAndPermissions(defaultWorkspaceName, SamWorkspaceActions.read), atMost)
 
     actual shouldBe defaultWorkspace
+
+    // successful case should only call workspaceRepository once
+    verify(workspaceRepository, times(1)).getWorkspace(any[WorkspaceName], any[Option[WorkspaceAttributeSpecs]])
+    verifyNoMoreInteractions(workspaceRepository)
+    // successful case should only call Sam once
+    verify(samDAO, times(1)).userHasAction(any[SamResourceTypeName],
+                                           any[String],
+                                           any[SamResourceAction],
+                                           any[RawlsRequestContext]
+    )
+    verifyNoMoreInteractions(samDAO)
   }
 
   // error cases where only one check fails
@@ -93,6 +104,16 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     intercept[UserDisabledException] {
       Await.result(support.getV2WorkspaceContextAndPermissions(defaultWorkspaceName, SamWorkspaceActions.read), atMost)
     }
+    // should only call workspaceRepository once
+    verify(workspaceRepository, times(1)).getWorkspace(any[WorkspaceName], any[Option[WorkspaceAttributeSpecs]])
+    verifyNoMoreInteractions(workspaceRepository)
+    // should only call Sam once
+    verify(samDAO, times(1)).userHasAction(any[SamResourceTypeName],
+                                           any[String],
+                                           any[SamResourceAction],
+                                           any[RawlsRequestContext]
+    )
+    verifyNoMoreInteractions(samDAO)
   }
 
   it should "throw UserDisabledException if user is not enabled" in {
@@ -110,6 +131,16 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     intercept[UserDisabledException] {
       Await.result(support.getV2WorkspaceContextAndPermissions(defaultWorkspaceName, SamWorkspaceActions.read), atMost)
     }
+    // should only call workspaceRepository once
+    verify(workspaceRepository, times(1)).getWorkspace(any[WorkspaceName], any[Option[WorkspaceAttributeSpecs]])
+    verifyNoMoreInteractions(workspaceRepository)
+    // should only call Sam once
+    verify(samDAO, times(1)).userHasAction(any[SamResourceTypeName],
+                                           any[String],
+                                           any[SamResourceAction],
+                                           any[RawlsRequestContext]
+    )
+    verifyNoMoreInteractions(samDAO)
   }
 
   it should "throw NoSuchWorkspaceException if workspace does not exist" in {
@@ -121,15 +152,19 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     // user is enabled
     when(samDAO.getUserStatus(any[RawlsRequestContext]))
       .thenReturn(Future.successful(Option(defaultUserStatus)))
-    // user has permission
-    when(samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[RawlsRequestContext]))
-      .thenReturn(Future.successful(true))
 
     val support = new WorkspaceSupportFixture(samDAO, workspaceRepository)
 
     intercept[NoSuchWorkspaceException] {
       Await.result(support.getV2WorkspaceContextAndPermissions(defaultWorkspaceName, SamWorkspaceActions.read), atMost)
     }
+    // should only call workspaceRepository once
+    verify(workspaceRepository, times(1)).getWorkspace(any[WorkspaceName], any[Option[WorkspaceAttributeSpecs]])
+    verifyNoMoreInteractions(workspaceRepository)
+    // should only call Sam once, to check if the user is enabled once we discover the
+    // workspace is missing
+    verify(samDAO, times(1)).getUserStatus(any[RawlsRequestContext])
+    verifyNoMoreInteractions(samDAO)
   }
 
   it should "throw NoSuchWorkspaceException if user cannot read" in {
@@ -147,6 +182,16 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     intercept[NoSuchWorkspaceException] {
       Await.result(support.getV2WorkspaceContextAndPermissions(defaultWorkspaceName, SamWorkspaceActions.read), atMost)
     }
+    // should only call workspaceRepository once
+    verify(workspaceRepository, times(1)).getWorkspace(any[WorkspaceName], any[Option[WorkspaceAttributeSpecs]])
+    verifyNoMoreInteractions(workspaceRepository)
+    // should only call Sam once
+    verify(samDAO, times(1)).userHasAction(any[SamResourceTypeName],
+                                           any[String],
+                                           any[SamResourceAction],
+                                           any[RawlsRequestContext]
+    )
+    verifyNoMoreInteractions(samDAO)
   }
 
   it should "throw WorkspaceAccessDeniedException if user can read but doesn't have requested permission" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupportSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.util
 
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import org.broadinstitute.dsde.rawls.{
   NoSuchWorkspaceException,
@@ -64,10 +65,7 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     // workspace exists
     when(workspaceRepository.getWorkspace(mockeq(defaultWorkspaceName), any[Option[WorkspaceAttributeSpecs]]))
       .thenReturn(Future.successful(Option(defaultWorkspace)))
-    // user is enabled
-    when(samDAO.getUserStatus(any[RawlsRequestContext]))
-      .thenReturn(Future.successful(Option(defaultUserStatus)))
-    // user has permission
+    // user has permission and is enabled
     when(samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[RawlsRequestContext]))
       .thenReturn(Future.successful(true))
 
@@ -87,11 +85,8 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     when(workspaceRepository.getWorkspace(mockeq(defaultWorkspaceName), any[Option[WorkspaceAttributeSpecs]]))
       .thenReturn(Future.successful(Option(defaultWorkspace)))
     // user does not exist
-    when(samDAO.getUserStatus(any[RawlsRequestContext]))
-      .thenReturn(Future.successful(None))
-    // user has permission
     when(samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[RawlsRequestContext]))
-      .thenReturn(Future.successful(true))
+      .thenAnswer(_ => Future.failed(new ApiException(StatusCodes.Forbidden.intValue, "Azure Id 123 not found in sam")))
 
     val support = new WorkspaceSupportFixture(samDAO, workspaceRepository)
 
@@ -107,11 +102,8 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     when(workspaceRepository.getWorkspace(mockeq(defaultWorkspaceName), any[Option[WorkspaceAttributeSpecs]]))
       .thenReturn(Future.successful(Option(defaultWorkspace)))
     // user is NOT enabled
-    when(samDAO.getUserStatus(any[RawlsRequestContext]))
-      .thenReturn(Future.successful(Option(defaultUserStatus.copy(enabled = false))))
-    // user has permission
     when(samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[RawlsRequestContext]))
-      .thenReturn(Future.successful(true))
+      .thenAnswer(_ => Future.failed(new ApiException(StatusCodes.Unauthorized.intValue, "Message: User is disabled.")))
 
     val support = new WorkspaceSupportFixture(samDAO, workspaceRepository)
 
@@ -146,9 +138,6 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     // workspace exist
     when(workspaceRepository.getWorkspace(mockeq(defaultWorkspaceName), any[Option[WorkspaceAttributeSpecs]]))
       .thenReturn(Future.successful(Option(defaultWorkspace)))
-    // user is enabled
-    when(samDAO.getUserStatus(any[RawlsRequestContext]))
-      .thenReturn(Future.successful(Option(defaultUserStatus)))
     // user DOES NOT have permission
     when(samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[RawlsRequestContext]))
       .thenReturn(Future.successful(false))
@@ -166,9 +155,6 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     // workspace exist
     when(workspaceRepository.getWorkspace(mockeq(defaultWorkspaceName), any[Option[WorkspaceAttributeSpecs]]))
       .thenReturn(Future.successful(Option(defaultWorkspace)))
-    // user is enabled
-    when(samDAO.getUserStatus(any[RawlsRequestContext]))
-      .thenReturn(Future.successful(Option(defaultUserStatus)))
     // user DOES NOT have write permission
     when(
       samDAO.userHasAction(any[SamResourceTypeName],
@@ -205,9 +191,9 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     // user is NOT enabled
     when(samDAO.getUserStatus(any[RawlsRequestContext]))
       .thenReturn(Future.successful(Option(defaultUserStatus.copy(enabled = false))))
-    // user has permission
+    // user is NOT enabled
     when(samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[RawlsRequestContext]))
-      .thenReturn(Future.successful(true))
+      .thenAnswer(_ => Future.failed(new ApiException(StatusCodes.Unauthorized.intValue, "Message: User is disabled.")))
 
     val support = new WorkspaceSupportFixture(samDAO, workspaceRepository)
 
@@ -251,9 +237,9 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     // user is NOT enabled
     when(samDAO.getUserStatus(any[RawlsRequestContext]))
       .thenReturn(Future.successful(Option(defaultUserStatus.copy(enabled = false))))
-    // user DOES NOT have permission
+    // user is NOT enabled
     when(samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[RawlsRequestContext]))
-      .thenReturn(Future.successful(false))
+      .thenAnswer(_ => Future.failed(new ApiException(StatusCodes.Unauthorized.intValue, "Message: User is disabled.")))
 
     val support = new WorkspaceSupportFixture(samDAO, workspaceRepository)
 
@@ -263,26 +249,6 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
   }
 
   // error cases where a Sam API call fails
-  it should "propagate Sam's ApiException if Sam user-enabled API call fails" in {
-    val samDAO = mock[SamDAO]
-    val workspaceRepository = mock[WorkspaceRepository]
-    // workspace exists
-    when(workspaceRepository.getWorkspace(mockeq(defaultWorkspaceName), any[Option[WorkspaceAttributeSpecs]]))
-      .thenReturn(Future.successful(Option(defaultWorkspace)))
-    // user status API call fails
-    when(samDAO.getUserStatus(any[RawlsRequestContext]))
-      .thenAnswer(_ => Future.failed(new ApiException(555, "Unit test mock error")))
-    // user has permission
-    when(samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[RawlsRequestContext]))
-      .thenReturn(Future.successful(true))
-
-    val support = new WorkspaceSupportFixture(samDAO, workspaceRepository)
-
-    intercept[ApiException] {
-      Await.result(support.getV2WorkspaceContextAndPermissions(defaultWorkspaceName, SamWorkspaceActions.read), atMost)
-    }
-  }
-
   it should "propagate Sam's ApiException if the initial permission check API call fails" in {
     val samDAO = mock[SamDAO]
     val workspaceRepository = mock[WorkspaceRepository]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupportSpec.scala
@@ -30,6 +30,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.mockito.ArgumentMatchers._
 import org.mockito.ArgumentMatchers.{eq => mockeq}
+import org.mockito.Mockito
 import org.scalatest.matchers.should.Matchers
 
 import java.util.UUID
@@ -224,6 +225,19 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     intercept[WorkspaceAccessDeniedException] {
       Await.result(support.getV2WorkspaceContextAndPermissions(defaultWorkspaceName, SamWorkspaceActions.write), atMost)
     }
+    // should only call workspaceRepository once
+    verify(workspaceRepository, times(1)).getWorkspace(any[WorkspaceName], any[Option[WorkspaceAttributeSpecs]])
+    verifyNoMoreInteractions(workspaceRepository)
+    // should call Sam twice - first to see if the user has write (which returns false),
+    // then again to see if the user has read
+    val inOrder = Mockito.inOrder(samDAO)
+    inOrder
+      .verify(samDAO, times(1))
+      .userHasAction(any[SamResourceTypeName], any[String], mockeq(SamWorkspaceActions.write), any[RawlsRequestContext])
+    inOrder
+      .verify(samDAO, times(1))
+      .userHasAction(any[SamResourceTypeName], any[String], mockeq(SamWorkspaceActions.read), any[RawlsRequestContext])
+    inOrder.verifyNoMoreInteractions()
   }
 
   // error cases where multiple checks fail
@@ -236,15 +250,19 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     // user is NOT enabled
     when(samDAO.getUserStatus(any[RawlsRequestContext]))
       .thenReturn(Future.successful(Option(defaultUserStatus.copy(enabled = false))))
-    // user is NOT enabled
-    when(samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[RawlsRequestContext]))
-      .thenAnswer(_ => Future.failed(new ApiException(StatusCodes.Unauthorized.intValue, "Message: User is disabled.")))
 
     val support = new WorkspaceSupportFixture(samDAO, workspaceRepository)
 
     intercept[UserDisabledException] {
       Await.result(support.getV2WorkspaceContextAndPermissions(defaultWorkspaceName, SamWorkspaceActions.read), atMost)
     }
+    // should only call workspaceRepository once
+    verify(workspaceRepository, times(1)).getWorkspace(any[WorkspaceName], any[Option[WorkspaceAttributeSpecs]])
+    verifyNoMoreInteractions(workspaceRepository)
+    // should only call Sam once, to check if the user is enabled once we discover the
+    // workspace is missing
+    verify(samDAO, times(1)).getUserStatus(any[RawlsRequestContext])
+    verifyNoMoreInteractions(samDAO)
   }
 
   it should "throw NoSuchWorkspaceException if workspace does not exist and user doesn't have permission" in {
@@ -259,15 +277,19 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     // user is enabled
     when(samDAO.getUserStatus(any[RawlsRequestContext]))
       .thenReturn(Future.successful(Option(defaultUserStatus)))
-    // user DOES NOT have permission
-    when(samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[RawlsRequestContext]))
-      .thenReturn(Future.successful(false))
 
     val support = new WorkspaceSupportFixture(samDAO, workspaceRepository)
 
     intercept[NoSuchWorkspaceException] {
       Await.result(support.getV2WorkspaceContextAndPermissions(defaultWorkspaceName, SamWorkspaceActions.read), atMost)
     }
+    // should only call workspaceRepository once
+    verify(workspaceRepository, times(1)).getWorkspace(any[WorkspaceName], any[Option[WorkspaceAttributeSpecs]])
+    verifyNoMoreInteractions(workspaceRepository)
+    // should only call Sam once, to check if the user is enabled once we discover the
+    // workspace is missing
+    verify(samDAO, times(1)).getUserStatus(any[RawlsRequestContext])
+    verifyNoMoreInteractions(samDAO)
   }
 
   it should "throw NoSuchWorkspaceException if user is not enabled, workspace does not exist, and user doesn't have permission" in {
@@ -282,15 +304,19 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     // user is NOT enabled
     when(samDAO.getUserStatus(any[RawlsRequestContext]))
       .thenReturn(Future.successful(Option(defaultUserStatus.copy(enabled = false))))
-    // user is NOT enabled
-    when(samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[RawlsRequestContext]))
-      .thenAnswer(_ => Future.failed(new ApiException(StatusCodes.Unauthorized.intValue, "Message: User is disabled.")))
 
     val support = new WorkspaceSupportFixture(samDAO, workspaceRepository)
 
     intercept[UserDisabledException] {
       Await.result(support.getV2WorkspaceContextAndPermissions(defaultWorkspaceName, SamWorkspaceActions.read), atMost)
     }
+    // should only call workspaceRepository once
+    verify(workspaceRepository, times(1)).getWorkspace(any[WorkspaceName], any[Option[WorkspaceAttributeSpecs]])
+    verifyNoMoreInteractions(workspaceRepository)
+    // should only call Sam once, to check if the user is enabled once we discover the
+    // workspace is missing
+    verify(samDAO, times(1)).getUserStatus(any[RawlsRequestContext])
+    verifyNoMoreInteractions(samDAO)
   }
 
   // error cases where a Sam API call fails
@@ -312,6 +338,16 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     intercept[ApiException] {
       Await.result(support.getV2WorkspaceContextAndPermissions(defaultWorkspaceName, SamWorkspaceActions.read), atMost)
     }
+    // should only call workspaceRepository once
+    verify(workspaceRepository, times(1)).getWorkspace(any[WorkspaceName], any[Option[WorkspaceAttributeSpecs]])
+    verifyNoMoreInteractions(workspaceRepository)
+    // should only call Sam once
+    verify(samDAO, times(1)).userHasAction(any[SamResourceTypeName],
+                                           any[String],
+                                           any[SamResourceAction],
+                                           any[RawlsRequestContext]
+    )
+    verifyNoMoreInteractions(samDAO)
   }
 
   it should "propagate Sam's ApiException if the fallback permission check API call fails" in {
@@ -320,9 +356,6 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     // workspace exist
     when(workspaceRepository.getWorkspace(mockeq(defaultWorkspaceName), any[Option[WorkspaceAttributeSpecs]]))
       .thenReturn(Future.successful(Option(defaultWorkspace)))
-    // user is enabled
-    when(samDAO.getUserStatus(any[RawlsRequestContext]))
-      .thenReturn(Future.successful(Option(defaultUserStatus)))
     // user DOES have write permission
     when(
       samDAO.userHasAction(any[SamResourceTypeName],
@@ -348,6 +381,19 @@ class WorkspaceSupportSpec extends AnyFlatSpec with Matchers {
     intercept[ApiException] {
       Await.result(support.getV2WorkspaceContextAndPermissions(defaultWorkspaceName, SamWorkspaceActions.write), atMost)
     }
+    // should only call workspaceRepository once
+    verify(workspaceRepository, times(1)).getWorkspace(any[WorkspaceName], any[Option[WorkspaceAttributeSpecs]])
+    verifyNoMoreInteractions(workspaceRepository)
+    // should call Sam twice - first to see if the user has write (which throws an ApiException),
+    // then again to see if the user has read
+    val inOrder = Mockito.inOrder(samDAO)
+    inOrder
+      .verify(samDAO, times(1))
+      .userHasAction(any[SamResourceTypeName], any[String], mockeq(SamWorkspaceActions.write), any[RawlsRequestContext])
+    inOrder
+      .verify(samDAO, times(1))
+      .userHasAction(any[SamResourceTypeName], any[String], mockeq(SamWorkspaceActions.read), any[RawlsRequestContext])
+    inOrder.verifyNoMoreInteractions()
   }
 }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -25,6 +25,7 @@ import org.broadinstitute.dsde.rawls.{
   UserDisabledException,
   WorkspaceAccessDeniedException
 }
+import org.broadinstitute.dsde.workbench.client.sam.ApiException
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
@@ -242,11 +243,17 @@ class WorkspaceServiceUnitTests
   }
 
   it should "return an unauthorized error if the user is disabled" in {
+    // workspace exists
+    val repository = mock[WorkspaceRepository]
+    when(repository.getWorkspace(any[WorkspaceName], any[Option[WorkspaceAttributeSpecs]]))
+      .thenReturn(Future(Some(workspace)))
+    // user is disabled
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-    when(samDAO.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser.copy(enabled = false))))
+    when(samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], ArgumentMatchers.eq(ctx)))
+      .thenAnswer(_ => Future.failed(new ApiException(StatusCodes.Unauthorized.intValue, "Message: User is disabled.")))
 
     val exception = intercept[UserDisabledException] {
-      val service = workspaceServiceConstructor(samDAO = samDAO)(ctx)
+      val service = workspaceServiceConstructor(workspaceRepository = repository, samDAO = samDAO)(ctx)
       Await.result(service.getWorkspace(WorkspaceName("fake_namespace", "fake_name"), WorkspaceFieldSpecs()),
                    Duration.Inf
       )


### PR DESCRIPTION
Ticket: CORE-600

`getV2WorkspaceContextAndPermissions` is heavily used, in most (all?) APIs. Its use of Sam is inefficient.

Before this PR, its high-level flow was:
1. API call to Sam to ask if the current user is enabled
2. Retrieve the requested workspace from the db
3. API call to Sam to ask if the user has the desired action on the workspace

Sam will fail the second API call if the user is not enabled, so the first API call is extraneous. This PR eliminates that redundancy, which should result in a decrease in Sam's traffic.

Additionally, I've removed a redundant call in cases where the user does not have the requested permission. In that case, we previously always made a second call to Sam to ask if the user has read permission, so we could choose whether to throw `WorkspaceAccessDeniedException` (if the user has read) or `NoSuchWorkspaceException` (if the user does not have read). We always made this second call even if the first call was already checking read permission, which is common.

Unit tests have been updated to add verification of the number of calls to Sam for various use cases.

