### PR TITLE
CORE-606: quicksilver batch update overwrite

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -105,26 +105,29 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     *
     * `execution plan: multiple-row insert`
     */
-  def batchWriteEntities(workspaceId: UUID, entities: Seq[Entity], insertOnly: Boolean): ReadWriteAction[Int] = {
-    val baseSql =
-      sql"""insert into ENTITY(name, entity_type, workspace_id, record_version, deleted, attributes) values """
+  def batchWriteEntities(workspaceId: UUID, entities: Seq[Entity], insertOnly: Boolean): ReadWriteAction[Int] =
+    if (entities.isEmpty)
+      DBIO.successful(0)
+    else {
+      val baseSql =
+        sql"""insert into ENTITY(name, entity_type, workspace_id, record_version, deleted, attributes) values """
 
-    val values = entities.map { entity =>
-      val attributesJson: JsValue = toSql(entity.attributes)
+      val values = entities.map { entity =>
+        val attributesJson: JsValue = toSql(entity.attributes)
 
-      sql"""(${entity.name}, ${entity.entityType}, $workspaceId, 0, 0, $attributesJson)"""
+        sql"""(${entity.name}, ${entity.entityType}, $workspaceId, 0, 0, $attributesJson)"""
+      }
+
+      // when called with insertOnly=true, the SQL statement is a simple `insert into ...`.
+      // when called with insertOnly=false, the SQL statement is `insert into ... on duplicate key update`.
+      val upsertSql = if (insertOnly) {
+        sql""
+      } else {
+        sql""" as newvalues on duplicate key update ENTITY.record_version = ENTITY.record_version+1, ENTITY.attributes = newvalues.attributes;"""
+      }
+
+      concatSqlActions(baseSql, reduceSqlActionsWithDelim(values, sql","), upsertSql).asUpdate
     }
-
-    // when called with insertOnly=true, the SQL statement is a simple `insert into ...`.
-    // when called with insertOnly=false, the SQL statement is `insert into ... on duplicate key update`.
-    val upsertSql = if (insertOnly) {
-      sql""
-    } else {
-      sql""" on duplicate key update record_version = record_version+1, attributes = VALUES(attributes);"""
-    }
-
-    concatSqlActions(baseSql, reduceSqlActionsWithDelim(values, sql","), upsertSql).asUpdate
-  }
 
   /**
     * Insert a single entity to the db.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -222,6 +222,52 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
 
   }
 
+  it should "succeed for a noop update" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+
+    val metadataBefore = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
+    metadataBefore shouldBe empty
+
+    val testEntity = Entity(
+      "myName",
+      "myType",
+      Map(
+        AttributeName.withDefaultNS("one") -> AttributeNumber(1),
+        AttributeName.withDefaultNS("two") -> AttributeNumber(2)
+      )
+    )
+
+    // create the entity we'll be updating; give it two references
+    Await.result(
+      provider.createEntity(testEntity, defaultRequestContext),
+      atMost
+    )
+
+    // perform the batchUpsert, issuing a noop update
+    val updates = Source(
+      Seq(
+        EntityUpdateDefinition(
+          "myName",
+          "myType",
+          Seq(
+            AddUpdateAttribute(AttributeName.withDefaultNS("one"), AttributeNumber(1))
+          )
+        )
+      )
+    )
+
+    val numUpdated = Await.result(provider.batchUpsertEntities(updates, defaultRequestContext), atMost)
+    numUpdated shouldBe 0
+
+    // validate the entity after our batchUpsert
+    val finalEntity =
+      runAndWait(
+        provider.repository.queries.getEntity(wsid, "myType", "myName")
+      )
+    finalEntity should not be empty
+    finalEntity.get.toEntity shouldBe testEntity
+  }
+
   it should "remove obsolete references for entities during update" in withMinimalTestDatabase { _ =>
     val provider = defaultProvider()
 


### PR DESCRIPTION
Ticket: CORE-606

In production, it was very easy to trigger a sql error in a Quicksilver workspace:
1. Upload a TSV
2. Re-upload the exact same TSV

The root cause of the error was an error probably introduced in #3327. We optimize away updates to any entity which hasn't changed. However, if ZERO entities have changed, it resulted in an invalid SQL statement that looked like:
```sql
insert into ENTITY(column-names)
VALUES
on duplicate key update ...
```
Note that there are no values after `VALUES` - invalid SQL.

Additionally, this PR updates the syntax inside the `on duplicate key update` clause to reflect the syntax deprecation in MySQL 8.0.20. Search for "The use of VALUES() to access new row values" at https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-20.html#mysqld-8-0-20-sql-syntax for this deprecation. The syntax changes from using the VALUES keyword `VALUES(attributes)` to using an alias for the incoming values: `newvalues.attributes`.