### PR TITLE
[CORE-580] Enable Compact Data Table Migration from Workspace Settings

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -365,23 +365,26 @@ object Boot extends IOApp with LazyLogging {
 
       val workspaceSettingRepository = new WorkspaceSettingRepository(slickDataSource)
 
-      val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService =
-        new WorkspaceSettingService(_,
-                                    workspaceSettingRepository,
-                                    workspaceRepository,
-                                    gcsDAO,
-                                    samDAO,
-                                    appDependencies.googleStorageService
-        )(implicitly, IORuntime.global)
-
-      val entityServiceConstructor: RawlsRequestContext => EntityService = EntityService.constructor(
+      // Define both constructors using lazy evaluation to break the circular dependency
+      lazy val entityServiceConstructor: RawlsRequestContext => EntityService = EntityService.constructor(
         slickDataSource,
         samDAO,
         workbenchMetricBaseName = metricsPrefix,
         entityManager,
         appConfigManager.conf.getInt("entities.pageSizeLimit"),
-        Option(workspaceSettingServiceConstructor)
+        Some(workspaceSettingServiceConstructor)
       )
+
+      lazy val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService =
+        (ctx: RawlsRequestContext) =>
+          new WorkspaceSettingService(ctx,
+                                      workspaceSettingRepository,
+                                      workspaceRepository,
+                                      gcsDAO,
+                                      samDAO,
+                                      appDependencies.googleStorageService,
+                                      entityServiceConstructor(ctx)
+          )(implicitly, IORuntime.global)
 
       val workspaceServiceConstructor: RawlsRequestContext => WorkspaceService = WorkspaceService.constructor(
         slickDataSource,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
@@ -153,5 +153,16 @@ trait WorkspaceSettingComponent {
             && rec.settingType === settingType.toString
         ).take(1).result.map(_.map(WorkspaceSettingRecord.toWorkspaceSetting).toList)
       )
+
+    def getPendingSettingForWorkspaceByType(workspaceId: UUID,
+                                            settingType: WorkspaceSettingType
+    ): ReadAction[Option[WorkspaceSetting]] =
+      uniqueResult(
+        filter(rec =>
+          rec.workspaceId === workspaceId
+            && rec.status === WorkspaceSettingRecord.SettingStatus.Pending.toString
+            && rec.settingType === settingType.toString
+        ).take(1).result.map(_.map(WorkspaceSettingRecord.toWorkspaceSetting).toList)
+      )
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -60,14 +60,21 @@ class EntityManager(providerBuilders: Set[EntityProviderBuilder[_ <: EntityProvi
       )
     }
 
-    // If the workspace has the CompactDataTables setting enabled, use CompactEntityProvider; else use LocalEntityProvider.
-    val compactDataTables =
-      workspaceSettingRepository.getWorkspaceSettingOfType(requestArguments.workspace.workspaceIdAsUUID,
-                                                           CompactDataTables
-      ) map {
-        case Some(qs: CompactDataTablesSetting) => qs.config.enabled
-        case _                                  => false
-      }
+    // If the workspace has the CompactDataTables setting enabled and no pending CompactDataTables Settings,
+    // use CompactEntityProvider; else use LocalEntityProvider.
+    val compactDataTables = for {
+      settingOpt <- workspaceSettingRepository.getWorkspaceSettingOfType(
+        requestArguments.workspace.workspaceIdAsUUID,
+        CompactDataTables
+      )
+      hasPending <- workspaceSettingRepository.hasPendingSettings(
+        requestArguments.workspace.workspaceIdAsUUID,
+        CompactDataTables
+      )
+    } yield settingOpt match {
+      case Some(qs: CompactDataTablesSetting) if qs.config.enabled && !hasPending => true
+      case _                                                                      => false
+    }
     val targetTagFuture = compactDataTables map {
       case true  => typeTag[CompactEntityProvider]
       case false => typeTag[LocalEntityProvider]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -71,9 +71,16 @@ class EntityManager(providerBuilders: Set[EntityProviderBuilder[_ <: EntityProvi
         requestArguments.workspace.workspaceIdAsUUID,
         CompactDataTables
       )
-    } yield settingOpt match {
-      case Some(qs: CompactDataTablesSetting) if qs.config.enabled && !hasPending => true
-      case _                                                                      => false
+    } yield {
+      if (hasPending) {
+        throw new DataEntityException(
+          s"CompactDataTable migration is in progress for workspace ${requestArguments.workspace.toWorkspaceName}. Writes are temporarily disabled."
+        )
+      }
+      settingOpt match {
+        case Some(qs: CompactDataTablesSetting) if qs.config.enabled => true
+        case _                                                       => false
+      }
     }
     val targetTagFuture = compactDataTables map {
       case true  => typeTag[CompactEntityProvider]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -612,10 +612,10 @@ class EntityService(protected val ctx: RawlsRequestContext,
           throw new RawlsExceptionWithErrorReport(ErrorReport("Quicksilver already enabled for this workspace"))
         }
 
-        // Check if there are any pending settings for this workspace
+        // Check if there are any pending compactDataTables settings for this workspace
         // Pending settings indicate that this originated from a workspace setting request
         hasPendingSettings <- traceFutureWithParent("workspaceHasPendingSettings", s) { _ =>
-          workspaceSettingService.workspaceHasPendingSettings(workspaceName)
+          workspaceSettingService.workspaceHasPendingSettings(workspaceName, CompactDataTables)
         }
 
         // If there are pending settings, we need to ensure that the Quicksilver migration is not already in progress.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -618,8 +618,15 @@ class EntityService(protected val ctx: RawlsRequestContext,
           workspaceSettingService.workspaceHasPendingSettings(workspaceName, CompactDataTables)
         }
 
-        // If there are pending settings, we need to ensure that the Quicksilver migration is not already in progress.
-        _ = if (hasPendingSettings) {
+        // If there are pending settings and the CompactDataTables setting exists but is not yet enabled,
+        // it means a Quicksilver migration has already been requested and is currently in progress.
+        // Prevent starting another migration to avoid conflicts or inconsistent state.
+        _ = if (
+          hasPendingSettings && settings
+            .find(_.isInstanceOf[CompactDataTablesSetting])
+            .asInstanceOf[Option[CompactDataTablesSetting]]
+            .exists(!_.config.enabled)
+        ) {
           throw new RawlsExceptionWithErrorReport(
             ErrorReport(StatusCodes.BadRequest, "Quicksilver migration is already in progress for this workspace")
           )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -612,6 +612,25 @@ class EntityService(protected val ctx: RawlsRequestContext,
           throw new RawlsExceptionWithErrorReport(ErrorReport("Quicksilver already enabled for this workspace"))
         }
 
+        // Check if there are any pending settings for this workspace
+        // Pending settings indicate that this originated from a workspace setting request
+        hasPendingSettings <- traceFutureWithParent("workspaceHasPendingSettings", s) { _ =>
+          workspaceSettingService.workspaceHasPendingSettings(workspaceName)
+        }
+
+        // If there are pending settings, we need to ensure that the Quicksilver migration is not already in progress.
+        _ = if (
+          hasPendingSettings &&
+          settings
+            .find(_.isInstanceOf[CompactDataTablesSetting])
+            .asInstanceOf[Option[CompactDataTablesSetting]]
+            .exists(!_.config.enabled)
+        ) {
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.BadRequest, "Quicksilver migration is already in progress for this workspace")
+          )
+        }
+
         // start a transaction; here's where we do a bunch of writes
         userResult <- dataSource.inTransaction { dataAccess =>
           val shardId: String = dataAccess.determineShard(workspaceId)
@@ -663,12 +682,17 @@ class EntityService(protected val ctx: RawlsRequestContext,
         }
 
         // finally, change the workspace to be quicksilver-enabled
-        _ <- traceFutureWithParent("setWorkspaceSettings", s) { _ =>
-          workspaceSettingService.setWorkspaceSettings(
-            workspaceName,
-            List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
-          )
-        }
+        _ <-
+          if (!hasPendingSettings) {
+            traceFutureWithParent("setWorkspaceSettings", s) { _ =>
+              workspaceSettingService.setWorkspaceSettings(
+                workspaceName,
+                List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
+              )
+            }
+          } else {
+            Future.successful(())
+          }
 
         // return a count of entities updated
       } yield userResult

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -618,15 +618,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
           workspaceSettingService.workspaceHasPendingSettings(workspaceName, CompactDataTables)
         }
 
-        // If there are pending settings and the CompactDataTables setting exists but is not yet enabled,
-        // it means a Quicksilver migration has already been requested and is currently in progress.
-        // Prevent starting another migration to avoid conflicts or inconsistent state.
-        _ = if (
-          hasPendingSettings && settings
-            .find(_.isInstanceOf[CompactDataTablesSetting])
-            .asInstanceOf[Option[CompactDataTablesSetting]]
-            .exists(!_.config.enabled)
-        ) {
+        // If there are pending settings, it means migration has already been requested and is currently in progress.
+        // Prevent starting another migration to avoid conflicts or an inconsistent state.
+        _ = if (hasPendingSettings) {
           throw new RawlsExceptionWithErrorReport(
             ErrorReport(StatusCodes.BadRequest, "Quicksilver migration is already in progress for this workspace")
           )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -619,13 +619,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         }
 
         // If there are pending settings, we need to ensure that the Quicksilver migration is not already in progress.
-        _ = if (
-          hasPendingSettings &&
-          settings
-            .find(_.isInstanceOf[CompactDataTablesSetting])
-            .asInstanceOf[Option[CompactDataTablesSetting]]
-            .exists(!_.config.enabled)
-        ) {
+        _ = if (hasPendingSettings) {
           throw new RawlsExceptionWithErrorReport(
             ErrorReport(StatusCodes.BadRequest, "Quicksilver migration is already in progress for this workspace")
           )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -631,6 +631,17 @@ class EntityService(protected val ctx: RawlsRequestContext,
           )
         }
 
+        // If there are no pending settings, we can set the workspace settings to enable Quicksilver migration
+        // This is done before the migration starts to ensure that the workspace setting marked as "Pending"
+        _ = if (!hasPendingSettings) {
+          traceFutureWithParent("setWorkspaceSettings", s) { _ =>
+            workspaceSettingService.setWorkspaceSettings(
+              workspaceName,
+              List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
+            )
+          }
+        }
+
         // start a transaction; here's where we do a bunch of writes
         userResult <- dataSource.inTransaction { dataAccess =>
           val shardId: String = dataAccess.determineShard(workspaceId)
@@ -680,19 +691,6 @@ class EntityService(protected val ctx: RawlsRequestContext,
           }
 
         }
-
-        // finally, change the workspace to be quicksilver-enabled
-        _ <-
-          if (!hasPendingSettings) {
-            traceFutureWithParent("setWorkspaceSettings", s) { _ =>
-              workspaceSettingService.setWorkspaceSettings(
-                workspaceName,
-                List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
-              )
-            }
-          } else {
-            Future.successful(())
-          }
 
         // return a count of entities updated
       } yield userResult

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepository.scala
@@ -35,11 +35,13 @@ class WorkspaceSettingRepository(dataSource: SlickDataSource) {
       access.workspaceSettingQuery.getAppliedSettingForWorkspaceByType(workspaceId, settingType)
     }
 
-  // Return if the workspace has any pending settings. Applied and deleted settings are not returned.
-  def hasPendingSettings(workspaceId: UUID)(implicit ec: ExecutionContext): Future[Boolean] =
+  // Return if the workspace has pending settings for the settingType. Applied and deleted settings are not returned.
+  def hasPendingSettings(workspaceId: UUID, settingType: WorkspaceSettingType)(implicit
+    ec: ExecutionContext
+  ): Future[Boolean] =
     dataSource.inTransaction { access =>
       access.workspaceSettingQuery
-        .listSettingsForWorkspaceByStatus(workspaceId, WorkspaceSettingRecord.SettingStatus.Pending)
+        .getPendingSettingForWorkspaceByType(workspaceId, settingType)
         .map(_.nonEmpty)
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepository.scala
@@ -35,6 +35,14 @@ class WorkspaceSettingRepository(dataSource: SlickDataSource) {
       access.workspaceSettingQuery.getAppliedSettingForWorkspaceByType(workspaceId, settingType)
     }
 
+  // Return if the workspace has any pending settings. Applied and deleted settings are not returned.
+  def hasPendingSettings(workspaceId: UUID)(implicit ec: ExecutionContext): Future[Boolean] =
+    dataSource.inTransaction { access =>
+      access.workspaceSettingQuery
+        .listSettingsForWorkspaceByStatus(workspaceId, WorkspaceSettingRecord.SettingStatus.Pending)
+        .map(_.nonEmpty)
+    }
+
   // Create new settings for a workspace as pending. If there are any existing pending settings, throw an exception.
   def createWorkspaceSettingsRecords(workspaceId: UUID,
                                      workspaceSettings: List[WorkspaceSetting],

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -287,10 +287,8 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
       // Check if the setting is already enabled in the database
       getWorkspaceSettingOfType(workspaceName, WorkspaceSettingTypes.CompactDataTables).flatMap {
         case Some(CompactDataTablesSetting(CompactDataTablesConfig(true))) =>
-          Future.failed(
-            new RawlsExceptionWithErrorReport(
-              ErrorReport(StatusCodes.BadRequest, "Cannot disable compact data tables setting once enabled.")
-            )
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.BadRequest, "Cannot disable compact data tables setting once enabled.")
           )
         case _ =>
           Future.successful(())

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -11,6 +11,7 @@ import com.google.cloud.storage.BucketInfo.{LifecycleRule, SoftDeletePolicy}
 import com.google.cloud.storage.Storage
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
+import org.broadinstitute.dsde.rawls.entities.EntityService
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig._
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.WorkspaceSettingType
 import org.broadinstitute.dsde.rawls.model.{
@@ -47,7 +48,8 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
                               val workspaceRepository: WorkspaceRepository,
                               gcsDAO: GoogleServicesDAO,
                               val samDAO: SamDAO,
-                              googleStorageService: GoogleStorageService[IO]
+                              googleStorageService: GoogleStorageService[IO],
+                              entityService: EntityService
 )(implicit protected val executionContext: ExecutionContext, ioRuntime: IORuntime)
     extends WorkspaceSupport
     with LazyLogging {
@@ -74,6 +76,11 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
       workspaceSettingRepository.getWorkspaceSettings(workspace.workspaceIdAsUUID)
     }
 
+  // Returns true if the workspace has any pending settings.
+  def workspaceHasPendingSettings(workspaceName: WorkspaceName): Future[Boolean] =
+    getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.readSettings).flatMap { workspace =>
+      workspaceSettingRepository.hasPendingSettings(workspace.workspaceIdAsUUID)
+    }
   def setWorkspaceSettings(workspaceName: WorkspaceName,
                            workspaceSettings: List[WorkspaceSetting]
   ): Future[WorkspaceSettingResponse] = {
@@ -201,8 +208,8 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
         // SeparateSubmissionFinalOutputsSetting, UseCromwellGcpBatchBackendSetting, and CompactDataTablesSetting
         // are not bucket settings, so we do not need to apply anything here
 
-        case CompactDataTablesSetting(CompactDataTablesConfig(_)) =>
-          Future.successful(())
+        case CompactDataTablesSetting(CompactDataTablesConfig(enabled)) =>
+          applyCompactDataTablesSetting(WorkspaceName(workspace.namespace, workspace.name), enabled)
 
         case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) =>
           Future.successful(())
@@ -270,4 +277,25 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
         }
       _ <- iamPolicyAction.compile.drain.unsafeToFuture()
     } yield ()
+
+  /**
+   * Call to handle entity attributes migration when compact data tables setting enabled.
+   */
+  private def applyCompactDataTablesSetting(workspaceName: WorkspaceName, enabled: Boolean): Future[Unit] =
+    if (!enabled) {
+      // If compact data tables setting is disabled, we do not need to do anything.
+      Future.successful(())
+    } else {
+      // If compact data tables setting is enabled, we need to migrate the entity attributes.
+      Future {
+        entityService
+          .quicksilverMigration(workspaceName = workspaceName)
+          .map(_ => ())
+          .recover { case e: Exception =>
+            throw new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.InternalServerError, s"Quicksilver migration failed: ${e.getMessage}")
+            )
+          }
+      }.flatten
+    }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -78,9 +78,9 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
     }
 
   // Returns true if the workspace has any pending settings.
-  def workspaceHasPendingSettings(workspaceName: WorkspaceName): Future[Boolean] =
+  def workspaceHasPendingSettings(workspaceName: WorkspaceName, settingType: WorkspaceSettingType): Future[Boolean] =
     getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.readSettings).flatMap { workspace =>
-      workspaceSettingRepository.hasPendingSettings(workspace.workspaceIdAsUUID)
+      workspaceSettingRepository.hasPendingSettings(workspace.workspaceIdAsUUID, settingType)
     }
   def setWorkspaceSettings(workspaceName: WorkspaceName,
                            workspaceSettings: List[WorkspaceSetting]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -30,7 +30,8 @@ import org.broadinstitute.dsde.rawls.model.{
   Workspace,
   WorkspaceName,
   WorkspaceSetting,
-  WorkspaceSettingResponse
+  WorkspaceSettingResponse,
+  WorkspaceSettingTypes
 }
 import org.broadinstitute.dsde.rawls.util.WorkspaceSupport
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
@@ -283,8 +284,17 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
    */
   private def applyCompactDataTablesSetting(workspaceName: WorkspaceName, enabled: Boolean): Future[Unit] =
     if (!enabled) {
-      // If compact data tables setting is disabled, we do not need to do anything.
-      Future.successful(())
+      // Check if the setting is already enabled in the database
+      getWorkspaceSettingOfType(workspaceName, WorkspaceSettingTypes.CompactDataTables).flatMap {
+        case Some(CompactDataTablesSetting(CompactDataTablesConfig(true))) =>
+          Future.failed(
+            new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.BadRequest, "Cannot disable compact data tables setting once enabled.")
+            )
+          )
+        case _ =>
+          Future.successful(())
+      }
     } else {
       // If compact data tables setting is enabled, we need to migrate the entity attributes.
       Future {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityManagerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityManagerSpec.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.entities.base.AuditLoggingEntityProvider
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityProvider
+import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.entities.local.LocalEntityProvider
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.CompactDataTablesConfig
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.CompactDataTables
@@ -99,31 +100,15 @@ class EntityManagerSpec extends AnyFlatSpec with MockitoTestUtils with Matchers 
     val afterUpdateAuditProvider = afterUpdate.asInstanceOf[AuditLoggingEntityProvider]
     afterUpdateAuditProvider.delegate shouldBe a[LocalEntityProvider]
 
-    // Mock workspace has pending compact data tables setting
+    // check the EntityManager behavior when there are pending compact data tables settings
     when(workspaceSettingRepository.hasPendingSettings(workspaceId, CompactDataTables))
       .thenReturn(Future.successful(true))
-
-    // check the EntityManager behavior when compact data tables is enabled but there are pending settings
     when(workspaceSettingRepository.getWorkspaceSettingOfType(workspaceId, CompactDataTables))
       .thenReturn(Future.successful(Option(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))))
-    val afterSettingEnabledPending =
+    val afterSettingPending = intercept[DataEntityException] {
       Await.result(entityManager.resolveProviderFuture(entityRequestArguments), Duration.Inf)
-
-    // Provider should be an AuditLoggingEntityProvider with a LocalEntityProvider delegate
-    afterSettingEnabledPending shouldBe a[AuditLoggingEntityProvider]
-    val afterSettingEnabledPendingAuditProvider = afterSettingEnabledPending.asInstanceOf[AuditLoggingEntityProvider]
-    afterSettingEnabledPendingAuditProvider.delegate shouldBe a[LocalEntityProvider]
-
-    // check the EntityManager behavior when compact data tables is disabled but there are pending settings
-    when(workspaceSettingRepository.getWorkspaceSettingOfType(workspaceId, CompactDataTables))
-      .thenReturn(Future.successful(Option(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))))
-    val afterSettingDisabledPending =
-      Await.result(entityManager.resolveProviderFuture(entityRequestArguments), Duration.Inf)
-
-    // Provider should be an AuditLoggingEntityProvider with a LocalEntityProvider delegate
-    afterSettingDisabledPending shouldBe a[AuditLoggingEntityProvider]
-    val afterSettingDisabledPendingAuditProvider = afterSettingDisabledPending.asInstanceOf[AuditLoggingEntityProvider]
-    afterSettingDisabledPendingAuditProvider.delegate shouldBe a[LocalEntityProvider]
+    }
+    afterSettingPending.getMessage should include("migration is in progress")
   }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityManagerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityManagerSpec.scala
@@ -65,6 +65,10 @@ class EntityManagerSpec extends AnyFlatSpec with MockitoTestUtils with Matchers 
 
     val entityRequestArguments = EntityRequestArguments(workspace, defaultRequestContext)
 
+    // Mock workspace has no pending compact data tables setting
+    when(workspaceSettingRepository.hasPendingSettings(workspaceId, CompactDataTables))
+      .thenReturn(Future.successful(false))
+
     // check the EntityManager behavior when the compact data tables setting is not set
     when(workspaceSettingRepository.getWorkspaceSettingOfType(workspaceId, CompactDataTables))
       .thenReturn(Future.successful(None))
@@ -94,6 +98,32 @@ class EntityManagerSpec extends AnyFlatSpec with MockitoTestUtils with Matchers 
     afterUpdate shouldBe a[AuditLoggingEntityProvider]
     val afterUpdateAuditProvider = afterUpdate.asInstanceOf[AuditLoggingEntityProvider]
     afterUpdateAuditProvider.delegate shouldBe a[LocalEntityProvider]
+
+    // Mock workspace has pending compact data tables setting
+    when(workspaceSettingRepository.hasPendingSettings(workspaceId, CompactDataTables))
+      .thenReturn(Future.successful(true))
+
+    // check the EntityManager behavior when compact data tables is enabled but there are pending settings
+    when(workspaceSettingRepository.getWorkspaceSettingOfType(workspaceId, CompactDataTables))
+      .thenReturn(Future.successful(Option(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))))
+    val afterSettingEnabledPending =
+      Await.result(entityManager.resolveProviderFuture(entityRequestArguments), Duration.Inf)
+
+    // Provider should be an AuditLoggingEntityProvider with a LocalEntityProvider delegate
+    afterSettingEnabledPending shouldBe a[AuditLoggingEntityProvider]
+    val afterSettingEnabledPendingAuditProvider = afterSettingEnabledPending.asInstanceOf[AuditLoggingEntityProvider]
+    afterSettingEnabledPendingAuditProvider.delegate shouldBe a[LocalEntityProvider]
+
+    // check the EntityManager behavior when compact data tables is disabled but there are pending settings
+    when(workspaceSettingRepository.getWorkspaceSettingOfType(workspaceId, CompactDataTables))
+      .thenReturn(Future.successful(Option(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))))
+    val afterSettingDisabledPending =
+      Await.result(entityManager.resolveProviderFuture(entityRequestArguments), Duration.Inf)
+
+    // Provider should be an AuditLoggingEntityProvider with a LocalEntityProvider delegate
+    afterSettingDisabledPending shouldBe a[AuditLoggingEntityProvider]
+    val afterSettingDisabledPendingAuditProvider = afterSettingDisabledPending.asInstanceOf[AuditLoggingEntityProvider]
+    afterSettingDisabledPendingAuditProvider.delegate shouldBe a[LocalEntityProvider]
   }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -103,7 +103,8 @@ class EntityServiceCompactMigrationSpec
         new WorkspaceRepository(dataSource),
         new MockGoogleServicesDAO("groupsPrefix"),
         samDAO,
-        googleStorageService
+        googleStorageService,
+        entityService
       )(executionContext, global)
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -273,13 +273,16 @@ trait ApiServiceSpec
       new RequesterPaysSetupServiceImpl(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
 
     override val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService =
-      new WorkspaceSettingService(_,
-                                  new WorkspaceSettingRepository(slickDataSource),
-                                  new WorkspaceRepository(slickDataSource),
-                                  gcsDAO,
-                                  samDAO,
-                                  mock[GoogleStorageService[IO]]
-      )
+      ctx =>
+        new WorkspaceSettingService(
+          ctx,
+          new WorkspaceSettingRepository(slickDataSource),
+          new WorkspaceRepository(slickDataSource),
+          gcsDAO,
+          samDAO,
+          mock[GoogleStorageService[IO]],
+          entityServiceConstructor(ctx)
+        )
 
     val entityManager = EntityManager.defaultEntityManager(
       dataSource,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceProviderEquivalenceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceProviderEquivalenceSpec.scala
@@ -46,10 +46,9 @@ class EntityApiServiceProviderEquivalenceSpec extends ApiServiceSpec with SprayJ
 
   def withApiServices[T](dataSource: SlickDataSource)(testCode: TestApiService => T): T = {
     val apiService = TestApiService(dataSource, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)
-    try {
-      setupProviders(apiService) // tweaks to minimalTestData for this test suite
+    try
       testCode(apiService)
-    } finally
+    finally
       apiService.cleanupSupervisor
   }
 
@@ -270,18 +269,6 @@ class EntityApiServiceProviderEquivalenceSpec extends ApiServiceSpec with SprayJ
   // ====================================================================================================
   //  helper methods
   // ====================================================================================================
-
-  private def setupProviders(services: TestApiService): Unit = {
-    // configure compactWs to use compact ("Quicksilver") data tables
-    // no changes to legacyWs, so that will use legacy data tables
-    val compactDataTablesSetting = CompactDataTablesSetting(CompactDataTablesConfig(enabled = true))
-    val workspaceSettingService = services.workspaceSettingServiceConstructor(testContext)
-    val workspaceSettingResponse = Await.result(
-      workspaceSettingService.setWorkspaceSettings(compactWs.toWorkspaceName, List(compactDataTablesSetting)),
-      atMost
-    )
-    workspaceSettingResponse.successes should have size 1
-  }
 
   private def withHandlers(route: server.Route): server.Route =
     (handleExceptions(RawlsApiService.exceptionHandler) & handleRejections(RawlsApiService.rejectionHandler)) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
@@ -221,6 +221,55 @@ class WorkspaceSettingRepositorySpec
     assertResult(result)(None)
   }
 
+  behavior of "hasPendingSettings"
+
+  it should "return true if there are pending settings" in {
+    val repo = new WorkspaceSettingRepository(slickDataSource)
+    val workspaceRepo = new WorkspaceRepository(slickDataSource)
+    val ws: Workspace = makeWorkspace()
+    Await.result(workspaceRepo.createWorkspace(ws), Duration.Inf)
+    val pendingSetting = GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(123))
+
+    Await.result(
+      slickDataSource.inTransaction { dataAccess =>
+        dataAccess.workspaceSettingQuery.saveAll(ws.workspaceIdAsUUID, List(pendingSetting), userInfo.userSubjectId)
+      },
+      Duration.Inf
+    )
+
+    val result = Await.result(repo.hasPendingSettings(ws.workspaceIdAsUUID), Duration.Inf)
+    result shouldBe true
+  }
+
+  it should "return false if there are no pending settings" in {
+    val repo = new WorkspaceSettingRepository(slickDataSource)
+    val workspaceRepo = new WorkspaceRepository(slickDataSource)
+    val ws: Workspace = makeWorkspace()
+    Await.result(workspaceRepo.createWorkspace(ws), Duration.Inf)
+    val appliedSetting = GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(456))
+
+    Await.result(
+      slickDataSource.inTransaction { dataAccess =>
+        for {
+          _ <- dataAccess.workspaceSettingQuery.saveAll(ws.workspaceIdAsUUID,
+                                                        List(appliedSetting),
+                                                        userInfo.userSubjectId
+          )
+          _ <- dataAccess.workspaceSettingQuery.updateSettingStatus(
+            ws.workspaceIdAsUUID,
+            WorkspaceSettingTypes.GcpBucketSoftDelete,
+            WorkspaceSettingRecord.SettingStatus.Pending,
+            WorkspaceSettingRecord.SettingStatus.Applied
+          )
+        } yield ()
+      },
+      Duration.Inf
+    )
+
+    val result = Await.result(repo.hasPendingSettings(ws.workspaceIdAsUUID), Duration.Inf)
+    result shouldBe false
+  }
+
   behavior of "createWorkspaceSettingsRecords"
 
   it should "create pending workspace settings" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
@@ -13,7 +13,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   SeparateSubmissionFinalOutputsConfig,
   UseCromwellGcpBatchBackendConfig
 }
-import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.GcpBucketSoftDelete
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.{CompactDataTables, GcpBucketSoftDelete}
 import org.broadinstitute.dsde.rawls.model.{
   GcpBucketLifecycleSetting,
   GcpBucketRequesterPaysSetting,
@@ -237,7 +237,7 @@ class WorkspaceSettingRepositorySpec
       Duration.Inf
     )
 
-    val result = Await.result(repo.hasPendingSettings(ws.workspaceIdAsUUID), Duration.Inf)
+    val result = Await.result(repo.hasPendingSettings(ws.workspaceIdAsUUID, GcpBucketSoftDelete), Duration.Inf)
     result shouldBe true
   }
 
@@ -257,7 +257,7 @@ class WorkspaceSettingRepositorySpec
           )
           _ <- dataAccess.workspaceSettingQuery.updateSettingStatus(
             ws.workspaceIdAsUUID,
-            WorkspaceSettingTypes.GcpBucketSoftDelete,
+            GcpBucketSoftDelete,
             WorkspaceSettingRecord.SettingStatus.Pending,
             WorkspaceSettingRecord.SettingStatus.Applied
           )
@@ -266,7 +266,7 @@ class WorkspaceSettingRepositorySpec
       Duration.Inf
     )
 
-    val result = Await.result(repo.hasPendingSettings(ws.workspaceIdAsUUID), Duration.Inf)
+    val result = Await.result(repo.hasPendingSettings(ws.workspaceIdAsUUID, GcpBucketSoftDelete), Duration.Inf)
     result shouldBe false
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -58,6 +58,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.must.Matchers.{contain, include}
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
@@ -1068,5 +1069,67 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
         any()
       )
     ).thenReturn(Future.successful(true))
+  }
+
+  it should "not allow disabling if already enabled" in {
+    val workspaceId = workspace.workspaceIdAsUUID
+    val workspaceName = workspace.toWorkspaceName
+    val enabledSetting = CompactDataTablesSetting(CompactDataTablesConfig(true))
+    val disableSetting = CompactDataTablesSetting(CompactDataTablesConfig(false))
+
+    val samDAO = mock[SamDAO]
+    when(samDAO.getUserStatus(any()))
+      .thenReturn(Future.successful(Option(SamUserStatusResponse("fake_user_id", "user@example.com", true))))
+    when(
+      samDAO.userHasAction(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceId.toString),
+        ArgumentMatchers.eq(SamWorkspaceActions.readSettings),
+        any()
+      )
+    ).thenReturn(Future.successful(true))
+    when(
+      samDAO.userHasAction(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceId.toString),
+        ArgumentMatchers.eq(SamWorkspaceActions.writeSettings),
+        any()
+      )
+    ).thenReturn(Future.successful(true))
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
+
+    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
+    when(workspaceSettingRepository.getWorkspaceSettingOfType(workspaceId, WorkspaceSettingTypes.CompactDataTables))
+      .thenReturn(Future.successful(Some(enabledSetting)))
+    when(workspaceSettingRepository.getWorkspaceSettings(workspaceId))
+      .thenReturn(Future.successful(List(enabledSetting)))
+    when(
+      workspaceSettingRepository.createWorkspaceSettingsRecords(workspaceId,
+                                                                List(disableSetting),
+                                                                defaultRequestContext.userInfo.userSubjectId
+      )
+    ).thenReturn(Future.successful(List(disableSetting)))
+    when(workspaceSettingRepository.removePendingSetting(workspaceId, enabledSetting.settingType))
+      .thenReturn(Future.successful(1))
+
+    val entityService = mock[EntityService]
+
+    val service =
+      workspaceSettingServiceConstructor(
+        samDAO = samDAO,
+        workspaceRepository = workspaceRepository,
+        workspaceSettingRepository = workspaceSettingRepository,
+        entityService = entityService
+      )
+
+    val future = service.setWorkspaceSettings(workspaceName, List(disableSetting))
+    val result = Await.result(future, Duration.Inf)
+    result.successes shouldBe Matchers.empty
+    result.failures.keySet should contain(WorkspaceSettingTypes.CompactDataTables)
+    val error = result.failures(WorkspaceSettingTypes.CompactDataTables)
+    error.statusCode shouldBe Some(StatusCodes.BadRequest)
+    error.message should include("Cannot disable compact data tables setting once enabled.")
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -8,13 +8,16 @@ import cats.effect.unsafe.implicits.global
 import com.google.cloud.Identity
 import com.google.cloud.storage.BucketInfo.{LifecycleRule, SoftDeletePolicy}
 import com.google.cloud.storage.BucketInfo.LifecycleRule.{LifecycleAction, LifecycleCondition}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.QuicksilverMigrationResult
 import org.broadinstitute.dsde.rawls.{
   NoSuchWorkspaceException,
   RawlsExceptionWithErrorReport,
   WorkspaceAccessDeniedException
 }
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
+import org.broadinstitute.dsde.rawls.entities.EntityService
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
+  CompactDataTablesConfig,
   GcpBucketLifecycleAction,
   GcpBucketLifecycleCondition,
   GcpBucketLifecycleConfig,
@@ -43,6 +46,7 @@ import org.broadinstitute.dsde.rawls.model.{
   UseCromwellGcpBatchBackendSetting,
   UserInfo,
   Workspace,
+  WorkspaceName,
   WorkspaceSettingTypes
 }
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
@@ -79,14 +83,16 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     workspaceRepository: WorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS),
     gcsDAO: GoogleServicesDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
     samDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS),
-    googleStorageService: GoogleStorageService[IO] = mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS)
+    googleStorageService: GoogleStorageService[IO] = mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS),
+    entityService: EntityService = mock[EntityService](RETURNS_SMART_NULLS)
   ): WorkspaceSettingService =
     new WorkspaceSettingService(ctx,
                                 workspaceSettingRepository,
                                 workspaceRepository,
                                 gcsDAO,
                                 samDAO,
-                                googleStorageService
+                                googleStorageService,
+                                entityService
     )
 
   val workspace: Workspace = Workspace(
@@ -966,5 +972,101 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     result.successes shouldEqual List.empty
     result.failures.keys should contain theSameElementsAs List(WorkspaceSettingTypes.PubliclyReadable)
     result.failures(WorkspaceSettingTypes.PubliclyReadable).statusCode shouldBe Some(StatusCodes.Forbidden)
+  }
+
+  "Compact Data Tables setting" should "allow enabling CompactDataTables setting" in {
+    val workspaceId = workspace.workspaceIdAsUUID
+    val workspaceName = workspace.toWorkspaceName
+    val enableCompactDataTablesSetting = CompactDataTablesSetting(CompactDataTablesConfig(true))
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
+
+    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
+    when(workspaceSettingRepository.getWorkspaceSettings(workspaceId)).thenReturn(Future.successful(List.empty))
+    when(
+      workspaceSettingRepository.createWorkspaceSettingsRecords(workspaceId,
+                                                                List(enableCompactDataTablesSetting),
+                                                                defaultRequestContext.userInfo.userSubjectId
+      )
+    ).thenReturn(Future.successful(List(enableCompactDataTablesSetting)))
+    when(
+      workspaceSettingRepository.markWorkspaceSettingApplied(workspaceId, enableCompactDataTablesSetting.settingType)
+    )
+      .thenReturn(Future.successful(1))
+
+    val samDAO = mock[SamDAO]
+    when(samDAO.getUserStatus(any()))
+      .thenReturn(Future.successful(Option(SamUserStatusResponse("fake_user_id", "user@example.com", true))))
+    when(
+      samDAO.userHasAction(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceId.toString),
+        ArgumentMatchers.eq(SamWorkspaceActions.writeSettings),
+        any()
+      )
+    ).thenReturn(Future.successful(true))
+
+    val entityService = mock[EntityService]
+    when(
+      entityService.quicksilverMigration(workspaceName = WorkspaceName(workspace.namespace, workspace.name))
+    )
+      .thenReturn(Future.successful(QuicksilverMigrationResult(2, 2, 2)))
+    when(
+      entityService.quicksilverMigration(
+        ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
+        any[Boolean],
+        any[Int]
+      )
+    ).thenReturn(Future.successful(QuicksilverMigrationResult(2, 2, 2)))
+
+    val service =
+      workspaceSettingServiceConstructor(samDAO = samDAO,
+                                         workspaceRepository = workspaceRepository,
+                                         workspaceSettingRepository = workspaceSettingRepository,
+                                         entityService = entityService
+      )
+
+    val res =
+      Await.result(service.setWorkspaceSettings(workspaceName, List(enableCompactDataTablesSetting)), Duration.Inf)
+    res.successes should contain theSameElementsAs List(enableCompactDataTablesSetting)
+    res.failures shouldEqual Map.empty
+    verify(entityService).quicksilverMigration(
+      ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
+      any[Boolean],
+      any[Int]
+    )
+  }
+
+  it should "handle quicksilver migration failure for CompactDataTables setting" in {
+    val workspaceId = workspace.workspaceIdAsUUID
+    val workspaceName = workspace.toWorkspaceName
+    val enableCompactDataTablesSetting = CompactDataTablesSetting(CompactDataTablesConfig(true))
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
+
+    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
+    when(workspaceSettingRepository.getWorkspaceSettings(workspaceId)).thenReturn(Future.successful(List.empty))
+    when(
+      workspaceSettingRepository.createWorkspaceSettingsRecords(workspaceId,
+                                                                List(enableCompactDataTablesSetting),
+                                                                defaultRequestContext.userInfo.userSubjectId
+      )
+    ).thenReturn(Future.successful(List(enableCompactDataTablesSetting)))
+    when(workspaceSettingRepository.removePendingSetting(workspaceId, enableCompactDataTablesSetting.settingType))
+      .thenReturn(Future.successful(1))
+
+    val samDAO = mock[SamDAO]
+    when(samDAO.getUserStatus(any()))
+      .thenReturn(Future.successful(Option(SamUserStatusResponse("fake_user_id", "user@example.com", true))))
+    when(
+      samDAO.userHasAction(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceId.toString),
+        ArgumentMatchers.eq(SamWorkspaceActions.writeSettings),
+        any()
+      )
+    ).thenReturn(Future.successful(true))
   }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-580

Enable Compact Data Table Migration when `CompactDataTables` Setting is Enabled
This PR replaces https://github.com/broadinstitute/rawls/pull/3400

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
