### PR TITLE
CORE-620: Quicksilver copyEntities includes entities without references

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -304,7 +304,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   }
 
   /**
-   * Recursively retrieves all entity references for a given set of entities in a workspace.
+   * Recursively retrieves the specified entities and all entities they reference.
    *
    * This method performs a recursive query on the `ENTITY_REFS` table to find all downstream entities
    * referenced by the input entities. It returns a `Set[RefMapping]`, where each `RefMapping` contains:
@@ -340,13 +340,13 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         sql"""with recursive EntityReferences as (
                 select workspace_id, id as from_entity_id, entity_type as from_entity_type, name as from_name,
              	  jt.from_attribute_name, jt.to_entity_type, jt.to_name
-             	from ENTITY, JSON_TABLE(
+               from ENTITY left outer join JSON_TABLE(
                              attributes,
                              '$$.refs[*]' COLUMNS (
                                  from_attribute_name varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.a',
              					to_entity_type varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.t',
              		            to_name varchar(254) PATH '$$.n'
-                              )) jt
+                              )) jt on true
              	where workspace_id = $workspaceId
              	and (""",
         entityTypeNameClauses,
@@ -374,7 +374,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
             EntityPointer(row.toEntityType, row.toName)
           )
           .view
-          .mapValues(_.toSet)
+          // the query can return nulls in the "to" columns; filter those here
+          .mapValues(_.filterNot(x => Option(x.entityType).isEmpty || Option(x.entityName).isEmpty).toSet)
           .toMap
           .map { case (key, value) => RefMapping(key, value) }
           .toSet

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -1059,6 +1059,65 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
 
   behavior of "copyEntities"
 
+  it should "copy entities without references from source to destination workspace" in withMinimalTestDatabase { _ =>
+    val sourceWorkspace = minimalTestData.workspace2
+    val destinationWorkspace = minimalTestData.workspace
+
+    val sourceProvider = new CompactEntityProvider(
+      defaultEntityRequestArguments.copy(workspace = sourceWorkspace),
+      new CompactEntityRepository(slickDataSource)
+    )(ec, system)
+
+    val destinationProvider = new CompactEntityProvider(
+      defaultEntityRequestArguments.copy(workspace = destinationWorkspace),
+      new CompactEntityRepository(slickDataSource)
+    )(ec, system)
+
+    // insert entities to be copied to source workspace
+    val entityA1 = Entity("name1", "typeA", Map())
+    val entityA2 = Entity("name2", "typeA", Map())
+    val entityB1 = Entity("name3", "typeB", Map())
+    Await.result(sourceProvider.createEntity(entityA1, defaultRequestContext), atMost) shouldBe entityA1
+    Await.result(sourceProvider.createEntity(entityA2, defaultRequestContext), atMost) shouldBe entityA2
+    Await.result(sourceProvider.createEntity(entityB1, defaultRequestContext), atMost) shouldBe entityB1
+
+    // validate results of creations
+    val metadataAfter =
+      Await.result(sourceProvider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
+    metadataAfter.size shouldBe 2
+    metadataAfter.keys should contain theSameElementsAs Seq("typeA", "typeB")
+    metadataAfter("typeA").count shouldBe 2
+    metadataAfter("typeB").count shouldBe 1
+
+    // validate the destination workspace is empty before copying
+
+    Await.result(destinationProvider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost) shouldBe empty
+
+    // copy entities from workspace 2 to workspace 1
+    val copyResult =
+      Await.result(
+        sourceProvider.copyEntities(
+          sourceWorkspace,
+          destinationWorkspace,
+          entityA1.entityType,
+          Seq(entityA1.name, entityA2.name),
+          linkExistingEntities = false,
+          defaultRequestContext
+        ),
+        atMost
+      )
+    copyResult.hardConflicts shouldBe empty
+    copyResult.softConflicts shouldBe empty
+    copyResult.entitiesCopied should contain theSameElementsAs Seq(entityA1.toReference, entityA2.toReference)
+
+    // validate results of copying
+    val metadataDestination =
+      Await.result(destinationProvider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
+    metadataDestination.size shouldBe 1
+    metadataDestination.keys should contain theSameElementsAs Seq("typeA")
+    metadataDestination("typeA").count shouldBe 2
+  }
+
   it should "copy entities and entity references from source to destination workspace" in withMinimalTestDatabase { _ =>
     val provider = defaultProvider()
 


### PR DESCRIPTION
Ticket: CORE-620

Fixes a bug where the `copyEntities` method would only copy entities that had references (along with the entities they referenced). In the simple case of trying to copy entities without references, it copied nothing.

The root cause was an inner join instead of an outer join in a SQL query. When the user supplied the names of some entities to copy, we queried to see if they exist and to recursively traverse their reference tree. Because this query was an inner join against the specified entities and their references, it failed to return entities that have no references.

This PR changes to using an outer join, which requires a bit of extra logic to handle the nulls.