### PR TITLE
CORE-619: entity keys cache, part 1

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -144,4 +144,5 @@
     <include file="changesets/20250514_use_names_in_entity_refs.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250604_entity_refs_view.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250616_remove_all_gcpbatch_workspace_settings.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20250724_entity_keys_cache.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250724_entity_keys_cache.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250724_entity_keys_cache.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
+    <changeSet logicalFilePath="dummy" author="davidan" id="entity_keys_cache">
+        <!-- create ENTITY_KEYS_CACHE table -->
+        <createTable tableName="ENTITY_KEYS_CACHE">
+            <column name="workspace_id" type="BINARY(16)">
+                <constraints nullable="false"
+                             referencedTableName="WORKSPACE" referencedColumnNames="id"
+                             foreignKeyName="fk_entity_keys_cache_workspace_id" deleteCascade="true"/>
+            </column>
+            <column name="entity_type" type="VARCHAR(254)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="attribute_keys" type="JSON">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cached_at" type="TIMESTAMP(6)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="invalidated_at" type="TIMESTAMP(6)">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+        <!-- index on workspace_id + entity_type -->
+        <createIndex indexName="idx_entity_keys_cache_workspace_and_entity_type" tableName="ENTITY_KEYS_CACHE" unique="true">
+            <column name="workspace_id"/>
+            <column name="entity_type"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250724_entity_keys_cache.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250724_entity_keys_cache.xml
@@ -10,7 +10,7 @@
                              referencedTableName="WORKSPACE" referencedColumnNames="id"
                              foreignKeyName="fk_entity_keys_cache_workspace_id" deleteCascade="true"/>
             </column>
-            <column name="entity_type" type="VARCHAR(254)">
+            <column name="entity_type" type="VARCHAR(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin">
                 <constraints nullable="false"/>
             </column>
             <column name="attribute_keys" type="JSON">

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -39,6 +39,7 @@ trait CompactEntityComponent extends LazyLogging {
 
 class CompactEntityQuery(driverComponent: DriverComponent)
     extends CompactEntityMigration
+    with CompactEntityKeysCache
     with RawSqlQuery
     with CompactEntitySerialization {
   override val driver = driverComponent.driver

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
@@ -22,7 +22,7 @@ trait CompactEntityKeysCache {
          select entity_type, attribute_keys
          from ENTITY_KEYS_CACHE
          where workspace_id = $workspaceId
-         and cached_at > invalidated_at;
+         and (invalidated_at is null OR cached_at > invalidated_at);
        """.as[(String, String)].map { rows =>
       rows.map { case (entityType, keysJson) =>
         // parse the json array of keys
@@ -57,7 +57,7 @@ trait CompactEntityKeysCache {
         sql""" as vals
                on duplicate key update
                  ENTITY_KEYS_CACHE.attribute_keys = vals.attribute_keys,
-               E  NTITY_KEYS_CACHE.cached_at = CURRENT_TIMESTAMP(6);"""
+                 ENTITY_KEYS_CACHE.cached_at = CURRENT_TIMESTAMP(6);"""
       ).asUpdate
     }
 
@@ -80,10 +80,14 @@ trait CompactEntityKeysCache {
       DBIO.successful(0)
     } else {
       val inClause = reduceSqlActionsWithDelim(entityTypes.map(t => sql"$t").toSeq, sql", ")
-      sqlu"""update ENTITY_KEYS_CACHE
+      concatSqlActions(
+        sql"""update ENTITY_KEYS_CACHE
               set invalidated_at = CURRENT_TIMESTAMP(6)
               where workspace_id = $workspaceId
-              and entity_type in ($inClause);"""
+              and entity_type in (""",
+        inClause,
+        sql");"
+      ).asUpdate
     }
 
   // ========== delete from cache ==========
@@ -104,9 +108,13 @@ trait CompactEntityKeysCache {
       DBIO.successful(0)
     } else {
       val inClause = reduceSqlActionsWithDelim(entityTypes.map(t => sql"$t").toSeq, sql", ")
-      sqlu"""delete from ENTITY_KEYS_CACHE
+      concatSqlActions(
+        sql"""delete from ENTITY_KEYS_CACHE
               where workspace_id = $workspaceId
-              and entity_type in ($inClause);"""
+              and entity_type in (""",
+        inClause,
+        sql");"
+      ).asUpdate
     }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
@@ -63,12 +63,6 @@ trait CompactEntityKeysCache {
 
   // ========== cache invalidation ==========
 
-  /** Invalidate the cache for all entity types for this workspace */
-  def invalidateCache(workspaceId: UUID): ReadWriteAction[Int] =
-    sqlu"""update ENTITY_KEYS_CACHE
-            set invalidated_at = CURRENT_TIMESTAMP(6)
-            where workspace_id = $workspaceId;"""
-
   /** Invalidate the cache for the given entity type and workspace */
   def invalidateCache(workspaceId: UUID, entityType: String): ReadWriteAction[Int] =
     invalidateCache(workspaceId, Set(entityType))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
@@ -1,0 +1,92 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+import org.broadinstitute.dsde.rawls.model.AttributeName
+
+import java.util.UUID
+import slick.jdbc.MySQLProfile.api._
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+/**
+ * Queries for working with the compact entity keys cache,
+ * i.e. the ENTITY_KEYS_CACHE table
+ */
+trait CompactEntityKeysCache {
+  this: CompactEntityQuery =>
+
+  // ========== save to cache ==========
+
+  /** save the cache for the given entity type and workspace */
+  def saveCache(workspaceId: UUID, entityType: String, keys: Set[AttributeName]): ReadWriteAction[Int] =
+    saveCache(workspaceId, Set(EntityTypeAndAttributeKeys(entityType, keys)))
+
+  /** save multiple cache values for the given workspace */
+  def saveCache(workspaceId: UUID, cacheValues: Set[EntityTypeAndAttributeKeys]) =
+    // short-circuit
+    if (cacheValues.isEmpty) {
+      DBIO.successful(0)
+    } else {
+      val valueClauses = cacheValues.map { case EntityTypeAndAttributeKeys(entityType, keys) =>
+        // build json array value of keys
+        val sortedKeys = keys.toSeq.map(x => AttributeName.toDelimitedName(x)).sorted.toJson.compactPrint
+        sql"($workspaceId, $entityType, $sortedKeys, CURRENT_TIMESTAMP(6))"
+      }.toSeq
+
+      val values = reduceSqlActionsWithDelim(valueClauses, sql"")
+
+      sqlu"""insert into ENTITY_KEYS_CACHE (workspace_id, entity_type, attribute_keys, cached_at)
+              values $values as vals
+              on duplicate key update
+                ENTITY_KEYS_CACHE.attribute_keys = vals.attribute_keys,
+                ENTITY_KEYS_CACHE.cached_at = CURRENT_TIMESTAMP(6);"""
+    }
+
+  // ========== cache invalidation ==========
+
+  /** Invalidate the cache for all entity types for this workspace */
+  def invalidateCache(workspaceId: UUID): ReadWriteAction[Int] =
+    sqlu"""update ENTITY_KEYS_CACHE
+            set invalidated_at = CURRENT_TIMESTAMP(6)
+            where workspace_id = $workspaceId;"""
+
+  /** Invalidate the cache for the given entity type and workspace */
+  def invalidateCache(workspaceId: UUID, entityType: String): ReadWriteAction[Int] =
+    invalidateCache(workspaceId, Set(entityType))
+
+  /** Invalidate the cache for the given entity types and workspace */
+  def invalidateCache(workspaceId: UUID, entityTypes: Set[String]): ReadWriteAction[Int] =
+    // short-circuit
+    if (entityTypes.isEmpty) {
+      DBIO.successful(0)
+    } else {
+      val inClause = reduceSqlActionsWithDelim(entityTypes.map(t => sql"$t").toSeq, sql", ")
+      sqlu"""update ENTITY_KEYS_CACHE
+              set invalidated_at = CURRENT_TIMESTAMP(6)
+              where workspace_id = $workspaceId
+              and entity_type in ($inClause);"""
+    }
+
+  // ========== delete from cache ==========
+
+  /** delete all cache entries for this workspace */
+  def deleteCache(workspaceId: UUID): ReadWriteAction[Int] =
+    sqlu"""delete from ENTITY_KEYS_CACHE
+            where workspace_id = $workspaceId;"""
+
+  /** delete the cache entry for the given entity type and workspace */
+  def deleteCache(workspaceId: UUID, entityType: String): ReadWriteAction[Int] =
+    deleteCache(workspaceId, Set(entityType))
+
+  /** delete the cache entries for the given entity types and workspace */
+  def deleteCache(workspaceId: UUID, entityTypes: Set[String]): ReadWriteAction[Int] =
+    // short-circuit
+    if (entityTypes.isEmpty) {
+      DBIO.successful(0)
+    } else {
+      val inClause = reduceSqlActionsWithDelim(entityTypes.map(t => sql"$t").toSeq, sql", ")
+      sqlu"""delete from ENTITY_KEYS_CACHE
+              where workspace_id = $workspaceId
+              and entity_type in ($inClause);"""
+    }
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
@@ -49,10 +49,10 @@ trait CompactEntityKeysCache {
         sql"($workspaceId, $entityType, $sortedKeys, CURRENT_TIMESTAMP(6))"
       }.toSeq
 
-      val values = reduceSqlActionsWithDelim(valueClauses, sql"")
+      val values = reduceSqlActionsWithDelim(valueClauses, sql", ")
 
       concatSqlActions(
-        sql"insert into ENTITY_KEYS_CACHE (workspace_id, entity_type, attribute_keys, cached_at) values",
+        sql"insert into ENTITY_KEYS_CACHE (workspace_id, entity_type, attribute_keys, cached_at) values ",
         values,
         sql""" as vals
                on duplicate key update

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
@@ -38,7 +38,7 @@ trait CompactEntityKeysCache {
     saveCache(workspaceId, Set(EntityTypeAndAttributeKeys(entityType, keys)))
 
   /** save multiple cache values for the given workspace */
-  def saveCache(workspaceId: UUID, cacheValues: Set[EntityTypeAndAttributeKeys]) =
+  def saveCache(workspaceId: UUID, cacheValues: Set[EntityTypeAndAttributeKeys]): ReadWriteAction[Int] =
     // short-circuit
     if (cacheValues.isEmpty) {
       DBIO.successful(0)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
@@ -90,31 +90,4 @@ trait CompactEntityKeysCache {
       ).asUpdate
     }
 
-  // ========== delete from cache ==========
-
-  /** delete all cache entries for this workspace */
-  def deleteCache(workspaceId: UUID): ReadWriteAction[Int] =
-    sqlu"""delete from ENTITY_KEYS_CACHE
-            where workspace_id = $workspaceId;"""
-
-  /** delete the cache entry for the given entity type and workspace */
-  def deleteCache(workspaceId: UUID, entityType: String): ReadWriteAction[Int] =
-    deleteCache(workspaceId, Set(entityType))
-
-  /** delete the cache entries for the given entity types and workspace */
-  def deleteCache(workspaceId: UUID, entityTypes: Set[String]): ReadWriteAction[Int] =
-    // short-circuit
-    if (entityTypes.isEmpty) {
-      DBIO.successful(0)
-    } else {
-      val inClause = reduceSqlActionsWithDelim(entityTypes.map(t => sql"$t").toSeq, sql", ")
-      concatSqlActions(
-        sql"""delete from ENTITY_KEYS_CACHE
-              where workspace_id = $workspaceId
-              and entity_type in (""",
-        inClause,
-        sql");"
-      ).asUpdate
-    }
-
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
@@ -14,6 +14,23 @@ import spray.json.DefaultJsonProtocol._
 trait CompactEntityKeysCache {
   this: CompactEntityQuery =>
 
+  // ========== read from cache ==========
+
+  /** get all valid cache entries for this workspace */
+  def getCachedKeys(workspaceId: UUID): ReadAction[Seq[EntityTypeAndAttributeKeys]] =
+    sql"""
+         select entity_type, attribute_keys
+         from ENTITY_KEYS_CACHE
+         where workspace_id = $workspaceId
+         and cached_at > invalidated_at;
+       """.as[(String, String)].map { rows =>
+      rows.map { case (entityType, keysJson) =>
+        // parse the json array of keys
+        val attrs = keysJson.parseJson.convertTo[Set[String]].map(AttributeName.fromDelimitedName)
+        EntityTypeAndAttributeKeys(entityType, attrs)
+      }
+    }
+
   // ========== save to cache ==========
 
   /** save the cache for the given entity type and workspace */
@@ -34,11 +51,14 @@ trait CompactEntityKeysCache {
 
       val values = reduceSqlActionsWithDelim(valueClauses, sql"")
 
-      sqlu"""insert into ENTITY_KEYS_CACHE (workspace_id, entity_type, attribute_keys, cached_at)
-              values $values as vals
-              on duplicate key update
-                ENTITY_KEYS_CACHE.attribute_keys = vals.attribute_keys,
-                ENTITY_KEYS_CACHE.cached_at = CURRENT_TIMESTAMP(6);"""
+      concatSqlActions(
+        sql"insert into ENTITY_KEYS_CACHE (workspace_id, entity_type, attribute_keys, cached_at) values",
+        values,
+        sql""" as vals
+               on duplicate key update
+                 ENTITY_KEYS_CACHE.attribute_keys = vals.attribute_keys,
+               E  NTITY_KEYS_CACHE.cached_at = CURRENT_TIMESTAMP(6);"""
+      ).asUpdate
     }
 
   // ========== cache invalidation ==========

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
@@ -82,6 +82,11 @@ case class EntityTypeAndAttributeKey(
   attributeKey: AttributeName
 )
 
+case class EntityTypeAndAttributeKeys(
+  entityType: String,
+  attributeKeys: Set[AttributeName]
+)
+
 case class EntityTypeAndCount(
   entityType: String,
   count: Int

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -150,6 +150,8 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                 }
               }
           }
+        // invalidate the cache for the destination workspace
+        _ <- repository.queries.invalidateCache(destWorkspaceContext.workspaceIdAsUUID, entityType)
       } yield result
     }
     withWorkspaceLastModified(copyResult)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -306,7 +306,9 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                                   java.lang.Long.valueOf(numHardDeletes)
         )
         _ = setTraceSpanAttribute(parentContext, AttributeKey.longKey("softDeletes"), java.lang.Long.valueOf(res))
-      } yield res
+        // invalidate the cache for this entity type
+        _ <- repository.queries.invalidateCache(workspaceId, entityType)
+      } yield res + numHardDeletes
     }
 
   override def deleteEntityAttributes(entityType: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -636,8 +636,16 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
   ): ReadWriteAction[Int] =
     if (updatedEntities.isEmpty)
       DBIO.successful(0)
-    else
-      repository.queries.batchWriteEntities(workspace.workspaceIdAsUUID, updatedEntities, insertOnly = false)
+    else {
+      for {
+        rowCount <- repository.queries.batchWriteEntities(workspace.workspaceIdAsUUID,
+                                                          updatedEntities,
+                                                          insertOnly = false
+        )
+        // invalidate the cache for all entity types that were updated
+        _ <- repository.queries.invalidateCache(workspace.workspaceIdAsUUID, updatedEntities.map(_.entityType).toSet)
+      } yield rowCount
+    }
 
   override def updateEntity(entityType: String,
                             entityName: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -334,6 +334,8 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
             entityType,
             attributeNames
           )
+          // Invalidate the cache for this entity type
+          _ <- repository.queries.invalidateCache(workspaceId, entityType)
         } yield ()
       }
     }
@@ -517,6 +519,10 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                                                                   oldName,
                                                                   attributeRenameRequest
         )
+        // invalidate the cache for this entity type
+        // we could optimize this to rename the attribute inside the cache instead of invalidating,
+        // but that would add complexity
+        _ <- repository.queries.invalidateCache(workspaceId, entityType)
       } yield numEntitiesAffected
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -275,7 +275,9 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                                   java.lang.Long.valueOf(numHardDeletes)
         )
         _ = setTraceSpanAttribute(parentContext, AttributeKey.longKey("softDeletes"), java.lang.Long.valueOf(res))
-      } yield res
+        // invalidate the cache for all entity types that were deleted
+        _ <- repository.queries.invalidateCache(workspaceId, pointers.map(_.entityType).toSet)
+      } yield res + numHardDeletes
     }
 
   override def deleteEntitiesOfType(entityType: String, parentContext: RawlsRequestContext): Future[Int] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -246,6 +246,8 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
           throw new RawlsConcurrentModificationException(
             s"Detected concurrent modifications to entity ${savedEntityRecord.toPointer}."
           )
+        // invalidate cache for this entity type
+        _ <- repository.queries.invalidateCache(workspaceId, savedEntityRecord.entityType)
       } yield savedEntityRecord.toEntity
     }
     // fire-and-forget an update to the workspace's last-modified date; no need to wait for it to complete

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -151,6 +151,9 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
           }
         }
 
+        // invalidate the attribute keys cache for all entity types in this batch
+        _ <- repository.queries.invalidateCache(workspaceId, updatedEntities.map(_.entityType).toSet)
+
       } yield writeCount
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCacheSpec.scala
@@ -1,0 +1,177 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
+import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization.{SqlEntityData, SqlEntityReference}
+import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
+import org.broadinstitute.dsde.rawls.model.{
+  Attributable,
+  AttributeBoolean,
+  AttributeEntityReference,
+  AttributeEntityReferenceList,
+  AttributeName,
+  AttributeNull,
+  AttributeNumber,
+  AttributeRename,
+  AttributeString,
+  AttributeValueList,
+  Entity,
+  EntityColumnFilter,
+  EntityPointer,
+  EntityQuery,
+  FilterOperators,
+  SortDirections,
+  WorkspaceFieldSpecs
+}
+import org.scalatest.Inspectors.forEvery
+import slick.dbio.Effect.Read
+import slick.jdbc.GetResult
+import slick.sql.SqlStreamingAction
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+import java.sql.SQLIntegrityConstraintViolationException
+import java.util.UUID
+import scala.util.Random
+
+class CompactEntityKeysCacheSpec extends TestDriverComponentWithFlatSpecAndMatchers {
+
+  // shorthand vars for tests below to enhance readability
+  private val wsid = minimalTestData.workspace.workspaceIdAsUUID
+  private val ws2id = minimalTestData.workspace2.workspaceIdAsUUID
+  private val q = compactEntityQuery
+
+  // some attribute names used in tests
+  private val attr1 = AttributeName.withDefaultNS("one")
+  private val attr2 = AttributeName.withLibraryNS("two")
+  private val attr3 = AttributeName.fromDelimitedName("three")
+  private val attr4 = AttributeName.fromDelimitedName("namespace:four")
+  private val attr5 = AttributeName.fromDelimitedName("other:five")
+  private val attr6 = AttributeName.fromDelimitedName("six:six")
+
+  behavior of "entity keys cache"
+
+  it should "save and retrieve entity keys cache" in withMinimalTestDatabase { _ =>
+    val entityType = "entityType"
+    val keys = Set(attr1, attr2, attr3, attr4, attr5, attr6)
+
+    // save the cache
+    runAndWait(q.saveCache(wsid, entityType, keys)) shouldBe 1
+
+    // retrieve the cache
+    val actual = runAndWait(q.getCachedKeys(wsid))
+    actual should contain only EntityTypeAndAttributeKeys(entityType, keys)
+  }
+
+  it should "save, update, and retrieve" is pending
+
+  it should "save, invalidate, and retrieve" is pending
+
+  it should "respect workspace boundaries" is pending
+
+  it should "respect entityType criteria when one is supplied" is pending
+
+  it should "respect entityType criteria when multiple are supplied" is pending
+
+  // ====================================================================================================
+  //  helpers for tests
+  // ====================================================================================================
+
+  // This does NOT delegate to insertAndGetAll. This helper uses createEntity.
+  private def insertAndGet(entity: Entity, workspaceId: UUID = wsid): CompactEntityRecord = {
+    // row should not exist before inserting
+    runAndWait(q.getEntity(workspaceId, entity.entityType, entity.name)) shouldBe empty
+
+    // insert the entities
+    runAndWait(q.createEntity(workspaceId, entity)) shouldBe 1
+    // retrieve the entities; retrieved value includes its id
+
+    val actual = runAndWait(q.getEntity(workspaceId, entity.entityType, entity.name))
+    actual should not be empty
+    val rec = actual.get
+    // check entityType, name, and attributes
+    rec.toEntity shouldBe entity
+    // check other db columns which are not present in the Entity object
+    rec.deleted shouldBe false
+    rec.recordVersion shouldBe 0
+
+    rec
+  }
+
+  // This helper uses batchCreateEntities.
+  private def insertAndGetAll(entities: Seq[Entity], workspaceId: UUID = wsid): Seq[CompactEntityRecord] = {
+    // rows should not exist before inserting
+    entities.foreach { entity =>
+      runAndWait(q.getEntity(workspaceId, entity.entityType, entity.name)) shouldBe empty
+    }
+
+    // insert the entities
+    runAndWait(q.batchWriteEntities(workspaceId, entities, insertOnly = true)) shouldBe entities.size
+    // retrieve the entities; retrieved value includes its id
+    entities.map { entity =>
+      val actual = runAndWait(q.getEntity(workspaceId, entity.entityType, entity.name))
+      actual should not be empty
+      val rec = actual.get
+      // check entityType, name, and attributes
+      rec.toEntity shouldBe entity
+      // check other db columns which are not present in the Entity object
+      rec.deleted shouldBe false
+      rec.recordVersion shouldBe 0
+
+      rec
+    }
+  }
+
+  def testDesiredFields(filterTerms: Option[String], columnFilter: Option[EntityColumnFilter])(
+    testQuery: (String, EntityQuery) => SqlStreamingAction[Seq[Entity], Entity, Read]
+  ): Unit = {
+    val entityType = "entityType"
+    val columnFilterAttr = AttributeName.withDefaultNS("foo")
+    val desiredColumnAttr1 = AttributeName.withDefaultNS("bar")
+    val desiredColumnAttr2 = AttributeName.withDefaultNS("baz")
+    val entity1 =
+      Entity(UUID.randomUUID().toString,
+             entityType,
+             Map(columnFilterAttr -> AttributeString("foo"), desiredColumnAttr1 -> AttributeString("bar"))
+      )
+    val entity2 =
+      Entity(
+        UUID.randomUUID().toString,
+        entityType,
+        Map(columnFilterAttr -> AttributeString("foo"),
+            desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux")))
+        )
+      )
+    insertAndGet(entity1)
+    insertAndGet(entity2)
+
+    val entityQuery = EntityQuery(
+      1,
+      10,
+      Attributable.nameReservedAttribute,
+      SortDirections.Ascending,
+      filterTerms,
+      columnFilter = columnFilter,
+      fields = WorkspaceFieldSpecs(Some(Set(toDelimitedName(desiredColumnAttr1), toDelimitedName(desiredColumnAttr2))))
+    )
+    val actual = runAndWait(testQuery(entityType, entityQuery))
+
+    actual should contain theSameElementsAs List(
+      entity1.copy(attributes = Map(desiredColumnAttr1 -> AttributeString("bar"), desiredColumnAttr2 -> AttributeNull)),
+      entity2.copy(attributes =
+        Map(desiredColumnAttr1 -> AttributeNull,
+            desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux")))
+        )
+      )
+    )
+  }
+
+  // helper to validate counts of entities by workspace and type. Note this does not have a `where deleted=0` clause.
+  def getRawCounts: Seq[(UUID, String, Int)] = {
+    import driver.api._ // for bespoke SQL queries
+    implicit val getter: GetResult[(UUID, String, Int)] = GetResult(r => (r.<<, r.<<, r.<<))
+    runAndWait(
+      sql"select workspace_id, entity_type, count(1) from ENTITY group by workspace_id, entity_type"
+        .as[(UUID, String, Int)]
+    )
+  }
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCacheSpec.scala
@@ -1,37 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
-import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
-import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization.{SqlEntityData, SqlEntityReference}
-import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
-import org.broadinstitute.dsde.rawls.model.{
-  Attributable,
-  AttributeBoolean,
-  AttributeEntityReference,
-  AttributeEntityReferenceList,
-  AttributeName,
-  AttributeNull,
-  AttributeNumber,
-  AttributeRename,
-  AttributeString,
-  AttributeValueList,
-  Entity,
-  EntityColumnFilter,
-  EntityPointer,
-  EntityQuery,
-  FilterOperators,
-  SortDirections,
-  WorkspaceFieldSpecs
-}
-import org.scalatest.Inspectors.forEvery
-import slick.dbio.Effect.Read
-import slick.jdbc.GetResult
-import slick.sql.SqlStreamingAction
-import spray.json.DefaultJsonProtocol._
-import spray.json._
-
-import java.sql.SQLIntegrityConstraintViolationException
-import java.util.UUID
-import scala.util.Random
+import org.broadinstitute.dsde.rawls.model.AttributeName
 
 class CompactEntityKeysCacheSpec extends TestDriverComponentWithFlatSpecAndMatchers {
 
@@ -51,127 +20,103 @@ class CompactEntityKeysCacheSpec extends TestDriverComponentWithFlatSpecAndMatch
   behavior of "entity keys cache"
 
   it should "save and retrieve entity keys cache" in withMinimalTestDatabase { _ =>
-    val entityType = "entityType"
-    val keys = Set(attr1, attr2, attr3, attr4, attr5, attr6)
+    val cacheEntry1 = EntityTypeAndAttributeKeys("entityType1", Set(attr1, attr2))
+    val cacheEntry2 = EntityTypeAndAttributeKeys("entityType2", Set(attr3, attr4))
+    val cacheEntry3 = EntityTypeAndAttributeKeys("entityType3", Set(attr5, attr6))
 
     // save the cache
-    runAndWait(q.saveCache(wsid, entityType, keys)) shouldBe 1
+    runAndWait(q.saveCache(wsid, Set(cacheEntry1, cacheEntry2, cacheEntry3))) shouldBe 3
 
     // retrieve the cache
     val actual = runAndWait(q.getCachedKeys(wsid))
-    actual should contain only EntityTypeAndAttributeKeys(entityType, keys)
+    actual should contain theSameElementsAs Seq(cacheEntry1, cacheEntry2, cacheEntry3)
   }
 
-  it should "save, update, and retrieve" is pending
+  it should "update existing cache entries" in withMinimalTestDatabase { _ =>
+    val cacheEntry1 = EntityTypeAndAttributeKeys("entityType1", Set(attr1, attr2))
+    val cacheEntry2 = EntityTypeAndAttributeKeys("entityType2", Set(attr3, attr4))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntry1, cacheEntry2))) shouldBe 2
 
-  it should "save, invalidate, and retrieve" is pending
+    // validate first save
+    val actual = runAndWait(q.getCachedKeys(wsid))
+    actual should contain theSameElementsAs Seq(cacheEntry1, cacheEntry2)
 
-  it should "respect workspace boundaries" is pending
+    // update the cache for entityType1
+    val updatedCacheEntry = EntityTypeAndAttributeKeys("entityType1", Set(attr5, attr6))
+    // note this returns 2, not 1. When MySQL updates an existing row in
+    // an "insert ... on duplicate key update" statement, it counts that as 2 rows affected.
+    runAndWait(q.saveCache(wsid, Set(updatedCacheEntry))) shouldBe 2
 
-  it should "respect entityType criteria when one is supplied" is pending
-
-  it should "respect entityType criteria when multiple are supplied" is pending
-
-  // ====================================================================================================
-  //  helpers for tests
-  // ====================================================================================================
-
-  // This does NOT delegate to insertAndGetAll. This helper uses createEntity.
-  private def insertAndGet(entity: Entity, workspaceId: UUID = wsid): CompactEntityRecord = {
-    // row should not exist before inserting
-    runAndWait(q.getEntity(workspaceId, entity.entityType, entity.name)) shouldBe empty
-
-    // insert the entities
-    runAndWait(q.createEntity(workspaceId, entity)) shouldBe 1
-    // retrieve the entities; retrieved value includes its id
-
-    val actual = runAndWait(q.getEntity(workspaceId, entity.entityType, entity.name))
-    actual should not be empty
-    val rec = actual.get
-    // check entityType, name, and attributes
-    rec.toEntity shouldBe entity
-    // check other db columns which are not present in the Entity object
-    rec.deleted shouldBe false
-    rec.recordVersion shouldBe 0
-
-    rec
+    // validate the update
+    val update = runAndWait(q.getCachedKeys(wsid))
+    update should contain theSameElementsAs Seq(updatedCacheEntry, cacheEntry2)
   }
 
-  // This helper uses batchCreateEntities.
-  private def insertAndGetAll(entities: Seq[Entity], workspaceId: UUID = wsid): Seq[CompactEntityRecord] = {
-    // rows should not exist before inserting
-    entities.foreach { entity =>
-      runAndWait(q.getEntity(workspaceId, entity.entityType, entity.name)) shouldBe empty
+  it should "support invalidation of cache entries" in withMinimalTestDatabase { _ =>
+    val cacheEntry1 = EntityTypeAndAttributeKeys("entityType1", Set(attr1, attr2))
+    val cacheEntry2 = EntityTypeAndAttributeKeys("entityType2", Set(attr3, attr4))
+    val cacheEntry3 = EntityTypeAndAttributeKeys("entityType3", Set(attr5, attr6))
+
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntry1, cacheEntry2, cacheEntry3))) shouldBe 3
+
+    // retrieve the cache
+    val actual = runAndWait(q.getCachedKeys(wsid))
+    actual should contain theSameElementsAs Seq(cacheEntry1, cacheEntry2, cacheEntry3)
+
+    // invalidate the cache for entityType2
+    runAndWait(q.invalidateCache(wsid, Set(cacheEntry2.entityType))) shouldBe 1
+
+    // retrieve the cache
+    val afterInvalidation = runAndWait(q.getCachedKeys(wsid))
+    afterInvalidation should contain theSameElementsAs Seq(cacheEntry1, cacheEntry3)
+
+  }
+
+  it should "respect workspace boundaries for reads" in withMinimalTestDatabase { _ =>
+    val cacheEntry1 = EntityTypeAndAttributeKeys("entityType1", Set(attr1, attr2))
+    val cacheEntry2 = EntityTypeAndAttributeKeys("entityType2", Set(attr3, attr4))
+    val cacheEntry3 = EntityTypeAndAttributeKeys("entityType3", Set(attr5, attr6))
+
+    // save cacheEntry1 and cacheEntry2 to workspace 1
+    runAndWait(q.saveCache(wsid, Set(cacheEntry1, cacheEntry2))) shouldBe 2
+
+    // save cacheEntry3 to workspace 2
+    runAndWait(q.saveCache(ws2id, Set(cacheEntry3))) shouldBe 1
+
+    // retrieve the cache for workspace 1
+    val actual1 = runAndWait(q.getCachedKeys(wsid))
+    actual1 should contain theSameElementsAs Seq(cacheEntry1, cacheEntry2)
+
+    // retrieve the cache for workspace 2
+    val actual2 = runAndWait(q.getCachedKeys(ws2id))
+    actual2 should contain theSameElementsAs Seq(cacheEntry3)
+  }
+
+  it should "respect workspace boundaries for invalidations" in withMinimalTestDatabase { _ =>
+    val cacheEntry1 = EntityTypeAndAttributeKeys("entityType1", Set(attr1, attr2))
+    val cacheEntry2 = EntityTypeAndAttributeKeys("entityType2", Set(attr3, attr4))
+    val cacheEntry3 = EntityTypeAndAttributeKeys("entityType3", Set(attr5, attr6))
+
+    // save all cache entries to both workspace 1 and workspace 2
+    Seq(wsid, ws2id).foreach { workspaceId =>
+      runAndWait(q.saveCache(workspaceId, Set(cacheEntry1, cacheEntry2, cacheEntry3))) shouldBe 3
+      runAndWait(q.getCachedKeys(workspaceId)) should contain theSameElementsAs Seq(cacheEntry1,
+                                                                                    cacheEntry2,
+                                                                                    cacheEntry3
+      )
     }
+    // invalidate cacheEntry2 in workspace 1
+    runAndWait(q.invalidateCache(wsid, cacheEntry2.entityType)) shouldBe 1
 
-    // insert the entities
-    runAndWait(q.batchWriteEntities(workspaceId, entities, insertOnly = true)) shouldBe entities.size
-    // retrieve the entities; retrieved value includes its id
-    entities.map { entity =>
-      val actual = runAndWait(q.getEntity(workspaceId, entity.entityType, entity.name))
-      actual should not be empty
-      val rec = actual.get
-      // check entityType, name, and attributes
-      rec.toEntity shouldBe entity
-      // check other db columns which are not present in the Entity object
-      rec.deleted shouldBe false
-      rec.recordVersion shouldBe 0
+    // retrieve the cache for workspace 1
+    val actual1 = runAndWait(q.getCachedKeys(wsid))
+    actual1 should contain theSameElementsAs Seq(cacheEntry1, cacheEntry3)
 
-      rec
-    }
+    // retrieve the cache for workspace 2
+    val actual2 = runAndWait(q.getCachedKeys(ws2id))
+    actual2 should contain theSameElementsAs Seq(cacheEntry1, cacheEntry2, cacheEntry3)
   }
 
-  def testDesiredFields(filterTerms: Option[String], columnFilter: Option[EntityColumnFilter])(
-    testQuery: (String, EntityQuery) => SqlStreamingAction[Seq[Entity], Entity, Read]
-  ): Unit = {
-    val entityType = "entityType"
-    val columnFilterAttr = AttributeName.withDefaultNS("foo")
-    val desiredColumnAttr1 = AttributeName.withDefaultNS("bar")
-    val desiredColumnAttr2 = AttributeName.withDefaultNS("baz")
-    val entity1 =
-      Entity(UUID.randomUUID().toString,
-             entityType,
-             Map(columnFilterAttr -> AttributeString("foo"), desiredColumnAttr1 -> AttributeString("bar"))
-      )
-    val entity2 =
-      Entity(
-        UUID.randomUUID().toString,
-        entityType,
-        Map(columnFilterAttr -> AttributeString("foo"),
-            desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux")))
-        )
-      )
-    insertAndGet(entity1)
-    insertAndGet(entity2)
-
-    val entityQuery = EntityQuery(
-      1,
-      10,
-      Attributable.nameReservedAttribute,
-      SortDirections.Ascending,
-      filterTerms,
-      columnFilter = columnFilter,
-      fields = WorkspaceFieldSpecs(Some(Set(toDelimitedName(desiredColumnAttr1), toDelimitedName(desiredColumnAttr2))))
-    )
-    val actual = runAndWait(testQuery(entityType, entityQuery))
-
-    actual should contain theSameElementsAs List(
-      entity1.copy(attributes = Map(desiredColumnAttr1 -> AttributeString("bar"), desiredColumnAttr2 -> AttributeNull)),
-      entity2.copy(attributes =
-        Map(desiredColumnAttr1 -> AttributeNull,
-            desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux")))
-        )
-      )
-    )
-  }
-
-  // helper to validate counts of entities by workspace and type. Note this does not have a `where deleted=0` clause.
-  def getRawCounts: Seq[(UUID, String, Int)] = {
-    import driver.api._ // for bespoke SQL queries
-    implicit val getter: GetResult[(UUID, String, Int)] = GetResult(r => (r.<<, r.<<, r.<<))
-    runAndWait(
-      sql"select workspace_id, entity_type, count(1) from ENTITY group by workspace_id, entity_type"
-        .as[(UUID, String, Int)]
-    )
-  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -92,7 +92,30 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
     runAndWait(q.getCachedKeys(wsid)) shouldBe empty
   }
 
-  it should "invalidate after updateEntity" is pending
+  it should "invalidate after updateEntity" in withMinimalTestDatabase { _ =>
+    val entityType = "entityType1"
+    // create entity
+    val provider = defaultProvider()
+    val entity = Entity("name", entityType, Map())
+    val createResult =
+      Await.result(provider.createEntity(entity, defaultRequestContext), atMost)
+    // insert valid cache entry
+    val cacheEntry = EntityTypeAndAttributeKeys(entityType, Set(AttributeName.withDefaultNS("attr1")))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntry))) shouldBe 1
+    // validate cache entry
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntry)
+    // update entity
+    val ops = Seq(AddUpdateAttribute(AttributeName.withDefaultNS("attr1"), AttributeString("value")))
+    val updateResult =
+      Await.result(provider.updateEntity(entity.entityType, entity.name, ops, defaultRequestContext), atMost)
+    updateResult shouldBe entity.copy(attributes =
+      Map(AttributeName.withDefaultNS("attr1") -> AttributeString("value"))
+    )
+    // validate cache entry invalidated
+    runAndWait(q.getCachedKeys(wsid)) shouldBe empty
+  }
+
   it should "invalidate after renameAttribute" is pending
   it should "invalidate after deleteEntityAttributes" is pending
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -264,7 +264,7 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
   it should "invalidate after deleteEntities" in withMinimalTestDatabase { _ =>
     val provider = defaultProvider()
 
-    // insert entities to be updated
+    // insert entities to be deleted
     val entityA1 = Entity("name1", "typeA", Map())
     val entityA2 = Entity("name2", "typeA", Map())
     val entityB1 = Entity("name3", "typeB", Map())
@@ -290,7 +290,82 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
     runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntryC)
   }
 
-  it should "invalidate after copyEntities" is pending
+  it should "invalidate after copyEntities" ignore withMinimalTestDatabase { _ =>
+    val sourceWorkspace = minimalTestData.workspace2
+    val destinationWorkspace = minimalTestData.workspace
+
+    val sourceProvider = new CompactEntityProvider(
+      defaultEntityRequestArguments.copy(workspace = sourceWorkspace),
+      new CompactEntityRepository(slickDataSource)
+    )(ec, system)
+
+    val destinationProvider = new CompactEntityProvider(
+      defaultEntityRequestArguments.copy(workspace = destinationWorkspace),
+      new CompactEntityRepository(slickDataSource)
+    )(ec, system)
+
+    // insert entities to be copied to source workspace
+    val entityA1 = Entity("name1", "typeA", Map())
+    val entityA2 = Entity("name2", "typeA", Map())
+    val entityB1 = Entity("name3", "typeB", Map())
+    Await.result(sourceProvider.createEntity(entityA1, defaultRequestContext), atMost) shouldBe entityA1
+    Await.result(sourceProvider.createEntity(entityA2, defaultRequestContext), atMost) shouldBe entityA2
+    Await.result(sourceProvider.createEntity(entityB1, defaultRequestContext), atMost) shouldBe entityB1
+
+    // validate results of creations
+    val metadataAfter = Await.result(sourceProvider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
+    metadataAfter.size shouldBe 2
+    metadataAfter.keys should contain theSameElementsAs Seq("typeA", "typeB")
+    metadataAfter("typeA").count shouldBe 2
+    metadataAfter("typeB").count shouldBe 1
+
+    // insert valid cache entries for typeA, typeB, and typeC to workspace 1
+    val cacheEntryA = EntityTypeAndAttributeKeys("typeA", Set(AttributeName.withDefaultNS("attr1")))
+    val cacheEntryB = EntityTypeAndAttributeKeys("typeB", Set(AttributeName.withDefaultNS("attr2")))
+    val cacheEntryC = EntityTypeAndAttributeKeys("typeC", Set(AttributeName.withDefaultNS("attr3")))
+    // save the cache
+    runAndWait(
+      q.saveCache(destinationWorkspace.workspaceIdAsUUID, Set(cacheEntryA, cacheEntryB, cacheEntryC))
+    ) shouldBe 3
+    // validate cache entries
+    runAndWait(q.getCachedKeys(destinationWorkspace.workspaceIdAsUUID)) should contain theSameElementsAs Seq(
+      cacheEntryA,
+      cacheEntryB,
+      cacheEntryC
+    )
+
+    // copy entities from workspace 2 to workspace 1
+    val copyResult =
+      Await.result(
+        sourceProvider.copyEntities(
+          sourceWorkspace,
+          destinationWorkspace,
+          entityA1.entityType,
+          Seq(entityA1.name, entityA2.name),
+          linkExistingEntities = false,
+          defaultRequestContext
+        ),
+        atMost
+      )
+
+    // validate results of copying
+    val metadataDestination =
+      Await.result(destinationProvider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
+    metadataDestination.size shouldBe 1
+    metadataDestination.keys should contain theSameElementsAs Seq("typeA")
+    metadataDestination("typeA").count shouldBe 2
+
+    copyResult.hardConflicts shouldBe empty
+    copyResult.softConflicts shouldBe empty
+    copyResult.entitiesCopied should contain theSameElementsAs Seq(entityA1.toReference, entityA2.toReference)
+
+    // validate that typeA cache entry is invalidated
+    runAndWait(q.getCachedKeys(destinationWorkspace.workspaceIdAsUUID)) should contain theSameElementsAs Seq(
+      cacheEntryB,
+      cacheEntryC
+    )
+  }
+
   it should "invalidate after saveWorkflowOutputEntities" is pending
 
   behavior of "clone"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -121,8 +121,89 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
 
   behavior of "multiple entity-type cache invalidation"
 
-  it should "invalidate after batchUpsertEntities" is pending
-  it should "invalidate after batchUpdateEntities" is pending
+  it should "invalidate after batchUpsertEntities" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+
+    // define updates for typeA and typeB
+    val updates: Seq[EntityUpdateDefinition] = Seq(
+      EntityUpdateDefinition("name1", "typeA", Seq()),
+      EntityUpdateDefinition("name2", "typeA", Seq()),
+      EntityUpdateDefinition("name3", "typeB", Seq())
+    )
+
+    // insert valid cache entries for typeA, typeB, and typeC
+    val cacheEntryA = EntityTypeAndAttributeKeys("typeA", Set(AttributeName.withDefaultNS("attr1")))
+    val cacheEntryB = EntityTypeAndAttributeKeys("typeB", Set(AttributeName.withDefaultNS("attr2")))
+    val cacheEntryC = EntityTypeAndAttributeKeys("typeC", Set(AttributeName.withDefaultNS("attr3")))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntryA, cacheEntryB, cacheEntryC))) shouldBe 3
+    // validate cache entries
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntryA, cacheEntryB, cacheEntryC)
+
+    // perform the batch upsert
+    val numUpdated = Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
+    numUpdated shouldBe 3
+    // validate results of batch upsert
+    val metadataAfter = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
+    metadataAfter.size shouldBe 2
+    metadataAfter.keys should contain theSameElementsAs Seq("typeA", "typeB")
+    metadataAfter("typeA").count shouldBe 2
+    metadataAfter("typeB").count shouldBe 1
+
+    // validate that typeA and typeB cache entries are invalidated
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntryC)
+  }
+
+  it should "invalidate after batchUpdateEntities" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+
+    // insert entities to be updated
+    val entityA1 = Entity("name1", "typeA", Map())
+    val entityA2 = Entity("name2", "typeA", Map())
+    val entityB1 = Entity("name3", "typeB", Map())
+    Await.result(provider.createEntity(entityA1, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityA2, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityB1, defaultRequestContext), atMost)
+
+    // define updates for typeA and typeB
+    val updates: Seq[EntityUpdateDefinition] = Seq(
+      EntityUpdateDefinition("name1",
+                             "typeA",
+                             Seq(AddUpdateAttribute(AttributeName.withDefaultNS("foo"), AttributeString("bar")))
+      ),
+      EntityUpdateDefinition("name2",
+                             "typeA",
+                             Seq(AddUpdateAttribute(AttributeName.withDefaultNS("foo"), AttributeString("baz")))
+      ),
+      EntityUpdateDefinition("name3",
+                             "typeB",
+                             Seq(AddUpdateAttribute(AttributeName.withDefaultNS("foo"), AttributeString("qux")))
+      )
+    )
+
+    // insert valid cache entries for typeA, typeB, and typeC
+    val cacheEntryA = EntityTypeAndAttributeKeys("typeA", Set(AttributeName.withDefaultNS("attr1")))
+    val cacheEntryB = EntityTypeAndAttributeKeys("typeB", Set(AttributeName.withDefaultNS("attr2")))
+    val cacheEntryC = EntityTypeAndAttributeKeys("typeC", Set(AttributeName.withDefaultNS("attr3")))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntryA, cacheEntryB, cacheEntryC))) shouldBe 3
+    // validate cache entries
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntryA, cacheEntryB, cacheEntryC)
+
+    // perform the batch upsert
+    val numUpdated = Await.result(provider.batchUpdateEntities(Source(updates), defaultRequestContext), atMost)
+    numUpdated shouldBe 3
+    // validate results of batch upsert
+    val metadataAfter = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
+    metadataAfter.size shouldBe 2
+    metadataAfter.keys should contain theSameElementsAs Seq("typeA", "typeB")
+    metadataAfter("typeA").count shouldBe 2
+    metadataAfter("typeB").count shouldBe 1
+
+    // validate that typeA and typeB cache entries are invalidated
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntryC)
+  }
+
   it should "invalidate after copyEntities" is pending
   it should "invalidate after saveWorkflowOutputEntities" is pending
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -176,6 +176,26 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
     runAndWait(q.getCachedKeys(wsid)) shouldBe empty
   }
 
+  it should "invalidate after deleteEntitiesOfType" in withMinimalTestDatabase { _ =>
+    val entityType = "entityType1"
+    // create entity
+    val provider = defaultProvider()
+    val entity = Entity("name", entityType, Map())
+    Await.result(provider.createEntity(entity, defaultRequestContext), atMost)
+    // insert valid cache entry
+    val cacheEntry = EntityTypeAndAttributeKeys(entityType, Set(AttributeName.withDefaultNS("attr1")))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntry))) shouldBe 1
+    // validate cache entry
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntry)
+    // delete entities of this type
+    val deleteResult =
+      Await.result(provider.deleteEntitiesOfType(entity.entityType, defaultRequestContext), atMost)
+    deleteResult shouldBe 1
+    // validate cache entry invalidated
+    runAndWait(q.getCachedKeys(wsid)) shouldBe empty
+  }
+
   behavior of "multiple entity-type cache invalidation"
 
   it should "invalidate after batchUpsertEntities" in withMinimalTestDatabase { _ =>
@@ -394,15 +414,13 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
 
   behavior of "clone"
 
+  // this is an optimization; it would be correct but slower without this
   it should "also clone cache entries" is pending
 
   behavior of "renameEntityType"
 
+  // this is an optimization; it would be correct but slower without this
   it should "also rename the cache entry" is pending
-
-  behavior of "deleteEntitiesOfType"
-
-  it should "also delete the cache entry" is pending
 
   // ====================================================================================================
   //  helper methods

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -97,8 +97,7 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
     // create entity
     val provider = defaultProvider()
     val entity = Entity("name", entityType, Map())
-    val createResult =
-      Await.result(provider.createEntity(entity, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entity, defaultRequestContext), atMost)
     // insert valid cache entry
     val cacheEntry = EntityTypeAndAttributeKeys(entityType, Set(AttributeName.withDefaultNS("attr1")))
     // save the cache
@@ -116,8 +115,66 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
     runAndWait(q.getCachedKeys(wsid)) shouldBe empty
   }
 
-  it should "invalidate after renameAttribute" is pending
-  it should "invalidate after deleteEntityAttributes" is pending
+  it should "invalidate after renameAttribute" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+
+    // insert the entities to be updated
+    val entityA1 = Entity("name1", "typeA", Map(AttributeName.withDefaultNS("old") -> AttributeNumber(42)))
+    Await.result(provider.createEntity(entityA1, defaultRequestContext), atMost)
+
+    // insert valid cache entries for typeA
+    val cacheEntryA = EntityTypeAndAttributeKeys("typeA", Set(AttributeName.withDefaultNS("attr1")))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntryA))) shouldBe 1
+    // validate cache entries
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntryA)
+
+    // perform the attribute rename
+    val numUpdated = Await.result(
+      provider.renameAttribute(entityA1.entityType,
+                               AttributeName.withDefaultNS("old"),
+                               AttributeRename(AttributeName.withDefaultNS("new")),
+                               defaultRequestContext
+      ),
+      atMost
+    )
+    numUpdated shouldBe 1
+
+    // validate that typeA and typeB cache entries are invalidated
+    runAndWait(q.getCachedKeys(wsid)) shouldBe empty
+  }
+
+  it should "invalidate after deleteEntityAttributes" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+
+    // insert the entities to be updated
+    val entityA1 = Entity("name1", "typeA", Map(AttributeName.withDefaultNS("deleteme1") -> AttributeNumber(42)))
+    val entityA2 = Entity("name2", "typeA", Map(AttributeName.withDefaultNS("deleteme2") -> AttributeNumber(123)))
+    Await.result(provider.createEntity(entityA1, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityA2, defaultRequestContext), atMost)
+
+    // insert valid cache entries for typeA
+    val cacheEntryA = EntityTypeAndAttributeKeys("typeA", Set(AttributeName.withDefaultNS("attr1")))
+
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntryA))) shouldBe 1
+    // validate cache entries
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntryA)
+
+    // perform the attribute delete
+    Await.result(
+      provider.deleteEntityAttributes(entityA1.entityType,
+                                      Set(AttributeName.withDefaultNS("deleteme1"),
+                                          AttributeName.withDefaultNS("deleteme2")
+                                      ),
+                                      defaultRequestContext
+      ),
+      atMost
+    )
+
+    // validate that typeA and typeB cache entries are invalidated
+    runAndWait(q.getCachedKeys(wsid)) shouldBe empty
+  }
 
   behavior of "multiple entity-type cache invalidation"
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -366,7 +366,31 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
     )
   }
 
-  it should "invalidate after saveWorkflowOutputEntities" is pending
+  it should "invalidate after saveWorkflowOutputEntities" in withMinimalTestDatabase { dataSource =>
+    val entityType = "entityType1"
+    // create entity
+    val provider = defaultProvider()
+    val entity = Entity("name", entityType, Map())
+    Await.result(provider.createEntity(entity, defaultRequestContext), atMost)
+    // insert valid cache entry
+    val cacheEntry = EntityTypeAndAttributeKeys(entityType, Set(AttributeName.withDefaultNS("attr1")))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntry))) shouldBe 1
+    // validate cache entry
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntry)
+    // call saveWorkflowOutputEntities on this entity
+
+    val updatedEntity = entity.copy(attributes = Map(AttributeName.withDefaultNS("attr1") -> AttributeString("value")))
+    val updateResult =
+      runAndWait(
+        provider.saveWorkflowOutputEntities(dataSource.dataAccess, minimalTestData.workspace, Seq(updatedEntity))
+      )
+    // note this returns 2, not 1. When MySQL updates an existing row in
+    // an "insert ... on duplicate key update" statement, it counts that as 2 rows affected.
+    updateResult shouldBe 2
+    // validate cache entry invalidated
+    runAndWait(q.getCachedKeys(wsid)) shouldBe empty
+  }
 
   behavior of "clone"
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -1,0 +1,122 @@
+package org.broadinstitute.dsde.rawls.entities.compact
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.stream.scaladsl.{Sink, Source}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{
+  EntityTypeAndAttributeKeys,
+  TestDriverComponentWithFlatSpecAndMatchers
+}
+import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
+import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityNotFoundException}
+import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
+  AddListMember,
+  AddUpdateAttribute,
+  AttributeUpdateOperation,
+  CreateAttributeEntityReferenceList,
+  EntityUpdateDefinition,
+  RemoveAttribute
+}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  AttributeEntityReferenceList,
+  AttributeName,
+  AttributeNumber,
+  AttributeRename,
+  AttributeString,
+  Entity,
+  EntityPointer,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  UserInfo
+}
+
+import java.sql.SQLException
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+/**
+  * This spec tests from CompactEntityProvider down to the database.
+  *
+  * Compare to CompactEntityProviderSpec for tests that don't hit the database.
+  *
+  */
+class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpecAndMatchers {
+
+  // shorthand vars for tests below to enhance readability
+  private val wsid = minimalTestData.workspace.workspaceIdAsUUID
+  private val q = compactEntityQuery
+
+  private val defaultRequestContext =
+    RawlsRequestContext(
+      UserInfo(RawlsUserEmail("test"), OAuth2BearerToken("Bearer 123"), 123, RawlsUserSubjectId("abc"))
+    )
+
+  private val defaultEntityRequestArguments =
+    EntityRequestArguments(minimalTestData.workspace, defaultRequestContext)
+
+  private val atMost = Duration("60 seconds") // timeout for Await() in tests
+
+  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+  implicit val system: ActorSystem = ActorSystem("CompactEntityProviderE2ESpec")
+
+  behavior of "entityTypeMetadata"
+
+  it should "read valid cache entries" is pending
+
+  it should "persist invalid cache entries" is pending
+
+  it should "persist missing cache entries" is pending
+
+  it should "ignore extraneous cache entries" is pending
+
+  behavior of "single entity-type cache invalidation"
+
+  it should "invalidate after createEntity" in withMinimalTestDatabase { _ =>
+    // insert valid cache entry
+    val cacheEntry = EntityTypeAndAttributeKeys("entityType1", Set(AttributeName.withDefaultNS("attr1")))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntry))) shouldBe 1
+    // validate cache entry
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntry)
+    // create entity
+    val provider = defaultProvider()
+    val entity = Entity("name", cacheEntry.entityType, Map())
+    val createResult =
+      Await.result(provider.createEntity(entity, defaultRequestContext), atMost)
+    // validate entity created
+    createResult shouldBe entity
+    // validate cache entry invalidated
+    runAndWait(q.getCachedKeys(wsid)) shouldBe empty
+  }
+
+  it should "invalidate after updateEntity" is pending
+  it should "invalidate after renameAttribute" is pending
+  it should "invalidate after deleteEntityAttributes" is pending
+
+  behavior of "multiple entity-type cache invalidation"
+
+  it should "invalidate after batchUpsertEntities" is pending
+  it should "invalidate after batchUpdateEntities" is pending
+  it should "invalidate after copyEntities" is pending
+  it should "invalidate after saveWorkflowOutputEntities" is pending
+
+  behavior of "clone"
+
+  it should "also clone cache entries" is pending
+
+  behavior of "renameEntityType"
+
+  it should "also rename the cache entry" is pending
+
+  // ====================================================================================================
+  //  helper methods
+  // ====================================================================================================
+  def defaultProvider(): CompactEntityProvider = {
+    val repository = new CompactEntityRepository(slickDataSource)
+    new CompactEntityProvider(defaultEntityRequestArguments, repository)(ec, system)
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -64,7 +64,7 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
 
   behavior of "entityTypeMetadata"
 
-  it should "read valid cache entries" is pending
+  it should "use valid cache entries" is pending
 
   it should "persist invalid cache entries" is pending
 
@@ -204,6 +204,7 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
     runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntryC)
   }
 
+  it should "invalidate after deleteEntities" is pending
   it should "invalidate after copyEntities" is pending
   it should "invalidate after saveWorkflowOutputEntities" is pending
 
@@ -214,6 +215,10 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
   behavior of "renameEntityType"
 
   it should "also rename the cache entry" is pending
+
+  behavior of "deleteEntitiesOfType"
+
+  it should "also delete the cache entry" is pending
 
   // ====================================================================================================
   //  helper methods

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -261,7 +261,35 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
     runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntryC)
   }
 
-  it should "invalidate after deleteEntities" is pending
+  it should "invalidate after deleteEntities" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+
+    // insert entities to be updated
+    val entityA1 = Entity("name1", "typeA", Map())
+    val entityA2 = Entity("name2", "typeA", Map())
+    val entityB1 = Entity("name3", "typeB", Map())
+    Await.result(provider.createEntity(entityA1, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityA2, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityB1, defaultRequestContext), atMost)
+
+    // insert valid cache entries for typeA, typeB, and typeC
+    val cacheEntryA = EntityTypeAndAttributeKeys("typeA", Set(AttributeName.withDefaultNS("attr1")))
+    val cacheEntryB = EntityTypeAndAttributeKeys("typeB", Set(AttributeName.withDefaultNS("attr2")))
+    val cacheEntryC = EntityTypeAndAttributeKeys("typeC", Set(AttributeName.withDefaultNS("attr3")))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntryA, cacheEntryB, cacheEntryC))) shouldBe 3
+    // validate cache entries
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntryA, cacheEntryB, cacheEntryC)
+
+    // delete some of the entities from typeA and typeB
+    val numDeleted =
+      Await.result(provider.deleteEntities(Seq(entityA1.toPointer, entityB1.toPointer), defaultRequestContext), atMost)
+    numDeleted shouldBe 2
+
+    // validate that typeA and typeB cache entries are invalidated
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntryC)
+  }
+
   it should "invalidate after copyEntities" is pending
   it should "invalidate after saveWorkflowOutputEntities" is pending
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -40,10 +40,9 @@ import org.broadinstitute.dsde.rawls.model.{
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, MockitoTestUtils}
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, anyString, eq => mockitoEq}
-import org.mockito.Mockito.{never, timeout => mockitotimeout, times, verify, when}
+import org.mockito.Mockito.{never, timeout => mockitotimeout, times, verify, when, RETURNS_SMART_NULLS}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.concurrent.Futures.{scaled, PatienceConfig}
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
 import slick.dbio.DBIO
 
@@ -93,11 +92,12 @@ class CompactEntityProviderSpec
   behavior of "batchUpsertEntities and batchUpdateEntities"
 
   it should "issue one insert statement for multiple entities" in {
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.batchWriteEntities(any(), any(), any())).thenReturn(DBIO.successful(0))
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.getEntities(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityVersions(any(), any())).thenReturn(DBIO.successful(Seq()))
+    when(mockQuery.invalidateCache(any(), any[Set[String]]())).thenReturn(DBIO.successful(0))
 
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
@@ -115,11 +115,12 @@ class CompactEntityProviderSpec
   }
 
   it should "issue multiple insert statements when given large batches" in {
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.batchWriteEntities(any(), any(), any())).thenReturn(DBIO.successful(0))
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.getEntities(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityVersions(any(), any())).thenReturn(DBIO.successful(Seq()))
+    when(mockQuery.invalidateCache(any(), any[Set[String]]())).thenReturn(DBIO.successful(0))
 
     val config = CompactEntityProviderConfig(batchUpsertBatchSize = 25) // pretty small to force batching
 
@@ -146,11 +147,12 @@ class CompactEntityProviderSpec
   }
 
   it should "ask to insert references" in {
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.batchWriteEntities(any(), any(), any())).thenReturn(DBIO.successful(-1))
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.getEntities(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.getEntityVersions(any(), any())).thenReturn(DBIO.successful(Seq()))
+    when(mockQuery.invalidateCache(any(), any[Set[String]]())).thenReturn(DBIO.successful(0))
 
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
@@ -204,12 +206,13 @@ class CompactEntityProviderSpec
       )
 
     // mocks
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.createEntity(any(), any())).thenReturn(DBIO.successful(1))
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(None)) // first request finds nothing
       .thenReturn(DBIO.successful(Some(createdEntityRec))) // second request finds the entity we saved
+    when(mockQuery.invalidateCache(any(), any[String]())).thenReturn(DBIO.successful(0))
 
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
@@ -244,12 +247,13 @@ class CompactEntityProviderSpec
                           Some("""{"baz":123,"foo":"bar"}""")
       )
 
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.createEntity(any(), any())).thenReturn(DBIO.successful(1))
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(None)) // first request finds nothing
       .thenReturn(DBIO.successful(Some(createdEntityRec))) // second request finds the entity we saved
+    when(mockQuery.invalidateCache(any(), any[String]())).thenReturn(DBIO.successful(0))
 
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
@@ -295,12 +299,13 @@ class CompactEntityProviderSpec
         )
       )
 
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(true))
     when(mockQuery.createEntity(any(), any())).thenReturn(DBIO.successful(1))
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(None)) // first request finds nothing
       .thenReturn(DBIO.successful(Some(createdEntityRec))) // second request finds the entity we saved
+    when(mockQuery.invalidateCache(any(), any[String]())).thenReturn(DBIO.successful(0))
 
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
@@ -341,7 +346,7 @@ class CompactEntityProviderSpec
       )
     )
 
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(None)) // first request finds nothing
     when(mockQuery.existsAll(any(), any())).thenReturn(DBIO.successful(false)) // reference targets are missing
@@ -382,7 +387,7 @@ class CompactEntityProviderSpec
                           Some("{}")
       )
 
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(Some(createdEntityRec)))
 
@@ -418,7 +423,7 @@ class CompactEntityProviderSpec
   illegalEntities foreach { case (hint, entityToCreate) =>
     it should s"throw RawlsExceptionWithErrorReport when presented with a(n) $hint" in {
       // provider using mocks
-      val mockQuery = mock[CompactEntityQuery]
+      val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
       val provider = providerWithMocks(mockQuery)
 
       val actual = intercept[RawlsExceptionWithErrorReport] {
@@ -470,7 +475,7 @@ class CompactEntityProviderSpec
                           Some("""{"baz":456,"foo":"boo"}""")
       )
 
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.getReferencesTo(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.deleteEntities(any(), any())).thenReturn(DBIO.successful(0))
     when(
@@ -488,6 +493,7 @@ class CompactEntityProviderSpec
     )
       .thenReturn(DBIO.successful(Some(createdEntityRec2)))
     when(mockQuery.batchHide(any(), any())).thenReturn(DBIO.successful(1))
+    when(mockQuery.invalidateCache(any(), any[Set[String]]())).thenReturn(DBIO.successful(0))
 
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
@@ -543,7 +549,7 @@ class CompactEntityProviderSpec
              )
       )
 
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.getReferencesTo(any(), any())).thenReturn(DBIO.successful(Seq(referencingEntity.toPointer)))
     when(
       mockQuery.getEntity(any[UUID],
@@ -577,10 +583,11 @@ class CompactEntityProviderSpec
   it should "delete all entities of type" in {
     val entityType = "type"
 
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.getReferencesToType(any(), any())).thenReturn(DBIO.successful(Seq()))
     when(mockQuery.deleteEntitiesOfType(any(), any())).thenReturn(DBIO.successful(0))
     when(mockQuery.batchHideType(any(), any())).thenReturn(DBIO.successful(1))
+    when(mockQuery.invalidateCache(any(), any[String]())).thenReturn(DBIO.successful(0))
 
     // provider using mocks
     val provider = providerWithMocks(mockQuery)
@@ -608,7 +615,7 @@ class CompactEntityProviderSpec
              )
       )
 
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.getReferencesToType(any(), any())).thenReturn(DBIO.successful(Seq(referencingEntity.toPointer)))
     when(mockQuery.batchHideType(any(), any())).thenReturn(DBIO.successful(1))
 
@@ -630,7 +637,7 @@ class CompactEntityProviderSpec
   behavior of "entityTypeMetadata"
 
   it should "return empty map when no entities exist" in {
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.listEntityKeysViaEntity(any[UUID]))
       .thenReturn(DBIO.successful(Seq.empty))
     when(mockQuery.countEntitiesGroupedByType(any[UUID]))
@@ -645,7 +652,7 @@ class CompactEntityProviderSpec
   }
 
   it should "return map with entity type and count when entities exist" in {
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     // type1 and type2 have keys, type3 has no keys
     when(mockQuery.listEntityKeysViaEntity(any[UUID]))
       .thenReturn(
@@ -687,7 +694,7 @@ class CompactEntityProviderSpec
       CompactEntityRecord(1, "name", "type", UUID.randomUUID(), -1, deleted = false, Some("{}"))
 
     // mocks
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(Some(rec)))
 
@@ -706,7 +713,7 @@ class CompactEntityProviderSpec
       CompactEntityRecord(1, "name", "type", UUID.randomUUID(), -1, deleted = false, Some(attrString))
 
     // mocks
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(Some(rec)))
 
@@ -728,7 +735,7 @@ class CompactEntityProviderSpec
 
   it should "throw EntityNotFoundException if row not found in db" in {
     // mocks
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.getEntity(any[UUID], anyString(), anyString()))
       .thenReturn(DBIO.successful(None))
     // provider using mocks
@@ -743,7 +750,7 @@ class CompactEntityProviderSpec
   behavior of "listWorkflowEntities"
 
   it should "pass the workspace and requested entity ids to the downstream query" in {
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
 
     val requestedIds = Seq(111L, 222L, 333L)
 
@@ -761,7 +768,7 @@ class CompactEntityProviderSpec
   }
 
   it should "bypass the database when asked to save nothing" in {
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     val provider = providerWithMocks(mockQueries)
 
     val mockDataAccess = mock[DataAccess]
@@ -784,7 +791,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("same")
     val newName = AttributeName.withDefaultNS("same")
 
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
 
     val provider = providerWithMocks(mockQueries)
 
@@ -803,7 +810,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("oldName")
     val newName = AttributeName.withDefaultNS("no! @@bad@@")
 
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
 
     val provider = providerWithMocks(mockQueries)
 
@@ -822,7 +829,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("no! @@bad@@")
     val newName = AttributeName.withDefaultNS("newName")
 
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
 
     val provider = providerWithMocks(mockQueries)
 
@@ -841,7 +848,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("oldName")
     val newName = AttributeName.withDefaultNS(s"${entityType}_id")
 
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
 
     val provider = providerWithMocks(mockQueries)
 
@@ -860,7 +867,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS(s"${entityType}_id")
     val newName = AttributeName.withDefaultNS("newName")
 
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
 
     val provider = providerWithMocks(mockQueries)
 
@@ -879,7 +886,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("oldName")
     val newName = AttributeName.withDefaultNS("newName")
 
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
 
     // mock: new name already exists
     when(mockQueries.attributeExists(any[UUID], anyString(), mockitoEq(newName)))
@@ -902,7 +909,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("oldName")
     val newName = AttributeName.withDefaultNS("newName")
 
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
 
     // mock: new name does not exist
     when(mockQueries.attributeExists(any[UUID], anyString(), mockitoEq(newName)))
@@ -928,7 +935,7 @@ class CompactEntityProviderSpec
     val oldName = AttributeName.withDefaultNS("oldName")
     val newName = AttributeName.withDefaultNS("newName")
 
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
 
     // mock: new name does not exist
     when(mockQueries.attributeExists(any[UUID], anyString(), mockitoEq(newName)))
@@ -939,6 +946,7 @@ class CompactEntityProviderSpec
     // mock: rename touches 123 entities
     when(mockQueries.renameAttribute(any[UUID], anyString(), mockitoEq(oldName), mockitoEq(AttributeRename(newName))))
       .thenReturn(DBIO.successful(123))
+    when(mockQueries.invalidateCache(any(), any[String]())).thenReturn(DBIO.successful(0))
 
     val provider = providerWithMocks(mockQueries)
 
@@ -1094,7 +1102,7 @@ class CompactEntityProviderSpec
   behavior of "renameEntityType"
 
   it should "throw NotFound if the entity type doesn't exist" in {
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
 
     // Mock the count for a non-existent entity type to return 0
     when(mockQueries.countEntities(any[UUID], anyString())).thenReturn(DBIO.successful(0))
@@ -1115,7 +1123,7 @@ class CompactEntityProviderSpec
   }
 
   it should "throw Conflict if the new entity type already exists" in {
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
 
     // The old type exists
     when(mockQueries.countEntities(any[UUID], mockitoEq("existingType"))).thenReturn(DBIO.successful(2))
@@ -1141,7 +1149,7 @@ class CompactEntityProviderSpec
     val oldType = "oldType"
     val newType = "newType"
 
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
 
     // The old type exists
     when(mockQueries.countEntities(any[UUID], mockitoEq(oldType))).thenReturn(DBIO.successful(5))
@@ -1164,7 +1172,7 @@ class CompactEntityProviderSpec
     val entityName = "entityName"
     val operations = Seq.empty[AttributeUpdateOperation]
 
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     val provider = providerWithMocks(mockQueries)
 
     val actual = intercept[UnsupportedEntityOperationException] {
@@ -1184,7 +1192,7 @@ class CompactEntityProviderSpec
       )
     )
 
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     // mock: batchUpdate does not find the pre-existing entity
     when(mockQueries.getEntities(mockitoEq(defaultWorkspace.workspaceIdAsUUID), any()))
       .thenAnswer(_ => throw new EntityNotFoundException())
@@ -1200,9 +1208,10 @@ class CompactEntityProviderSpec
   behavior of "saveWorkflowOutputEntities"
 
   it should "pass the workspace and requested entities to the downstream query" in {
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQueries.batchWriteEntities(any(), any(), any()))
       .thenReturn(DBIO.successful(2))
+    when(mockQueries.invalidateCache(any(), any[Set[String]]())).thenReturn(DBIO.successful(0))
     val provider = providerWithMocks(mockQueries)
 
     val mockDataAccess = mock[DataAccess]
@@ -1221,7 +1230,7 @@ class CompactEntityProviderSpec
   }
 
   it should "bypass the database when asked to save nothing" in {
-    val mockQueries = mock[CompactEntityQuery]
+    val mockQueries = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     val provider = providerWithMocks(mockQueries)
 
     val mockDataAccess = mock[DataAccess]
@@ -1246,7 +1255,7 @@ class CompactEntityProviderSpec
       AttributeName.withDefaultNS("baz") -> AttributeNumber(42)
     )
     val entity = Entity("name", "type", attributes)
-    val provider = providerWithMocks(mock[CompactEntityQuery])
+    val provider = providerWithMocks(mock[CompactEntityQuery](RETURNS_SMART_NULLS))
 
     val actual = provider.findAllReferences(entity)
 
@@ -1266,7 +1275,7 @@ class CompactEntityProviderSpec
       )
     )
     val entity = Entity("name", "type", attributes)
-    val provider = providerWithMocks(mock[CompactEntityQuery])
+    val provider = providerWithMocks(mock[CompactEntityQuery](RETURNS_SMART_NULLS))
 
     val actual = provider.findAllReferences(entity)
 
@@ -1289,7 +1298,7 @@ class CompactEntityProviderSpec
   it should "return an empty Map when fed an empty Seq" in {
     val input = Seq()
 
-    val provider = providerWithMocks(mock[CompactEntityQuery])
+    val provider = providerWithMocks(mock[CompactEntityQuery](RETURNS_SMART_NULLS))
 
     val actual = provider.findAllReferences(input)
 
@@ -1303,7 +1312,7 @@ class CompactEntityProviderSpec
     )
     val entity1 = Entity("name1", "type", attributes)
     val entity2 = Entity("name2", "type", attributes)
-    val provider = providerWithMocks(mock[CompactEntityQuery])
+    val provider = providerWithMocks(mock[CompactEntityQuery](RETURNS_SMART_NULLS))
 
     val actual =
       provider.findAllReferences(Seq(entity1, entity2))
@@ -1347,7 +1356,7 @@ class CompactEntityProviderSpec
       )
     )
 
-    val provider = providerWithMocks(mock[CompactEntityQuery])
+    val provider = providerWithMocks(mock[CompactEntityQuery](RETURNS_SMART_NULLS))
 
     val actual =
       provider.findAllReferences(Seq(entity1, entity2, entity3))
@@ -1391,7 +1400,7 @@ class CompactEntityProviderSpec
       )
     )
 
-    val provider = providerWithMocks(mock[CompactEntityQuery])
+    val provider = providerWithMocks(mock[CompactEntityQuery](RETURNS_SMART_NULLS))
 
     val actual =
       provider.findAllReferences(Seq(entity1, entity2, entity3))
@@ -1411,7 +1420,7 @@ class CompactEntityProviderSpec
   behavior of "withWorkspaceLastModified"
 
   it should "trigger a last-modified update on success of the original future" in {
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1431,7 +1440,7 @@ class CompactEntityProviderSpec
   }
 
   it should "not trigger a last-modified update on failure of the original future" in {
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1456,7 +1465,7 @@ class CompactEntityProviderSpec
   }
 
   it should "not fail if the last-modified update fails" in {
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1653,7 +1662,7 @@ class CompactEntityProviderSpec
 
   it should "copy entities from source workspace to destination workspace when no conflicts are present" in {
     val config = CompactEntityProviderConfig()
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1700,6 +1709,7 @@ class CompactEntityProviderSpec
       )
     when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]], any[Int]))
       .thenReturn(DBIO.successful(3))
+    when(mockQuery.invalidateCache(any(), any[String]())).thenReturn(DBIO.successful(0))
 
     val provider =
       providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext), config)
@@ -1726,7 +1736,7 @@ class CompactEntityProviderSpec
   }
 
   it should "not copy entities when a hard conflict is present" in {
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1760,6 +1770,7 @@ class CompactEntityProviderSpec
     val mockEntityRefs = entityNames.map(name => EntityPointer(entityType, name))
     when(mockQuery.getEntityRefs(any[UUID], any[Set[EntityPointer]]))
       .thenReturn(DBIO.successful(Seq(CompactEntityRefRecord(1, "entity1", entityType))))
+    when(mockQuery.invalidateCache(any(), any[String]())).thenReturn(DBIO.successful(0))
     val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
 
     val result = Await.result(provider.copyEntities(sourceWorkspace,
@@ -1785,7 +1796,7 @@ class CompactEntityProviderSpec
 
   it should "not copy entities when soft conflicts are present and linkExistingEntities is false" in {
     val config = CompactEntityProviderConfig()
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1833,6 +1844,7 @@ class CompactEntityProviderSpec
           Set(RefMapping(EntityPointer(entityType, "entity1"), Set(EntityPointer(entityType, "entity2"))))
         )
       )
+    when(mockQuery.invalidateCache(any(), any[String]())).thenReturn(DBIO.successful(0))
 
     val provider = providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext))
     val result = Await.result(provider.copyEntities(sourceWorkspace,
@@ -1860,7 +1872,7 @@ class CompactEntityProviderSpec
 
   it should "exclude copying soft conflicts when soft conflicts are present and linkExistingEntities is true" in {
     val config = CompactEntityProviderConfig()
-    val mockQuery = mock[CompactEntityQuery]
+    val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     val mockRepository = mock[CompactEntityRepository]
     when(mockRepository.queries).thenReturn(mockQuery)
     when(mockRepository.dataSource).thenReturn(slickDataSource)
@@ -1910,6 +1922,7 @@ class CompactEntityProviderSpec
       )
     when(mockQuery.copyEntitiesToNewWorkspace(any[UUID], any[UUID], any[Set[EntityPointer]], any[Int]))
       .thenReturn(DBIO.successful(1))
+    when(mockQuery.invalidateCache(any(), any[String]())).thenReturn(DBIO.successful(0))
 
     val provider =
       providerWithMocks(mockRepository, EntityRequestArguments(sourceWorkspace, defaultRequestContext), config)


### PR DESCRIPTION
Ticket: CORE-619

In support of a Quicksilver cache for entity type metadata:
* create a new ENTITY_KEYS_CACHE table
* helper methods to read, save, and invalidate cache entries in this table
* invalidation hooks for most provider methods

This is a "part 1" PR. We will not have a working cache after this PR merges; it just sets up a lot of the prep work so the "part 2" PR to use the cache can be smaller and more manageable.

The high-level flow of caching will be:
* When a user requests entity type metadata:
    * read all valid entries from the cache
    * read all remaining data from a live uncached query
    * persist the live uncached results back to cache
* When a user writes to their data tables:
    * invalidate the cache entries affected by the writes <-- _this PR_

see also the [design doc](https://docs.google.com/document/d/1HRIF5HPMwpcmK9zWDTqltyDLTmW6nc27ppb4cagR3ko/edit?tab=t.0#heading=h.g68d10jsmixz) for the cache.

