### PR TITLE
CORE-563: disable storage logs for workspace buckets

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -20,10 +20,6 @@ import spray.json.JsObject
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-object GoogleServicesDAO {
-  def getStorageLogsBucketName(googleProject: GoogleProjectId) = s"storage-logs-${googleProject.value}"
-}
-
 trait GoogleServicesDAO extends ErrorReportable {
   val errorReportSource = ErrorReportSource("google")
   val terraBucketReaderRole: String

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -14,7 +14,7 @@ import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.googleapis.auth.oauth2.{GoogleClientSecrets, GoogleCredential}
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
-import com.google.api.client.http.{HttpRequest, HttpRequestInitializer, HttpResponseException, InputStreamContent}
+import com.google.api.client.http.{HttpRequest, HttpRequestInitializer, HttpResponseException}
 import com.google.api.client.json.gson.GsonFactory
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.api.services.cloudbilling.Cloudbilling
@@ -210,26 +210,6 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
                               requestContext: RawlsRequestContext,
                               bucketLocation: Option[String]
   ): Future[GoogleWorkspaceInfo] = {
-    def insertInitialStorageLog: Future[Unit] = {
-      implicit val service = GoogleInstrumentedService.Storage
-      retryWhen500orGoogleError { () =>
-        // manually insert an initial storage log
-        val stream: InputStreamContent =
-          new InputStreamContent(
-            "text/plain",
-            new ByteArrayInputStream(s""""bucket","storage_byte_hours"
-                                        |"$bucketName","0"
-                                        |""".stripMargin.getBytes)
-          )
-        // use an object name that will always be superseded by a real storage log
-        val storageObject = new StorageObject().setName(s"${bucketName}_storage_00_initial_log")
-        val objectInserter = getStorage(getBucketServiceAccountCredential)
-          .objects()
-          .insert(GoogleServicesDAO.getStorageLogsBucketName(googleProject), storageObject, stream)
-        executeGoogleRequest(objectInserter)
-      }
-    }
-
     // setupWorkspace main logic
     val traceId = TraceId(UUID.randomUUID())
     val cors = List(
@@ -252,7 +232,7 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
             labels = labels,
             traceId = Option(traceId),
             bucketPolicyOnlyEnabled = true,
-            logBucket = Option(GcsBucketName(GoogleServicesDAO.getStorageLogsBucketName(googleProject))),
+            logBucket = None,
             location = bucketLocation,
             autoclassEnabled = true,
             autoclassTerminalStorageClass = Option(StorageClass.ARCHIVE),
@@ -273,11 +253,7 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
       updateBucketIamFuture = traceFutureWithParent("updateBucketIam", requestContext)(_ =>
         updateBucketIam(bucketName, policyGroupsByAccessLevel)
       )
-      insertInitialStorageLogFuture = traceFutureWithParent("insertInitialStorageLog", requestContext)(_ =>
-        insertInitialStorageLog
-      )
       _ <- updateBucketIamFuture
-      _ <- insertInitialStorageLogFuture
     } yield GoogleWorkspaceInfo(bucketName.value, policyGroupsByAccessLevel)
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
@@ -762,9 +762,7 @@ object MultiregionalBucketMigrationActor {
               bucketName = destBucketName,
               labels = Option(sourceBucket.getLabels).map(_.asScala.toMap).getOrElse(Map.empty),
               bucketPolicyOnlyEnabled = true,
-              logBucket = GcsBucketName(
-                GoogleServicesDAO.getStorageLogsBucketName(workspace.googleProjectId)
-              ).some,
+              logBucket = None,
               location = env.defaultBucketLocation.some,
               autoclassEnabled = true,
               autoclassTerminalStorageClass = Option(StorageClass.ARCHIVE)


### PR DESCRIPTION
Ticket: CORE-563

Disable [storage logs](https://cloud.google.com/storage/docs/access-logs) for workspace buckets.

Note that this change does not stop creation of the log bucket itself. That is controlled by RBS, [here](https://github.com/DataBiosphere/terra-resource-buffer/blob/624c8fd53349849f7b4ffb7266e302d23957178b/src/main/java/bio/terra/buffer/service/resource/flight/GoogleProjectCreationFlight.java#L54-L56) and will be handled in a future PR. This PR just stops collecting logs into that bucket; the logs bucket will be empty.

