### PR TITLE
CORE-564: report soft-deleted vs live storageState for getBucketUsageV2 API

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -6125,6 +6125,9 @@ components:
         storageClass:
           type: string
           description: The storage class of data in bucket
+        storageState:
+          type: string
+          description: The storage class of data in bucket
       description: ""
     PendingCloneWorkspaceFileTransfer:
       required:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -1146,7 +1146,10 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
   ): BucketMetricsResponse = {
     val metrics = ltspResponse.iterateAll().asScala.toSeq.flatMap { timeSeries =>
       timeSeries.getPointsList.asScala.map { point =>
-        BucketMetric(timeSeries.getMetric.getLabelsMap.get("storage_class"), Math.round(point.getValue.getDoubleValue))
+        BucketMetric(timeSeries.getMetric.getLabelsMap.get("storage_class"),
+                     timeSeries.getMetric.getLabelsMap.get("type"),
+                     Math.round(point.getValue.getDoubleValue)
+        )
       }
     }
     BucketMetricsResponse(metrics)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -291,8 +291,8 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with MockitoTe
     val response = httpGoogleServicesDao.listTimeSeriesPagedResponseToBucketMetricsResponse(mockResponse)
     response.metrics.length shouldBe 2
     val expectedMetrics = Set(
-      BucketMetric("COLDLINE", 123),
-      BucketMetric("REGIONAL", 5432)
+      BucketMetric("COLDLINE", "live-object", 123),
+      BucketMetric("REGIONAL", "soft-deleted-object", 5432)
     )
     response.metrics.toSet shouldBe expectedMetrics
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -182,7 +182,9 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     Future.successful(Some(new Group))
 
   override def getBucketMetrics(googleProject: GoogleProjectId): BucketMetricsResponse =
-    BucketMetricsResponse(Seq(BucketMetric("REGIONAL", 12345), BucketMetric("MULTI_REGIONAL", 54321)))
+    BucketMetricsResponse(
+      Seq(BucketMetric("REGIONAL", "live-object", 12345), BucketMetric("MULTI_REGIONAL", "live-object", 54321))
+    )
 
   override def addEmailToGoogleGroup(groupEmail: String, emailToAdd: String): Future[Unit] = {
     googleGroups(groupEmail) += emailToAdd

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -1101,7 +1101,7 @@ case class BucketMetricsResponse(
 //I believe the options for storageclass are STANDARD, NEARLINE, COLDLINE, ARCHIVE, REGIONAL, MULTI-REGIONAL and DRA.
 //I've seen REGIONAL and MULTI_REGIONAL in practice; I have not seen DRA so I don't know exactly how it would be coded
 //Hence I'm afraid to make an enumeration until I can verify what's possible to see.
-case class BucketMetric(storageClass: String, valueInBytes: Double)
+case class BucketMetric(storageClass: String, storageState: String, valueInBytes: Double)
 
 case class ErrorReport(source: String,
                        message: String,
@@ -1391,7 +1391,7 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val WorkspaceStatusFormat: RootJsonFormat[WorkspaceStatus] = jsonFormat2(WorkspaceStatus)
 
-  implicit val BucketMetricsFormat: RootJsonFormat[BucketMetric] = jsonFormat2(BucketMetric)
+  implicit val BucketMetricsFormat: RootJsonFormat[BucketMetric] = jsonFormat3(BucketMetric)
 
   implicit val BucketMetricsResponseFormat: RootJsonFormat[BucketMetricsResponse] = jsonFormat1(BucketMetricsResponse)
 


### PR DESCRIPTION
Ticket: CORE-564

When reporting on storage in the getBucketUsageV2 API, include details of the soft-deleted vs live-object state.

Future PRs under CORE-564 will expose this in the UI.

Before:
<img width="549" height="356" alt="Screenshot 18-07-2025 at 14 39" src="https://github.com/user-attachments/assets/826229ee-54b9-49a3-b69d-1b71bc4b3272" />

After:
<img width="537" height="401" alt="Screenshot 18-07-2025 at 14 38" src="https://github.com/user-attachments/assets/0389d98f-4846-490c-9565-d1599aafa158" />


