### PR TITLE
CORE-619: entity keys cache, part 3

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
-import org.broadinstitute.dsde.rawls.model.AttributeName
+import org.broadinstitute.dsde.rawls.model.{AttributeName, EntityTypeRename}
 
 import java.util.UUID
 import slick.jdbc.MySQLProfile.api._
@@ -84,4 +84,16 @@ trait CompactEntityKeysCache {
       ).asUpdate
     }
 
+  // ========== rename entity type for a cache entry ==========
+
+  def renameCacheType(workspaceId: UUID, oldName: String, renameInfo: EntityTypeRename): ReadWriteAction[Int] =
+    // rename the entity_type in the cache for the given workspace
+    if (oldName == renameInfo.newName) {
+      DBIO.successful(0)
+    } else {
+      sqlu"""update ENTITY_KEYS_CACHE
+              set entity_type = ${renameInfo.newName}
+              where workspace_id = $workspaceId
+              and entity_type = $oldName;"""
+    }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityKeysCache.scala
@@ -96,4 +96,17 @@ trait CompactEntityKeysCache {
               where workspace_id = $workspaceId
               and entity_type = $oldName;"""
     }
+
+  // ========== clone cache entries to a new workspace ==========
+
+  def cloneCache(sourceWorkspaceId: UUID, destinationWorkspaceId: UUID): WriteAction[Int] =
+    if (sourceWorkspaceId == destinationWorkspaceId) {
+      DBIO.successful(0)
+    } else {
+      sqlu"""insert into ENTITY_KEYS_CACHE (workspace_id, entity_type, attribute_keys, cached_at)
+              select $destinationWorkspaceId, entity_type, attribute_keys, cached_at
+              from ENTITY_KEYS_CACHE
+              where workspace_id = $sourceWorkspaceId
+              and (invalidated_at is null OR cached_at > invalidated_at);"""
+    }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -621,6 +621,9 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         // Call the renameEntityType method in CompactEntityComponent to update entity types and references
         entityRowsUpdated <- repository.queries.renameEntityType(workspaceId, oldName, newName)
 
+        // also rename any entity type cache entries
+        _ <- repository.queries.renameCacheType(workspaceId, oldName, renameInfo)
+
       } yield entityRowsUpdated // Return the number of entities that were renamed
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -162,9 +162,15 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                      destWorkspaceContext: Workspace,
                      parentContext: RawlsRequestContext
   ): WriteAction[(Int, Int)] =
+    // clone the cache entries from source to destination workspace
     repository.queries
-      .copyAllEntities(sourceWorkspaceContext.workspaceIdAsUUID, destWorkspaceContext.workspaceIdAsUUID)
-      .map { copyActionResults: Int => (copyActionResults, 0) }
+      .cloneCache(sourceWorkspaceContext.workspaceIdAsUUID, destWorkspaceContext.workspaceIdAsUUID) andThen
+      // then, clone the entities.
+      // we do it in this order to simplify syntax. This will be called within a transaction anyway, so the order
+      // doesn't matter
+      repository.queries
+        .copyAllEntities(sourceWorkspaceContext.workspaceIdAsUUID, destWorkspaceContext.workspaceIdAsUUID)
+        .map { copyActionResults: Int => (copyActionResults, 0) }
 
   /**
    * Copy all entities from sourceWorkspaceId to destWorkspaceId, excluding any entities that

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -415,8 +415,35 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
 
   behavior of "clone"
 
-  // this is an optimization; it would be correct but slower without this
-  it should "also clone cache entries" is pending
+  it should "also clone cache entries" in withMinimalTestDatabase { _ =>
+    val sourceWorkspace = minimalTestData.workspace
+    val destinationWorkspace = minimalTestData.workspace2
+
+    val entityType = "entityType1"
+    // create entity
+    val provider = defaultProvider()
+    val entity = Entity("name", entityType, Map())
+    Await.result(provider.createEntity(entity, defaultRequestContext), atMost)
+    // insert valid cache entries
+    val cacheEntry = EntityTypeAndAttributeKeys(entityType, Set(AttributeName.withDefaultNS("attr1")))
+    val anotherCacheEntry = EntityTypeAndAttributeKeys("someOtherType", Set(AttributeName.withDefaultNS("attr2")))
+    // save the cache
+    runAndWait(q.saveCache(sourceWorkspace.workspaceIdAsUUID, Set(cacheEntry, anotherCacheEntry))) shouldBe 2
+    // validate cache entries
+    runAndWait(q.getCachedKeys(sourceWorkspace.workspaceIdAsUUID)) should contain theSameElementsAs Seq(
+      cacheEntry,
+      anotherCacheEntry
+    )
+    // perform clone
+    val cloneResult =
+      runAndWait(provider.clone(sourceWorkspace, destinationWorkspace, defaultRequestContext))
+    cloneResult shouldBe (1, 0)
+    // validate cache entries were also cloned
+    runAndWait(q.getCachedKeys(destinationWorkspace.workspaceIdAsUUID)) should contain theSameElementsAs Seq(
+      cacheEntry,
+      anotherCacheEntry
+    )
+  }
 
   behavior of "renameEntityType"
 
@@ -427,12 +454,12 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
     val provider = defaultProvider()
     val entity = Entity("name", oldEntityType, Map())
     Await.result(provider.createEntity(entity, defaultRequestContext), atMost)
-    // insert valid cache entry
+    // insert valid cache entries
     val cacheEntry = EntityTypeAndAttributeKeys(oldEntityType, Set(AttributeName.withDefaultNS("attr1")))
     val anotherCacheEntry = EntityTypeAndAttributeKeys("someOtherType", Set(AttributeName.withDefaultNS("attr2")))
     // save the cache
     runAndWait(q.saveCache(wsid, Set(cacheEntry, anotherCacheEntry))) shouldBe 2
-    // validate cache entry
+    // validate cache entries
     runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntry, anotherCacheEntry)
     // rename entity type
     val renameResult =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -27,6 +27,7 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeString,
   Entity,
   EntityPointer,
+  EntityTypeRename,
   RawlsRequestContext,
   RawlsUserEmail,
   RawlsUserSubjectId,
@@ -419,8 +420,32 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
 
   behavior of "renameEntityType"
 
-  // this is an optimization; it would be correct but slower without this
-  it should "also rename the cache entry" is pending
+  it should "also rename the cache entry" in withMinimalTestDatabase { _ =>
+    val oldEntityType = "entityType1"
+    val newEntityType = "entityType1renamed"
+    // create entity
+    val provider = defaultProvider()
+    val entity = Entity("name", oldEntityType, Map())
+    Await.result(provider.createEntity(entity, defaultRequestContext), atMost)
+    // insert valid cache entry
+    val cacheEntry = EntityTypeAndAttributeKeys(oldEntityType, Set(AttributeName.withDefaultNS("attr1")))
+    val anotherCacheEntry = EntityTypeAndAttributeKeys("someOtherType", Set(AttributeName.withDefaultNS("attr2")))
+    // save the cache
+    runAndWait(q.saveCache(wsid, Set(cacheEntry, anotherCacheEntry))) shouldBe 2
+    // validate cache entry
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntry, anotherCacheEntry)
+    // rename entity type
+    val renameResult =
+      Await.result(
+        provider.renameEntityType(entity.entityType, EntityTypeRename(newEntityType), defaultRequestContext),
+        atMost
+      )
+    renameResult shouldBe 1
+    // validate cache entry was renamed
+    runAndWait(q.getCachedKeys(wsid)) should contain theSameElementsAs Seq(cacheEntry.copy(entityType = newEntityType),
+                                                                           anotherCacheEntry
+    )
+  }
 
   // ====================================================================================================
   //  helper methods

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -1157,6 +1157,7 @@ class CompactEntityProviderSpec
     when(mockQueries.countEntities(any[UUID], mockitoEq(newType))).thenReturn(DBIO.successful(0))
     // The rename operation will update 5 entities
     when(mockQueries.renameEntityType(any[UUID], mockitoEq(oldType), mockitoEq(newType))).thenReturn(DBIO.successful(5))
+    when(mockQueries.renameCacheType(any[UUID], anyString, any[EntityTypeRename])).thenReturn(DBIO.successful(0))
 
     val provider = providerWithMocks(mockQueries)
 


### PR DESCRIPTION
Ticket: CORE-619

Builds on #3418 and #3421.

This adds two optimizations for the entity type metadata cache:
* when renaming an entity type, also rename the cache for that entity type. This will prevent having to recalculate that type's cache.
* when cloning a workspace, also clone the cache. The new workspace will start off with whatever valid cache entries existed for the source workspace.