### PR TITLE
CORE-605: lenient parsing of cWDS job statuses

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -1109,20 +1109,20 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
     "succeeded" -> ImportStatuses.Done,
     "SUCCEEDED" -> ImportStatuses.Done,
     "error" -> ImportStatuses.Error,
-    "ERROR" -> ImportStatuses.Error
+    "ERROR" -> ImportStatuses.Error,
+    "queued" -> ImportStatuses.Unknown("queued"),
+    "QUEUED" -> ImportStatuses.Unknown("QUEUED"),
+    "created" -> ImportStatuses.Unknown("created"),
+    "CREATED" -> ImportStatuses.Unknown("CREATED"),
+    "cancelled" -> ImportStatuses.Unknown("cancelled"),
+    "CANCELLED" -> ImportStatuses.Unknown("CANCELLED"),
+    "UNKNOWN" -> ImportStatuses.Unknown("UNKNOWN"),
+    "something-else" -> ImportStatuses.Unknown("something-else")
   )
   testCases foreach { case (input, expected) =>
     it should s"translate $input to $expected" in {
       ImportStatuses.fromCwdsStatus(input) shouldBe expected
     }
-  }
-
-  private val errorCases = List("CREATED", "QUEUED", "CANCELLED", "UNKNOWN", "something-else")
-  errorCases foreach { input =>
-    it should s"throw error trying to translate $input" in
-      intercept[RawlsException] {
-        ImportStatuses.fromCwdsStatus(input)
-      }
   }
 
 }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -493,7 +493,7 @@ object ImportStatuses {
     case "running"   => ReadyForUpsert
     case "succeeded" => Done
     case "error"     => Error
-    case _           => throw new RawlsException(s"invalid cWDS status [$name]")
+    case _           => Unknown(name)
   }
 
   def withName(name: String): ImportStatus = name.toLowerCase match {
@@ -501,9 +501,10 @@ object ImportStatuses {
     case "upserting"      => Upserting
     case "done"           => Done
     case "error"          => Error
-    case _                => throw new RawlsException(s"invalid ImportStatus [$name]")
+    case _                => Unknown(name)
   }
 
+  case class Unknown(externalStatus: String) extends ImportStatus
   case object ReadyForUpsert extends ImportStatus
   case object Upserting extends ImportStatus
   case object Done extends ImportStatus


### PR DESCRIPTION
Ticket: CORE-605

Fixes an uncommon error that happens when a user queues up an import job via the UI and the UI starts polling for status of that job in cWDS before cWDS has started running the job.

Previously, Rawls didn't recognize any cWDS statuses beyond the ones it expected (and it expected the job to have started). Now, it won't throw any errors but also won't DO anything with the unrecognized statuses.