### PR TITLE
Revert "CORE-69: upgrade akka and akka-http"

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -3,8 +3,8 @@ import sbt._
 object Dependencies {
   val scalaV = "2.13"
 
-  val akkaV         = "2.10.5"
-  val akkaHttpV     = "10.7.1"
+  val akkaV         = "2.6.8"
+  val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.19.1"
 
   val workbenchLibsHash = "80e4b8d"
@@ -44,12 +44,11 @@ object Dependencies {
     "com.google.api-client" % "google-api-client" % "1.22.0" excludeAll (
       ExclusionRule("com.google.guava", "guava-jdk5"),
       ExclusionRule("org.apache.httpcomponents", "httpclient")),
-    "com.typesafe.akka"   %%  "akka-http-core"       % akkaHttpV,
-    "com.typesafe.akka"   %%  "akka-stream-testkit"  % akkaV,
-    "com.typesafe.akka"   %%  "akka-http"            % akkaHttpV,
-    "com.typesafe.akka"   %%  "akka-http-spray-json" % akkaHttpV,
-    "com.typesafe.akka"   %%  "akka-testkit"         % akkaV     % Test,
-    "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV,
+    "com.typesafe.akka"   %%  "akka-http-core"     % akkaHttpV,
+    "com.typesafe.akka"   %%  "akka-stream-testkit" % akkaV,
+    "com.typesafe.akka"   %%  "akka-http"           % akkaHttpV,
+    "com.typesafe.akka"   %%  "akka-testkit"        % akkaV     % Test,
+    "com.typesafe.akka"   %%  "akka-slf4j"          % akkaV,
     "org.scalatest"       %%  "scalatest"     % "3.2.2"   % Test,
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
     "org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.470-SNAP"

--- a/automation/project/Settings.scala
+++ b/automation/project/Settings.scala
@@ -8,8 +8,7 @@ object Settings {
   val artifactory = "https://us-central1-maven.pkg.dev/dsp-artifact-registry/"
   val commonResolvers = List(
     "artifactory-releases" at artifactory + "libs-release",
-    "artifactory-snapshots" at artifactory + "libs-snapshot",
-    "Akka library repository" at "https://repo.akka.io/maven"
+    "artifactory-snapshots" at artifactory + "libs-snapshot"
   )
 
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  val akkaV = "2.10.5"
-  val akkaHttpV = "10.7.1"
+  val akkaV = "2.6.20"
+  val akkaHttpV = "10.2.10"
   val slickV = "3.6.1"
 
   val googleV = "2.0.0" // service-specific client libraries

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -21,8 +21,7 @@ object Settings {
 
   val commonResolvers = List(
     "artifactory-releases" at googleArtifactoryRegistry + "libs-release",
-    "artifactory-snapshots" at googleArtifactoryRegistry + "libs-snapshot",
-    "Akka library repository" at "https://repo.akka.io/maven"
+    "artifactory-snapshots" at googleArtifactoryRegistry + "libs-snapshot"
   )
 
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings


### PR DESCRIPTION
Reverts broadinstitute/rawls#3414. Nothing hand-coded; this PR generated by github.