### PR TITLE
CORE-619: entity keys cache, part 2

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -479,6 +479,27 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       where workspace_id=$workspaceId and deleted = 0;""".as[EntityTypeAndAttributeKey]
 
   /**
+   * Get all entity attribute keys for a workspace.
+   *
+   * execution plan:
+   *    ENTITY: Using index condition (Using index condition; Using temporary); Using temporary
+   *    t: Table function: json_table; Using temporary
+   */
+  def listEntityKeysViaEntity(workspaceId: UUID,
+                              entityTypes: Set[String]
+  ): ReadAction[Seq[EntityTypeAndAttributeKey]] = {
+    val inClause = reduceSqlActionsWithDelim(entityTypes.map(t => sql"$t").toSeq, sql", ")
+
+    concatSqlActions(
+      sql"""SELECT distinct entity_type, attribute_key
+      FROM ENTITY, JSON_TABLE(JSON_KEYS(attributes, $slickAttrsPath), '$$[*]' COLUMNS(attribute_key VARCHAR(256) PATH '$$')) t
+      where workspace_id=$workspaceId and deleted = 0 and entity_type in (""",
+      inClause,
+      sql""");"""
+    ).as[EntityTypeAndAttributeKey]
+  }
+
+  /**
    * Gets the count of entities in a workspace, grouped by entity type.
    *
    * `execution plan: Index range scan; using where. Index: idx_entity_keys_workspace_and_entity_type.`

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -479,7 +479,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       where workspace_id=$workspaceId and deleted = 0;""".as[EntityTypeAndAttributeKey]
 
   /**
-   * Get all entity attribute keys for a workspace.
+   * Get the attribute keys for the given workspace and entity types.
    *
    * execution plan:
    *    ENTITY: Using index condition (Using index condition; Using temporary); Using temporary

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
@@ -33,10 +33,6 @@ trait CompactEntityKeysCache {
 
   // ========== save to cache ==========
 
-  /** save the cache for the given entity type and workspace */
-  def saveCache(workspaceId: UUID, entityType: String, keys: Set[AttributeName]): ReadWriteAction[Int] =
-    saveCache(workspaceId, Set(EntityTypeAndAttributeKeys(entityType, keys)))
-
   /** save multiple cache values for the given workspace */
   def saveCache(workspaceId: UUID, cacheValues: Set[EntityTypeAndAttributeKeys]): ReadWriteAction[Int] =
     // short-circuit

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -348,23 +348,66 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
 
   override def entityTypeMetadata(useCache: Boolean,
                                   parentContext: RawlsRequestContext
-  ): Future[Map[String, EntityTypeMetadata]] =
+  ): Future[Map[String, EntityTypeMetadata]] = {
+    setTraceSpanAttribute(parentContext, AttributeKey.booleanKey("useCache"), java.lang.Boolean.valueOf(useCache))
+
+    // helper: translate uncached lookup objects to cached lookup objects
+    def keyToKeys(keySeq: Seq[EntityTypeAndAttributeKey]): Seq[EntityTypeAndAttributeKeys] =
+      keySeq
+        .groupMap(_.entityType)(_.attributeKey)
+        .map { case (entityType, keys) =>
+          EntityTypeAndAttributeKeys(entityType, keys.toSet)
+        }
+        .toSeq
+    // helper: translate cached lookup objects to uncached lookup objects
+    def keysToKey(keysSeq: Seq[EntityTypeAndAttributeKeys]): Seq[EntityTypeAndAttributeKey] =
+      keysSeq.flatMap { cacheEntry =>
+        cacheEntry.attributeKeys.map { key =>
+          EntityTypeAndAttributeKey(cacheEntry.entityType, key)
+        }
+      }
+
     repository.dataSource.inTransaction(ReadOnly) { _ =>
       for {
-        entityTypeAndKeys <- traceDBIOWithParent("listEntityKeys", parentContext) { _ =>
-          // If useCache is true, calculate attributes via the ENTITY table. This allows us to gather real-world
-          // empirical performance data; requests from Terra UI have useCache=true.
-          //
-          // if useCache is false, calculate attributes via the ENTITY_KEYS table. These requests will be rare
-          // in the wild, but our automated perf tests will generate them.
-          if (useCache)
-            repository.queries.listEntityKeysViaEntity(workspaceId)
-          else
-            repository.queries.listEntityKeys(workspaceId)
+        // If useCache is true, retrieve valid cache entries from the ENTITY_KEYS_CACHE table.
+        cachedEntityTypeAndKeys <- traceDBIOWithParent("cachedEntityTypeAndKeys", parentContext) { _ =>
+          if (useCache) {
+            repository.queries.getCachedKeys(workspaceId)
+          } else
+            DBIO.successful(Seq.empty[EntityTypeAndAttributeKeys])
         }
+        // query for known entity types and their counts. This is always uncached.
         entityTypeAndCounts <- traceDBIOWithParent("countEntitiesGroupedByType", parentContext) { _ =>
           repository.queries.countEntitiesGroupedByType(workspaceId)
         }
+        // perform an uncached lookup of entity keys for anything not found in cache
+        entityTypeAndKeys: Seq[EntityTypeAndAttributeKey] <-
+          if (!useCache) {
+            // if useCache is false, always calculate attributes for all entity types via the ENTITY table.
+            traceDBIOWithParent("listEntityKeysViaEntity", parentContext) { _ =>
+              repository.queries.listEntityKeysViaEntity(workspaceId)
+            }
+          } else {
+            // determine which, if any, entity types did not have a cache entry
+            val missingEntityTypes =
+              entityTypeAndCounts.map(_.entityType).toSet diff cachedEntityTypeAndKeys.map(_.entityType).toSet
+            if (missingEntityTypes.isEmpty) {
+              // all entity types were found in cache. Translate the cache results to the proper format.
+              DBIO.successful(keysToKey(cachedEntityTypeAndKeys))
+            } else {
+              for {
+                // calculate attributes for the missing entity types via the ENTITY table.
+                liveLookup <- traceDBIOWithParent("listEntityKeysViaEntity", parentContext) { _ =>
+                  repository.queries.listEntityKeysViaEntity(workspaceId, missingEntityTypes)
+                }
+                //  - persist back to cache those attributes we had to calculate
+                _ <- traceDBIOWithParent("saveCache", parentContext) { _ =>
+                  repository.queries.saveCache(workspaceId, keyToKeys(liveLookup).toSet)
+                }
+              } yield liveLookup ++ keysToKey(cachedEntityTypeAndKeys)
+            }
+          }
+
       } yield trace("resultCalculation", parentContext) { _ =>
         // note that entityTypeAndKeys only contains entity types that have at least one key
         // and that entityTypeAndCounts contains all entity types, even those with zero keys
@@ -378,6 +421,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         }.toMap
       }
     }
+  }
 
   override def evaluateExpression(entityType: String,
                                   entityName: String,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -64,13 +64,158 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
 
   behavior of "entityTypeMetadata"
 
-  it should "use valid cache entries" is pending
+  it should "use valid cache entries" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
 
-  it should "persist invalid cache entries" is pending
+    val attr1 = AttributeName.withDefaultNS("attr1")
+    val attr2 = AttributeName.withLibraryNS("attr2")
+    val attr3 = AttributeName.fromDelimitedName("import:timestamp")
+    val attr4 = AttributeName.withDefaultNS("attr4")
+    val attr5 = AttributeName.withLibraryNS("attr5")
+    val attr6 = AttributeName.fromDelimitedName("foo:bar")
 
-  it should "persist missing cache entries" is pending
+    // insert some entities so metadata has values
+    val entityA1 = Entity("name1", "typeA", Map(attr1 -> AttributeString("value1")))
+    val entityA2 = Entity("name2", "typeA", Map(attr2 -> AttributeNumber(42)))
+    val entityB1 = Entity("name3", "typeB", Map(attr3 -> AttributeString("2023-10-01T00:00:00Z")))
+    Await.result(provider.createEntity(entityA1, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityA2, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityB1, defaultRequestContext), atMost)
 
-  it should "ignore extraneous cache entries" is pending
+    // validate initial metadata with no cache entries
+    // note useCache = false here to ensure the request for metadata doesn't save anything to the cache
+    val metadataInitial = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
+    metadataInitial.size shouldBe 2
+    metadataInitial.keys should contain theSameElementsAs Seq("typeA", "typeB")
+    metadataInitial("typeA").attributeNames should contain theSameElementsAs Seq(attr1, attr2).map(toDelimitedName)
+    metadataInitial("typeB").attributeNames should contain theSameElementsAs Seq(attr3).map(toDelimitedName)
+
+    // insert a valid cache entry for typeA
+    val cacheEntryA = EntityTypeAndAttributeKeys("typeA", Set(attr4, attr5, attr6))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntryA))) shouldBe 1
+
+    // validate metadata after inserting the cache entry; it should respect the cache entry
+    val metadataAfter = Await.result(provider.entityTypeMetadata(useCache = true, defaultRequestContext), atMost)
+    metadataAfter.size shouldBe 2
+    metadataAfter.keys should contain theSameElementsAs Seq("typeA", "typeB")
+    metadataAfter("typeA").attributeNames should contain theSameElementsAs Seq(attr4, attr5, attr6).map(toDelimitedName)
+    metadataAfter("typeB").attributeNames should contain theSameElementsAs Seq(attr3).map(toDelimitedName)
+  }
+
+  it should "persist invalid cache entries" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+
+    val attr1 = AttributeName.withDefaultNS("attr1")
+    val attr2 = AttributeName.withLibraryNS("attr2")
+    val attr3 = AttributeName.fromDelimitedName("import:timestamp")
+    val attr4 = AttributeName.withDefaultNS("attr4")
+    val attr5 = AttributeName.withLibraryNS("attr5")
+    val attr6 = AttributeName.fromDelimitedName("foo:bar")
+
+    // insert some entities so metadata has values
+    val entityA1 = Entity("name1", "typeA", Map(attr1 -> AttributeString("value1")))
+    val entityA2 = Entity("name2", "typeA", Map(attr2 -> AttributeNumber(42)))
+    val entityB1 = Entity("name3", "typeB", Map(attr3 -> AttributeString("2023-10-01T00:00:00Z")))
+    Await.result(provider.createEntity(entityA1, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityA2, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityB1, defaultRequestContext), atMost)
+
+    // validate cache is empty before requesting metadata
+    runAndWait(q.getCachedKeys(wsid)) shouldBe empty
+
+    // insert an invalid cache entry for typeA
+    val cacheEntryA = EntityTypeAndAttributeKeys("typeA", Set(attr4, attr5, attr6))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntryA))) shouldBe 1
+    // validate cache entry is saved
+    runAndWait(q.getCachedKeys(wsid)) should have size 1
+    // invalidate it
+    runAndWait(q.invalidateCache(wsid, Set(cacheEntryA.entityType))) shouldBe 1
+    // validate it is invalid
+    runAndWait(q.getCachedKeys(wsid)) should have size 0
+
+    // request metadata; this request should cause invalid cache entries to be updated
+    val metadataInitial = Await.result(provider.entityTypeMetadata(useCache = true, defaultRequestContext), atMost)
+    metadataInitial.size shouldBe 2
+    metadataInitial.keys should contain theSameElementsAs Seq("typeA", "typeB")
+    metadataInitial("typeA").attributeNames should contain theSameElementsAs Seq(attr1, attr2).map(toDelimitedName)
+    metadataInitial("typeB").attributeNames should contain theSameElementsAs Seq(attr3).map(toDelimitedName)
+
+    val actual = runAndWait(q.getCachedKeys(wsid))
+    actual should contain theSameElementsAs Seq(
+      EntityTypeAndAttributeKeys("typeA", Set(attr1, attr2)),
+      EntityTypeAndAttributeKeys("typeB", Set(attr3))
+    )
+  }
+
+  it should "persist missing cache entries" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+
+    val attr1 = AttributeName.withDefaultNS("attr1")
+    val attr2 = AttributeName.withLibraryNS("attr2")
+    val attr3 = AttributeName.fromDelimitedName("import:timestamp")
+
+    // insert some entities so metadata has values
+    val entityA1 = Entity("name1", "typeA", Map(attr1 -> AttributeString("value1")))
+    val entityA2 = Entity("name2", "typeA", Map(attr2 -> AttributeNumber(42)))
+    val entityB1 = Entity("name3", "typeB", Map(attr3 -> AttributeString("2023-10-01T00:00:00Z")))
+    Await.result(provider.createEntity(entityA1, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityA2, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityB1, defaultRequestContext), atMost)
+
+    // validate cache is empty before requesting metadata
+    runAndWait(q.getCachedKeys(wsid)) shouldBe empty
+
+    // request metadata; this request should cause cache entries to be created
+    val metadataInitial = Await.result(provider.entityTypeMetadata(useCache = true, defaultRequestContext), atMost)
+    metadataInitial.size shouldBe 2
+    metadataInitial.keys should contain theSameElementsAs Seq("typeA", "typeB")
+    metadataInitial("typeA").attributeNames should contain theSameElementsAs Seq(attr1, attr2).map(toDelimitedName)
+    metadataInitial("typeB").attributeNames should contain theSameElementsAs Seq(attr3).map(toDelimitedName)
+
+    val actual = runAndWait(q.getCachedKeys(wsid))
+    actual should contain theSameElementsAs Seq(
+      EntityTypeAndAttributeKeys("typeA", Set(attr1, attr2)),
+      EntityTypeAndAttributeKeys("typeB", Set(attr3))
+    )
+  }
+
+  it should "ignore extraneous cache entries" in withMinimalTestDatabase { _ =>
+    val provider = defaultProvider()
+
+    val attr1 = AttributeName.withDefaultNS("attr1")
+    val attr2 = AttributeName.withLibraryNS("attr2")
+    val attr3 = AttributeName.fromDelimitedName("import:timestamp")
+    val attr4 = AttributeName.withDefaultNS("attr4")
+    val attr5 = AttributeName.withLibraryNS("attr5")
+    val attr6 = AttributeName.fromDelimitedName("foo:bar")
+
+    // insert some entities so metadata has values
+    val entityA1 = Entity("name1", "typeA", Map(attr1 -> AttributeString("value1")))
+    val entityA2 = Entity("name2", "typeA", Map(attr2 -> AttributeNumber(42)))
+    val entityB1 = Entity("name3", "typeB", Map(attr3 -> AttributeString("2023-10-01T00:00:00Z")))
+    Await.result(provider.createEntity(entityA1, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityA2, defaultRequestContext), atMost)
+    Await.result(provider.createEntity(entityB1, defaultRequestContext), atMost)
+
+    // validate initial metadata with no cache entries
+    // note useCache = false here to ensure the request for metadata doesn't save anything to the cache
+    val metadataInitial = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
+    metadataInitial.size shouldBe 2
+    metadataInitial.keys should contain theSameElementsAs Seq("typeA", "typeB")
+    metadataInitial("typeA").attributeNames should contain theSameElementsAs Seq(attr1, attr2).map(toDelimitedName)
+    metadataInitial("typeB").attributeNames should contain theSameElementsAs Seq(attr3).map(toDelimitedName)
+
+    // insert a valid cache entry for typeC - note that this type does not exist in the database
+    val cacheEntryC = EntityTypeAndAttributeKeys("typeC", Set(attr4, attr5, attr6))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntryC))) shouldBe 1
+
+    // validate metadata after inserting the cache entry; the extraneous cache entry should be ignored
+    val metadataAfter = Await.result(provider.entityTypeMetadata(useCache = true, defaultRequestContext), atMost)
+    metadataAfter shouldBe metadataInitial // should not change
+  }
 
   behavior of "single entity-type cache invalidation"
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -640,6 +640,8 @@ class CompactEntityProviderSpec
     val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     when(mockQuery.listEntityKeysViaEntity(any[UUID]))
       .thenReturn(DBIO.successful(Seq.empty))
+    when(mockQuery.getCachedKeys(any[UUID]))
+      .thenReturn(DBIO.successful(Seq.empty))
     when(mockQuery.countEntitiesGroupedByType(any[UUID]))
       .thenReturn(DBIO.successful(Seq.empty))
 
@@ -654,7 +656,7 @@ class CompactEntityProviderSpec
   it should "return map with entity type and count when entities exist" in {
     val mockQuery = mock[CompactEntityQuery](RETURNS_SMART_NULLS)
     // type1 and type2 have keys, type3 has no keys
-    when(mockQuery.listEntityKeysViaEntity(any[UUID]))
+    when(mockQuery.listEntityKeysViaEntity(any[UUID], any[Set[String]]))
       .thenReturn(
         DBIO.successful(
           Seq(
@@ -664,6 +666,10 @@ class CompactEntityProviderSpec
           )
         )
       )
+    when(mockQuery.getCachedKeys(any[UUID]))
+      .thenReturn(DBIO.successful(Seq.empty))
+    when(mockQuery.saveCache(any[UUID], any[Set[EntityTypeAndAttributeKeys]]))
+      .thenReturn(DBIO.successful(0))
     when(mockQuery.countEntitiesGroupedByType(any[UUID]))
       .thenReturn(
         DBIO.successful(


### PR DESCRIPTION
Ticket: CORE-619

Builds on #3418 to implements the metadata cache for Quicksilver.

The high-level flow of caching:
* When a user requests entity type metadata: <-- _this PR_
    * read all valid entries from the cache
    * read all remaining data from a live uncached query
    * persist the live uncached results back to cache
* When a user writes to their data tables:
    * invalidate the cache entries affected by the writes <-- _done in #3418_

see also the [design doc](https://docs.google.com/document/d/1HRIF5HPMwpcmK9zWDTqltyDLTmW6nc27ppb4cagR3ko/edit?tab=t.0#heading=h.g68d10jsmixz) for the cache.

