### PR TITLE
CORE-597: entity provider latency metrics via opentelemetry

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -1,5 +1,9 @@
 <configuration>
 
+    <!-- Quiet down logback during startup. If you are trying to change or debug logging setup,
+         you may want to comment out this line during your development efforts. -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
     <if condition='!isDefined("RAWLS_LOG_APPENDER")'>
         <then>
             <variable name="RAWLS_LOG_APPENDER" value="console" />

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/AuditLoggingEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/AuditLoggingEntityProvider.scala
@@ -93,18 +93,15 @@ class AuditLoggingEntityProvider(val delegate: EntityProvider,
     val stopwatch = StopWatch.createStarted() // start a timer
     val tryResult: Try[T] = Try(op(())) // execute the function being wrapped
     stopwatch.stop() // stop the timer
-    val providerName = delegate.getClass.getSimpleName // provider name for metrics
     tryResult match {
       // on success, capture latency and count metrics for the wrapped function
       // then return the wrapped function's result
       case Success(result) =>
-        requestCount(functionName, providerName).inc()
-        requestLatency(functionName, providerName)
-          .update(stopwatch.getDuration.toMillis, TimeUnit.MILLISECONDS)
+        recordFunctionLatency(functionName, delegate, stopwatch.getDuration.toMillis)
         result
       // on error, increment the error count metric and rethrow the exception
       case Failure(exception) =>
-        errorCount(functionName, providerName, exception.getClass.getSimpleName).inc()
+        recordError(functionName, delegate, exception)
         throw exception
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
@@ -3,18 +3,17 @@ package org.broadinstitute.dsde.rawls.entities.base
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.{AttributeKey, Attributes}
 import io.opentelemetry.api.metrics.{DoubleHistogram, LongCounter}
-import io.opentelemetry.instrumentation.api.semconv.http.HttpClientMetrics
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 
 import scala.jdk.CollectionConverters._
 
 trait EntityProviderMetrics extends RawlsInstrumented {
 
-  protected val workbenchMetricBaseName: String
+  private val PREFIX = "rawls_entityprovider"
 
   private val FunctionKey = AttributeKey.stringKey("function")
-  private val ProviderNameKey = AttributeKey.stringKey("providerName")
-  private val ErrorClassKey = AttributeKey.stringKey("errorType")
+  private val ProviderNameKey = AttributeKey.stringKey("providername")
+  private val ErrorClassKey = AttributeKey.stringKey("errortype")
 
   private val BucketBoundaries =
     List[java.lang.Double](0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0).asJava
@@ -23,7 +22,7 @@ trait EntityProviderMetrics extends RawlsInstrumented {
 
   private def entityProviderFunctionLatency: DoubleHistogram =
     meter
-      .histogramBuilder(s"${workbenchMetricBaseName}_provider_function_latency")
+      .histogramBuilder(s"${PREFIX}_function_latency")
       .setDescription("Latency of entity provider function calls")
       .setUnit("ms")
       .setExplicitBucketBoundariesAdvice(BucketBoundaries)
@@ -31,7 +30,7 @@ trait EntityProviderMetrics extends RawlsInstrumented {
 
   private def entityProviderErrorCount: LongCounter =
     meter
-      .counterBuilder(s"${workbenchMetricBaseName}_provider_error_count")
+      .counterBuilder(s"${PREFIX}_error_count")
       .setDescription("Count of errors in entity provider functions")
       .setUnit("error")
       .build()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.entities.base
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.{AttributeKey, Attributes}
 import io.opentelemetry.api.metrics.{DoubleHistogram, LongCounter}
+import io.opentelemetry.instrumentation.api.semconv.http.HttpClientMetrics
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 
 import scala.jdk.CollectionConverters._
@@ -15,6 +16,9 @@ trait EntityProviderMetrics extends RawlsInstrumented {
   private val ProviderNameKey = AttributeKey.stringKey("providerName")
   private val ErrorClassKey = AttributeKey.stringKey("errorType")
 
+  private val BucketBoundaries =
+    List[java.lang.Double](0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0).asJava
+
   private def meter = GlobalOpenTelemetry.get().getMeter("RawlsMetrics")
 
   private def entityProviderFunctionLatency: DoubleHistogram =
@@ -22,7 +26,7 @@ trait EntityProviderMetrics extends RawlsInstrumented {
       .histogramBuilder(s"${workbenchMetricBaseName}_provider_function_latency")
       .setDescription("Latency of entity provider function calls")
       .setUnit("ms")
-      .setExplicitBucketBoundariesAdvice(List[java.lang.Double](50, 95, 99).asJava)
+      .setExplicitBucketBoundariesAdvice(BucketBoundaries)
       .build()
 
   private def entityProviderErrorCount: LongCounter =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
@@ -1,33 +1,61 @@
 package org.broadinstitute.dsde.rawls.entities.base
 
-import nl.grons.metrics4.scala.{Counter, Timer}
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.common.{AttributeKey, Attributes}
+import io.opentelemetry.api.metrics.{DoubleHistogram, LongCounter}
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
+
+import scala.jdk.CollectionConverters._
 
 trait EntityProviderMetrics extends RawlsInstrumented {
 
-  private val FunctionKey = "function"
-  private val ProviderNameKey = "providerName"
+  protected val workbenchMetricBaseName: String
 
-  private def entityProviderMetrics: ExpandedMetricBuilder =
-    ExpandedMetricBuilder.expand(WorkspaceDataMetricKey, "entityProvider")
+  private val FunctionKey = AttributeKey.stringKey("function")
+  private val ProviderNameKey = AttributeKey.stringKey("providerName")
+  private val ErrorClassKey = AttributeKey.stringKey("errorType")
 
-  def requestLatency(functionName: String, providerName: String): Timer =
-    entityProviderMetrics
-      .expand(FunctionKey, functionName)
-      .expand(ProviderNameKey, providerName)
-      .asTimer("latency")
+  private def meter = GlobalOpenTelemetry.get().getMeter("RawlsMetrics")
 
-  def requestCount(functionName: String, providerName: String): Counter =
-    entityProviderMetrics
-      .expand(FunctionKey, functionName)
-      .expand(ProviderNameKey, providerName)
-      .asCounter("count")
+  private def entityProviderFunctionLatency: DoubleHistogram =
+    meter
+      .histogramBuilder(s"${workbenchMetricBaseName}_provider_function_latency")
+      .setDescription("Latency of entity provider function calls")
+      .setUnit("ms")
+      .setExplicitBucketBoundariesAdvice(List[java.lang.Double](50, 95, 99).asJava)
+      .build()
 
-  def errorCount(functionName: String, providerName: String, errorType: String): Counter =
-    entityProviderMetrics
-      .expand(FunctionKey, functionName)
-      .expand(ProviderNameKey, providerName)
-      .expand("errorType", errorType)
-      .asCounter("errors")
+  private def entityProviderErrorCount: LongCounter =
+    meter
+      .counterBuilder(s"${workbenchMetricBaseName}_provider_error_count")
+      .setDescription("Count of errors in entity provider functions")
+      .setUnit("error")
+      .build()
+
+  private def nameOf(provider: EntityProvider): String = provider.getClass.getSimpleName
+
+  private def nameOf(error: Throwable): String = error.getClass.getSimpleName
+
+  def recordFunctionLatency(functionName: String, provider: EntityProvider, durationMs: Double): Unit = {
+    val attrs = Attributes.of(
+      FunctionKey,
+      functionName,
+      ProviderNameKey,
+      nameOf(provider)
+    )
+    entityProviderFunctionLatency.record(durationMs, attrs)
+  }
+
+  def recordError(functionName: String, provider: EntityProvider, error: Throwable): Unit = {
+    val attrs = Attributes.of(
+      FunctionKey,
+      functionName,
+      ProviderNameKey,
+      nameOf(provider),
+      ErrorClassKey,
+      nameOf(error)
+    )
+    entityProviderErrorCount.add(1, attrs)
+  }
 
 }


### PR DESCRIPTION
Ticket: CORE-597

Changes the entity provider metrics from the old Rawls->statsd-sidecar->Prometheus which uses Dropwizard metrics to the newer Rawls->Prometheus which uses OpenTelemetry metrics. Beyond being the preferred architecture, this gives us more control over how the metrics are reported and therefore more control over visualization. See `https://github.com/ReadyTalk/metrics-statsd/issues/21#issuecomment-101903258` for a diversion into limitations of the Dropwizard metrics.

The work in this PR is modeled after [MetricsHelper](https://github.com/broadinstitute/rawls/blob/develop/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/MetricsHelper.scala), which is used to record FastPass metrics.

I have tested this PR in a BEE and see that data tables still work. I have not been able to verify the metrics themselves but will check them once this is deployed to a live environment.