### PR TITLE
[CORE-616] Expression evaluation for complex entity expressions

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -169,13 +169,15 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
 
             val allLookups = inputExpressionData.flatMap { case (_, _, lookups) => lookups }
 
-            // If we have an entitylookup, prepend it to the relation chain of the query
+            // If we have an entitylookup, prepend its chain to the relation chain of the query
             val queryPlans = if (entityType != rootEntityType && entityLookups.nonEmpty) {
-              val entityRelationChain = entityLookups.flatMap(_.attributeName).toList
+              val entityRelationChain: List[String] =
+                entityLookups.flatMap(_.relations.map(_.attributeName()).map(_.getText)).toList
+              val updatedRelationChain = entityRelationChain ++ entityLookups.flatMap(_.attributeName).toList
               val baseQueryPlans = buildQueryPlans(allLookups)
 
               baseQueryPlans.map { plan =>
-                plan.copy(relationChain = entityRelationChain ++ plan.relationChain)
+                plan.copy(relationChain = updatedRelationChain ++ plan.relationChain)
               }
             } else {
               buildQueryPlans(allLookups)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -434,7 +434,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
         attributeNames.map { attrName =>
           val attributeName = AttributeName.fromDelimitedName(attrName)
 
-          val entityToAttributeValues = if (entityType == rootEntityType) {
+          val entityToAttributeValues: Map[String, Try[Seq[AttributeValue]]] = if (entityType == rootEntityType) {
             // Group all results under the original entityName since we want results grouped by the starting entity type
             val allAttrs: Seq[AttributeValue] = entityRecords.values.flatten.toSeq.flatMap { record =>
               if (
@@ -454,24 +454,27 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
             }
             Map(entityName -> Success(allAttrs))
           } else {
-            entityRecords.map { case (actualEntityName, records) =>
-              val attrs: Seq[AttributeValue] = records.flatMap { record =>
-                if (
-                  attributeName == AttributeName.withDefaultNS(record.entityType + Attributable.entityIdAttributeSuffix)
-                ) {
-                  Seq(AttributeString(record.name))
-                } else {
-                  record.toEntity.attributes.get(attributeName) match {
-                    case Some(avl: AttributeValueList) =>
-                      avl.list
-                    case Some(av: AttributeValue) =>
-                      Seq(av)
-                    case _ =>
-                      Seq.empty
+            entityRecords.flatMap { case (_, records) =>
+              records.map { record =>
+                val attrs: Seq[AttributeValue] =
+                  if (
+                    attributeName == AttributeName.withDefaultNS(
+                      record.entityType + Attributable.entityIdAttributeSuffix
+                    )
+                  ) {
+                    Seq(AttributeString(record.name))
+                  } else {
+                    record.toEntity.attributes.get(attributeName) match {
+                      case Some(avl: AttributeValueList) =>
+                        avl.list
+                      case Some(av: AttributeValue) =>
+                        Seq(av)
+                      case _ =>
+                        Seq.empty
+                    }
                   }
-                }
+                record.name -> Success(attrs)
               }
-              actualEntityName -> Success(attrs)
             }
           }
           (expression, entityToAttributeValues)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.rawls.expressions.parser.antlr.TerraExpressionPar
 }
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigTestSupport
 import org.broadinstitute.dsde.rawls.model.{
+  AgoraMethod,
   AttributeName,
   AttributeNumber,
   AttributeString,
@@ -337,6 +338,63 @@ class CompactExpressionEvaluatorSpec
         sampleGood2.name,
         Set(
           SubmissionValidationValue(Some(AttributeNumber(2)), None, intArgNameWithWfName)
+        )
+      )
+    )
+  }
+
+  it should "resolve method config inputs for a chained entity expression" in withConfigData {
+
+    val methConfig = MethodConfiguration(
+      "dsde",
+      "MethodConfig",
+      Some("Sample"),
+      prerequisites = Some(Map.empty[String, AttributeString]),
+      inputs = Map(stringArgNameWithWfName -> AttributeString("this.type")),
+      outputs = Map.empty,
+      AgoraMethod("dsde", "w1", 1)
+    )
+    when(
+      mockQueries.queryRelatedRecordsWithRelationChain(any(),
+                                                       any(),
+                                                       org.mockito.ArgumentMatchers.eq(testData.indiv1.name),
+                                                       any()
+      )
+    )
+      .thenReturn(
+        DBIO.successful(
+          Map(
+            testData.sample1.name -> Seq(toCompactEntityRecord(testData.sample1)),
+            testData.sample2.name -> Seq(toCompactEntityRecord(testData.sample2)),
+            testData.sample3.name -> Seq(toCompactEntityRecord(testData.sample3))
+          )
+        )
+      )
+
+    val expressionEvaluationContext =
+      ExpressionEvaluationContext(Some(testData.indiv1.entityType),
+                                  Some(testData.indiv1.name),
+                                  Some("this.sset.samples"),
+                                  Some(testData.sample1.entityType)
+      )
+    val result = evalInputs(expressionEvaluationContext, methConfig, stringWdl)
+    result should contain theSameElementsAs Seq(
+      SubmissionValidationEntityInputs(
+        testData.sample1.name,
+        Set(
+          SubmissionValidationValue(Some(AttributeString("normal")), None, stringArgNameWithWfName)
+        )
+      ),
+      SubmissionValidationEntityInputs(
+        testData.sample2.name,
+        Set(
+          SubmissionValidationValue(Some(AttributeString("tumor")), None, stringArgNameWithWfName)
+        )
+      ),
+      SubmissionValidationEntityInputs(
+        testData.sample3.name,
+        Set(
+          SubmissionValidationValue(Some(AttributeString("tumor")), None, stringArgNameWithWfName)
         )
       )
     )


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-616

When evaluating the entity expression in a submission, anything beyond the final value (e.g. "samples" of "this.sset.samples") was ignored.  This PR includes all relations from the entity expression in the query.  It also fixes a problem where gathering the results did not take into account that the records returned from the database were already grouped.


**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
