### PR TITLE
[CORE-528] Submissions with no inputs

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -172,6 +172,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
             ErrorReport(StatusCodes.BadRequest, s"Missing rootEntityType")
           )
         )
+
       case (Some(entityType), Some(entityName), Some(rootEntityType)) =>
         if (
           expressionEvaluationContext.expression.isEmpty &&
@@ -280,23 +281,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
                     convertToSubmissionValidationValues(resultMap, input)
                   }
 
-                if (resultsSeq.isEmpty) {
-                  LazyList(
-                    SubmissionValidationEntityInputs(entityName = expressionEvaluationContext.entityName.getOrElse(""),
-                                                     inputResolutions = Set.empty
-                    )
-                  )
-                } else {
-                  CollectionUtils
-                    .groupByTuples(resultsSeq)
-                    .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
-                      SubmissionValidationEntityInputs(
-                        entityName = entityName,
-                        inputResolutions = values.toSet
-                      )
-                    }
-                    .to(LazyList)
-                }
+                groupsResultsByEntityName(resultsSeq, entityName)
 
               }
             }
@@ -330,23 +315,9 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
             convertToSubmissionValidationValues(resultMap, input)
           }
 
-        Future.successful(if (resultsSeq.isEmpty) {
-          LazyList(
-            SubmissionValidationEntityInputs(entityName = expressionEvaluationContext.entityName.getOrElse(""),
-                                             inputResolutions = Set.empty
-            )
-          )
-        } else {
-          CollectionUtils
-            .groupByTuples(resultsSeq)
-            .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
-              SubmissionValidationEntityInputs(
-                entityName = entityName,
-                inputResolutions = values.toSet
-              )
-            }
-            .to(LazyList)
-        })
+        Future.successful(
+          groupsResultsByEntityName(resultsSeq, "")
+        )
     }
   }
 
@@ -545,5 +516,24 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
       val parsedTree = terraExpressionParser.root()
       val inputLookups: Seq[ExpressionLookup] = visitor.visit(parsedTree)
       (input, parsedTree, inputLookups)
+    }
+
+  private def groupsResultsByEntityName(resultsSeq: Seq[(EntityName, SubmissionValidationValue)],
+                                        entityName: String
+  ): LazyList[SubmissionValidationEntityInputs] =
+    if (resultsSeq.isEmpty) {
+      LazyList(
+        SubmissionValidationEntityInputs(entityName, inputResolutions = Set.empty)
+      )
+    } else {
+      CollectionUtils
+        .groupByTuples(resultsSeq)
+        .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
+          SubmissionValidationEntityInputs(
+            entityName = entityName,
+            inputResolutions = values.toSet
+          )
+        }
+        .to(LazyList)
     }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -3,11 +3,7 @@ package org.broadinstitute.dsde.rawls.expressions
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadAction
-import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{
-  EntityName,
-  ExpressionAndResult,
-  LookupExpression
-}
+import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{ExpressionAndResult, LookupExpression}
 import org.broadinstitute.dsde.rawls.entities.base.{
   ExpressionEvaluationContext,
   ExpressionEvaluationSupport,
@@ -26,8 +22,7 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeValue,
   AttributeValueList,
   ErrorReport,
-  SubmissionValidationEntityInputs,
-  SubmissionValidationValue
+  SubmissionValidationEntityInputs
 }
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
 import slick.dbio.DBIO
@@ -140,269 +135,181 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
                           workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]] = Map.empty
   )(implicit executionContext: ExecutionContext): Future[LazyList[SubmissionValidationEntityInputs]] = {
 
-    //    val initialProcessingFuture: Future[
-    //      (Seq[(MethodInput, RootContext, Seq[ExpressionLookup])], Seq[EntityName], Map[String, Seq[ExpressionAndResult]])
-    //    ] =
-    (expressionEvaluationContext.entityType,
-     expressionEvaluationContext.entityName,
-     expressionEvaluationContext.rootEntityType
-    ) match {
-      // If there are exactly one or two of entity type, entity name, and root entity, fail
-      case (Some(_), None, _) =>
-        Future.failed(
-          RawlsExceptionWithErrorReport(
-            ErrorReport(StatusCodes.BadRequest, s"Missing entityName")
-          )
-        )
-
-      case (None, Some(_), _) =>
-        Future.failed(
-          RawlsExceptionWithErrorReport(
-            ErrorReport(StatusCodes.BadRequest, s"Missing entityType")
-          )
-        )
-
-      case (None, None, Some(_)) =>
-        Future.failed(
-          RawlsExceptionWithErrorReport(
-            ErrorReport(StatusCodes.BadRequest, s"Missing entityType and entityName")
-          )
-        )
-
-      case (Some(_), Some(_), None) =>
-        Future.failed(
-          RawlsExceptionWithErrorReport(
-            ErrorReport(StatusCodes.BadRequest, s"Missing rootEntityType")
-          )
-        )
-      case (Some(entityType), Some(entityName), Some(rootEntityType)) =>
-        if (
-          expressionEvaluationContext.expression.isEmpty &&
-          entityType != rootEntityType
-        ) {
-          val whatYouGaveUs =
-            if (expressionEvaluationContext.entityType.isDefined)
-              s"an entity of type ${expressionEvaluationContext.entityType.get}"
-            else "no entity"
-          Future.failed(
-            new RawlsExceptionWithErrorReport(
-              errorReport = ErrorReport(
-                StatusCodes.BadRequest,
-                s"Method configuration expects an entity of type $rootEntityType, but you gave us $whatYouGaveUs."
+    val entityInfoFuture =
+      (expressionEvaluationContext.entityType,
+       expressionEvaluationContext.entityName,
+       expressionEvaluationContext.rootEntityType
+      ) match {
+        case (Some(entityType), Some(entityName), Some(rootEntityType)) =>
+          if (
+            expressionEvaluationContext.expression.isEmpty &&
+            entityType != rootEntityType
+          ) {
+            val whatYouGaveUs =
+              if (expressionEvaluationContext.entityType.isDefined)
+                s"an entity of type ${expressionEvaluationContext.entityType.get}"
+              else "no entity"
+            Future.failed(
+              new RawlsExceptionWithErrorReport(
+                errorReport = ErrorReport(
+                  StatusCodes.BadRequest,
+                  s"Method configuration expects an entity of type $rootEntityType, but you gave us $whatYouGaveUs."
+                )
               )
             )
-          )
-        } else {
-          val entityLookups: Seq[ExpressionLookup] = expressionEvaluationContext.expression match {
-            case None             => Seq.empty
-            case Some(expression) => parseLookups(expression)
+          } else {
+            val entityLookups: Seq[ExpressionLookup] = expressionEvaluationContext.expression match {
+              case None             => Seq.empty
+              case Some(expression) => parseLookups(expression)
+            }
+
+            val inputExpressionData: Seq[(MethodInput, RootContext, Seq[ExpressionLookup])] = inputsToExpressionData(
+              gatherInputsResult
+            )
+
+            val allLookups = inputExpressionData.flatMap { case (_, _, lookups) => lookups }
+
+            // If we have an entitylookup, prepend its chain to the relation chain of the query
+            val queryPlans = if (entityType != rootEntityType && entityLookups.nonEmpty) {
+              val entityRelationChain: List[String] =
+                entityLookups.flatMap(_.relations.map(_.attributeName()).map(_.getText)).toList
+              val updatedRelationChain = entityRelationChain ++ entityLookups.flatMap(_.attributeName).toList
+              val baseQueryPlans = buildQueryPlans(allLookups)
+
+              baseQueryPlans.map { plan =>
+                plan.copy(relationChain = updatedRelationChain ++ plan.relationChain)
+              }
+            } else {
+              buildQueryPlans(allLookups)
+            }
+
+            val queryActions: Seq[ReadAction[Seq[ExpressionAndResult]]] = queryPlans.map { plan =>
+              executeQueryPlan(workspaceId, entityType, entityName, rootEntityType, plan, entityLookups)
+            }
+
+            repository.dataSource
+              .inTransaction { _ =>
+                DBIO.sequence(queryActions)
+              }
+              .map { allQueryResults =>
+                val combinedExpressionAndResults: Seq[ExpressionAndResult] = allQueryResults.flatten
+
+                val rootEntityNames = if (entityType == rootEntityType) {
+                  Seq(entityName)
+                } else {
+                  combinedExpressionAndResults.flatMap { case (_, resultMap) => resultMap.keys }.distinct
+                }
+
+                // Pre-compute a map from expression -> ExpressionAndResult for O(1) lookup
+                val entityExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
+                  combinedExpressionAndResults.groupBy { case (expression, _) => expression }
+
+                // Transform workspaceExpressionResults to the same shape and add to the map
+                val workspaceExpressionAndResults: Seq[ExpressionAndResult] = workspaceExpressionResults.map {
+                  case (lookupExpression, tryValues) =>
+                    // Create a result map with the workspace values for all root entity names
+                    val resultMap = rootEntityNames.map { entityName =>
+                      entityName -> tryValues
+                    }.toMap
+
+                    (lookupExpression, resultMap)
+                }.toSeq
+
+                val workspaceExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
+                  workspaceExpressionAndResults.groupBy { case (expression, _) => expression }
+
+                // Combine both maps, with workspace results taking precedence if there are conflicts
+                val expressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
+                  entityExpressionToResultMap ++ workspaceExpressionToResultMap
+
+                inputExpressionData.flatMap { case (input, parsedTree, inputLookups) =>
+                  // Lookup ExpressionAndResults relevant to this input
+                  val relevantResults = inputLookups.flatMap { lookup =>
+                    expressionToResultMap.getOrElse(lookup.expression, Seq.empty)
+                  }
+
+                  val resultMap = InputExpressionReassembler.constructFinalInputValues(
+                    relevantResults,
+                    parsedTree,
+                    Some(rootEntityNames),
+                    Some(input)
+                  )
+                  convertToSubmissionValidationValues(resultMap, input)
+                }
+              }
           }
 
+        case (None, None, None) =>
+          // No entities involved, this should be static input expressions only
           val inputExpressionData: Seq[(MethodInput, RootContext, Seq[ExpressionLookup])] = inputsToExpressionData(
             gatherInputsResult
           )
 
-          val allLookups = inputExpressionData.flatMap { case (_, _, lookups) => lookups }
+          // Transform workspaceExpressionResults to the correct shape
+          val workspaceExpressionAndResults: Seq[ExpressionAndResult] = workspaceExpressionResults.map {
+            case (lookupExpression, tryValues) =>
+              // Create a result map with the workspace values for all root entity names
+              (lookupExpression, Map("" -> tryValues))
+          }.toSeq
 
-          // If we have an entitylookup, prepend its chain to the relation chain of the query
-          val queryPlans = if (entityType != rootEntityType && entityLookups.nonEmpty) {
-            val entityRelationChain: List[String] =
-              entityLookups.flatMap(_.relations.map(_.attributeName()).map(_.getText)).toList
-            val updatedRelationChain = entityRelationChain ++ entityLookups.flatMap(_.attributeName).toList
-            if (inputExpressionData.isEmpty) {
-              Seq(QueryPlan(updatedRelationChain, Map.empty))
-            } else {
-              buildQueryPlans(allLookups).map { plan =>
-                plan.copy(relationChain = updatedRelationChain ++ plan.relationChain)
-              }
+          val workspaceExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
+            workspaceExpressionAndResults.groupBy { case (expression, _) => expression }
+
+          // Repackage the parsed expressions into the correct form without querying the database
+          Future.successful {
+            inputExpressionData.flatMap { case (input, parsedTree, _) =>
+              val resultMap = InputExpressionReassembler.constructFinalInputValues(
+                workspaceExpressionToResultMap.getOrElse(input.expression, Seq.empty),
+                parsedTree,
+                None, // No root entity names since no entities are queried
+                Some(input)
+              )
+              convertToSubmissionValidationValues(resultMap, input)
             }
-          } else {
-            buildQueryPlans(allLookups)
           }
 
-          val queryActions: Seq[ReadAction[Seq[ExpressionAndResult]]] = queryPlans.map { plan =>
-            executeQueryPlan(workspaceId, entityType, entityName, rootEntityType, plan, entityLookups)
-          }
-
-          repository.dataSource
-            .inTransaction { _ =>
-              DBIO.sequence(queryActions)
-            }
-            .map { allQueryResults =>
-              val combinedExpressionAndResults: Seq[ExpressionAndResult] = allQueryResults.flatten
-
-              val rootEntityNames = if (entityType == rootEntityType) {
-                Seq(entityName)
-              } else {
-                combinedExpressionAndResults.flatMap { case (_, resultMap) => resultMap.keys }.distinct
-              }
-
-              // Pre-compute a map from expression -> ExpressionAndResult for O(1) lookup
-              val entityExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
-                combinedExpressionAndResults.groupBy { case (expression, _) => expression }
-
-              // Transform workspaceExpressionResults to the same shape and add to the map
-              val workspaceExpressionAndResults: Seq[ExpressionAndResult] = workspaceExpressionResults.map {
-                case (lookupExpression, tryValues) =>
-                  // Create a result map with the workspace values for all root entity names
-                  val resultMap = rootEntityNames.map { entityName =>
-                    entityName -> tryValues
-                  }.toMap
-
-                  (lookupExpression, resultMap)
-              }.toSeq
-
-              val workspaceExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
-                workspaceExpressionAndResults.groupBy { case (expression, _) => expression }
-
-              // Combine both maps, with workspace results taking precedence if there are conflicts
-              val expressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
-                entityExpressionToResultMap ++ workspaceExpressionToResultMap
-
-              //              (inputExpressionData, rootEntityNames, expressionToResultMap)
-              if (inputExpressionData.isEmpty) {
-                // Short-circuit if there are no inputs
-                rootEntityNames
-                  .map { rootEntityName =>
-                    SubmissionValidationEntityInputs(entityName = rootEntityName, inputResolutions = Set.empty)
-                  }
-                  .to(LazyList)
-              } else {
-                val resultsSeq =
-                  inputExpressionData.flatMap { case (input, parsedTree, inputLookups) =>
-                    // Lookup ExpressionAndResults relevant to this input
-                    val relevantResults = inputLookups.flatMap { lookup =>
-                      expressionToResultMap.getOrElse(lookup.expression, Seq.empty)
-                    }
-
-                    val resultMap = InputExpressionReassembler.constructFinalInputValues(
-                      relevantResults,
-                      parsedTree,
-                      Some(rootEntityNames),
-                      Some(input)
-                    )
-                    convertToSubmissionValidationValues(resultMap, input)
-                  }
-
-                if (resultsSeq.isEmpty) {
-                  LazyList(
-                    SubmissionValidationEntityInputs(entityName = expressionEvaluationContext.entityName.getOrElse(""),
-                                                     inputResolutions = Set.empty
-                    )
-                  )
-                } else {
-                  CollectionUtils
-                    .groupByTuples(resultsSeq)
-                    .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
-                      SubmissionValidationEntityInputs(
-                        entityName = entityName,
-                        inputResolutions = values.toSet
-                      )
-                    }
-                    .to(LazyList)
-                }
-
-              }
-            }
-        }
-
-      case (None, None, None) =>
-        // No entities involved, this should be static input expressions only
-        val inputExpressionData: Seq[(MethodInput, RootContext, Seq[ExpressionLookup])] = inputsToExpressionData(
-          gatherInputsResult
-        )
-
-        // Transform workspaceExpressionResults to the correct shape
-        val workspaceExpressionAndResults: Seq[ExpressionAndResult] = workspaceExpressionResults.map {
-          case (lookupExpression, tryValues) =>
-            // Create a result map with the workspace values for all root entity names
-            (lookupExpression, Map("" -> tryValues))
-        }.toSeq
-
-        val workspaceExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
-          workspaceExpressionAndResults.groupBy { case (expression, _) => expression }
-
-        //          Future.successful((inputExpressionData, Seq.empty[EntityName], workspaceExpressionToResultMap))
-
-        // Repackage the parsed expressions into the correct form without querying the database
-        //                  Future.successful {
-        val resultsSeq =
-          inputExpressionData.flatMap { case (input, parsedTree, _) =>
-            val resultMap = InputExpressionReassembler.constructFinalInputValues(
-              workspaceExpressionToResultMap.getOrElse(input.expression, Seq.empty),
-              parsedTree,
-              None, // No root entity names since no entities are queried
-              Some(input)
-            )
-            convertToSubmissionValidationValues(resultMap, input)
-          }
-        //                  }
-        Future.successful(if (resultsSeq.isEmpty) {
-          LazyList(
-            SubmissionValidationEntityInputs(entityName = expressionEvaluationContext.entityName.getOrElse(""),
-                                             inputResolutions = Set.empty
+        // If there are exactly one or two of entity type, entity name, and root entity, fail
+        case (Some(_), None, _) =>
+          Future.failed(
+            RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.BadRequest, s"Missing entityName")
             )
           )
-        } else {
-          CollectionUtils
-            .groupByTuples(resultsSeq)
-            .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
-              SubmissionValidationEntityInputs(
-                entityName = entityName,
-                inputResolutions = values.toSet
-              )
-            }
-            .to(LazyList)
-        })
+
+        case (None, Some(_), _) =>
+          Future.failed(
+            RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.BadRequest, s"Missing entityType")
+            )
+          )
+
+        case (None, None, Some(_)) =>
+          Future.failed(
+            RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.BadRequest, s"Missing entityType and entityName")
+            )
+          )
+
+        case (Some(_), Some(_), None) =>
+          Future.failed(
+            RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.BadRequest, s"Missing rootEntityType")
+            )
+          )
+      }
+
+    entityInfoFuture.map { resultsSeq =>
+      CollectionUtils
+        .groupByTuples(resultsSeq)
+        .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
+          SubmissionValidationEntityInputs(
+            entityName = entityName,
+            inputResolutions = values.toSet
+          )
+        }
+        .to(LazyList)
     }
   }
-//
-//    initialProcessingFuture
-//      .map { case (inputExpressionData, rootEntityNames, expressionToResultMap) =>
-//        if (inputExpressionData.isEmpty) {
-//          // Short-circuit if there are no inputs
-//          rootEntityNames
-//            .map { rootEntityName =>
-//              SubmissionValidationEntityInputs(entityName = rootEntityName, inputResolutions = Set.empty)
-//            }
-//            .to(LazyList)
-//        } else {
-//          val resultsSeq =
-//            inputExpressionData.flatMap { case (input, parsedTree, inputLookups) =>
-//              // Lookup ExpressionAndResults relevant to this input
-//              val relevantResults = inputLookups.flatMap { lookup =>
-//                expressionToResultMap.getOrElse(lookup.expression, Seq.empty)
-//              }
-//
-//              val resultMap = InputExpressionReassembler.constructFinalInputValues(
-//                relevantResults,
-//                parsedTree,
-//                Some(rootEntityNames),
-//                Some(input)
-//              )
-//              convertToSubmissionValidationValues(resultMap, input)
-//            }
-//
-//          if (resultsSeq.isEmpty) {
-//            LazyList(
-//              SubmissionValidationEntityInputs(entityName = expressionEvaluationContext.entityName.getOrElse(""),
-//                                               inputResolutions = Set.empty
-//              )
-//            )
-//          } else {
-//            CollectionUtils
-//              .groupByTuples(resultsSeq)
-//              .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
-//                SubmissionValidationEntityInputs(
-//                  entityName = entityName,
-//                  inputResolutions = values.toSet
-//                )
-//              }
-//              .to(LazyList)
-//          }
-//        }
-//      }
-//  }
 
   def parseLookups(expression: String): Seq[ExpressionLookup] = {
     val terraExpressionParser = AntlrTerraExpressionParser.getParser(expression)
@@ -522,67 +429,55 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
         }
       }
 
-      if (plan.expressionMappings.isEmpty) {
-        // Return entities with empty input resolutions
-        Seq(
-          ("",
-           entityRecords.values.flatten.map { entity =>
-             entity.name -> Success(Seq.empty[AttributeValue])
-           }.toMap
-          )
-        )
-      } else {
+      // For each expression in this query plan, create an ExpressionAndResult
+      plan.expressionMappings.toSeq.flatMap { case (expression, attributeNames) =>
+        attributeNames.map { attrName =>
+          val attributeName = AttributeName.fromDelimitedName(attrName)
 
-        // For each expression in this query plan, create an ExpressionAndResult
-        plan.expressionMappings.toSeq.flatMap { case (expression, attributeNames) =>
-          attributeNames.map { attrName =>
-            val attributeName = AttributeName.fromDelimitedName(attrName)
-
-            val entityToAttributeValues: Map[String, Try[Seq[AttributeValue]]] = if (entityType == rootEntityType) {
-              // Group all results under the original entityName since we want results grouped by the starting entity type
-              val allAttrs: Seq[AttributeValue] = entityRecords.values.flatten.toSeq.flatMap { record =>
-                if (
-                  attributeName == AttributeName.withDefaultNS(record.entityType + Attributable.entityIdAttributeSuffix)
-                ) {
-                  Seq(AttributeString(record.name))
-                } else {
-                  record.toEntity.attributes.get(attributeName) match {
-                    case Some(avl: AttributeValueList) =>
-                      avl.list
-                    case Some(av: AttributeValue) =>
-                      Seq(av)
-                    case _ =>
-                      Seq.empty
-                  }
-                }
-              }
-              Map(entityName -> Success(allAttrs))
-            } else {
-              entityRecords.flatMap { case (_, records) =>
-                records.map { record =>
-                  val attrs: Seq[AttributeValue] =
-                    if (
-                      attributeName == AttributeName.withDefaultNS(
-                        record.entityType + Attributable.entityIdAttributeSuffix
-                      )
-                    ) {
-                      Seq(AttributeString(record.name))
-                    } else {
-                      record.toEntity.attributes.get(attributeName) match {
-                        case Some(avl: AttributeValueList) =>
-                          avl.list
-                        case Some(av: AttributeValue) =>
-                          Seq(av)
-                        case _ =>
-                          Seq.empty
-                      }
-                    }
-                  record.name -> Success(attrs)
+          val entityToAttributeValues: Map[String, Try[Seq[AttributeValue]]] = if (entityType == rootEntityType) {
+            // Group all results under the original entityName since we want results grouped by the starting entity type
+            val allAttrs: Seq[AttributeValue] = entityRecords.values.flatten.toSeq.flatMap { record =>
+              if (
+                attributeName == AttributeName.withDefaultNS(record.entityType + Attributable.entityIdAttributeSuffix)
+              ) {
+                Seq(AttributeString(record.name))
+              } else {
+                record.toEntity.attributes.get(attributeName) match {
+                  case Some(avl: AttributeValueList) =>
+                    avl.list
+                  case Some(av: AttributeValue) =>
+                    Seq(av)
+                  case _ =>
+                    Seq.empty
                 }
               }
             }
-            (expression, entityToAttributeValues)
+            Map(entityName -> Success(allAttrs))
+          } else {
+            entityRecords.flatMap { case (_, records) =>
+              records.map { record =>
+                val attrs: Seq[AttributeValue] =
+                  if (
+                    attributeName == AttributeName.withDefaultNS(
+                      record.entityType + Attributable.entityIdAttributeSuffix
+                    )
+                  ) {
+                    Seq(AttributeString(record.name))
+                  } else {
+                    record.toEntity.attributes.get(attributeName) match {
+                      case Some(avl: AttributeValueList) =>
+                        avl.list
+                      case Some(av: AttributeValue) =>
+                        Seq(av)
+                      case _ =>
+                        Seq.empty
+                    }
+                  }
+                record.name -> Success(attrs)
+              }
+            }
           }
+          (expression, entityToAttributeValues)
         }
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -140,9 +140,6 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
                           workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]] = Map.empty
   )(implicit executionContext: ExecutionContext): Future[LazyList[SubmissionValidationEntityInputs]] = {
 
-    //    val initialProcessingFuture: Future[
-    //      (Seq[(MethodInput, RootContext, Seq[ExpressionLookup])], Seq[EntityName], Map[String, Seq[ExpressionAndResult]])
-    //    ] =
     (expressionEvaluationContext.entityType,
      expressionEvaluationContext.entityName,
      expressionEvaluationContext.rootEntityType
@@ -259,7 +256,6 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
               val expressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
                 entityExpressionToResultMap ++ workspaceExpressionToResultMap
 
-              //              (inputExpressionData, rootEntityNames, expressionToResultMap)
               if (inputExpressionData.isEmpty) {
                 // Short-circuit if there are no inputs
                 rootEntityNames
@@ -322,10 +318,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
         val workspaceExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
           workspaceExpressionAndResults.groupBy { case (expression, _) => expression }
 
-        //          Future.successful((inputExpressionData, Seq.empty[EntityName], workspaceExpressionToResultMap))
-
         // Repackage the parsed expressions into the correct form without querying the database
-        //                  Future.successful {
         val resultsSeq =
           inputExpressionData.flatMap { case (input, parsedTree, _) =>
             val resultMap = InputExpressionReassembler.constructFinalInputValues(
@@ -336,7 +329,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
             )
             convertToSubmissionValidationValues(resultMap, input)
           }
-        //                  }
+
         Future.successful(if (resultsSeq.isEmpty) {
           LazyList(
             SubmissionValidationEntityInputs(entityName = expressionEvaluationContext.entityName.getOrElse(""),
@@ -356,53 +349,6 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
         })
     }
   }
-//
-//    initialProcessingFuture
-//      .map { case (inputExpressionData, rootEntityNames, expressionToResultMap) =>
-//        if (inputExpressionData.isEmpty) {
-//          // Short-circuit if there are no inputs
-//          rootEntityNames
-//            .map { rootEntityName =>
-//              SubmissionValidationEntityInputs(entityName = rootEntityName, inputResolutions = Set.empty)
-//            }
-//            .to(LazyList)
-//        } else {
-//          val resultsSeq =
-//            inputExpressionData.flatMap { case (input, parsedTree, inputLookups) =>
-//              // Lookup ExpressionAndResults relevant to this input
-//              val relevantResults = inputLookups.flatMap { lookup =>
-//                expressionToResultMap.getOrElse(lookup.expression, Seq.empty)
-//              }
-//
-//              val resultMap = InputExpressionReassembler.constructFinalInputValues(
-//                relevantResults,
-//                parsedTree,
-//                Some(rootEntityNames),
-//                Some(input)
-//              )
-//              convertToSubmissionValidationValues(resultMap, input)
-//            }
-//
-//          if (resultsSeq.isEmpty) {
-//            LazyList(
-//              SubmissionValidationEntityInputs(entityName = expressionEvaluationContext.entityName.getOrElse(""),
-//                                               inputResolutions = Set.empty
-//              )
-//            )
-//          } else {
-//            CollectionUtils
-//              .groupByTuples(resultsSeq)
-//              .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
-//                SubmissionValidationEntityInputs(
-//                  entityName = entityName,
-//                  inputResolutions = values.toSet
-//                )
-//              }
-//              .to(LazyList)
-//          }
-//        }
-//      }
-//  }
 
   def parseLookups(expression: String): Seq[ExpressionLookup] = {
     val terraExpressionParser = AntlrTerraExpressionParser.getParser(expression)
@@ -432,7 +378,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
    *     up to relationLevel
    * @param relationLevel The current relation level starting with 0 and incrementing with each
    *     recursive call
-   * @return A seq of QueryPlans, which contain: 
+   * @return A seq of QueryPlans, which contain:
    *         - List of string representing the chain of relations,
    *         - Map of expression -> list of strings representing the attributes to get from the entities at the end of the chain
    */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -140,6 +140,9 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
                           workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]] = Map.empty
   )(implicit executionContext: ExecutionContext): Future[LazyList[SubmissionValidationEntityInputs]] = {
 
+    //    val initialProcessingFuture: Future[
+    //      (Seq[(MethodInput, RootContext, Seq[ExpressionLookup])], Seq[EntityName], Map[String, Seq[ExpressionAndResult]])
+    //    ] =
     (expressionEvaluationContext.entityType,
      expressionEvaluationContext.entityName,
      expressionEvaluationContext.rootEntityType
@@ -256,6 +259,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
               val expressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
                 entityExpressionToResultMap ++ workspaceExpressionToResultMap
 
+              //              (inputExpressionData, rootEntityNames, expressionToResultMap)
               if (inputExpressionData.isEmpty) {
                 // Short-circuit if there are no inputs
                 rootEntityNames
@@ -318,7 +322,10 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
         val workspaceExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
           workspaceExpressionAndResults.groupBy { case (expression, _) => expression }
 
+        //          Future.successful((inputExpressionData, Seq.empty[EntityName], workspaceExpressionToResultMap))
+
         // Repackage the parsed expressions into the correct form without querying the database
+        //                  Future.successful {
         val resultsSeq =
           inputExpressionData.flatMap { case (input, parsedTree, _) =>
             val resultMap = InputExpressionReassembler.constructFinalInputValues(
@@ -329,7 +336,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
             )
             convertToSubmissionValidationValues(resultMap, input)
           }
-
+        //                  }
         Future.successful(if (resultsSeq.isEmpty) {
           LazyList(
             SubmissionValidationEntityInputs(entityName = expressionEvaluationContext.entityName.getOrElse(""),
@@ -349,6 +356,53 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
         })
     }
   }
+//
+//    initialProcessingFuture
+//      .map { case (inputExpressionData, rootEntityNames, expressionToResultMap) =>
+//        if (inputExpressionData.isEmpty) {
+//          // Short-circuit if there are no inputs
+//          rootEntityNames
+//            .map { rootEntityName =>
+//              SubmissionValidationEntityInputs(entityName = rootEntityName, inputResolutions = Set.empty)
+//            }
+//            .to(LazyList)
+//        } else {
+//          val resultsSeq =
+//            inputExpressionData.flatMap { case (input, parsedTree, inputLookups) =>
+//              // Lookup ExpressionAndResults relevant to this input
+//              val relevantResults = inputLookups.flatMap { lookup =>
+//                expressionToResultMap.getOrElse(lookup.expression, Seq.empty)
+//              }
+//
+//              val resultMap = InputExpressionReassembler.constructFinalInputValues(
+//                relevantResults,
+//                parsedTree,
+//                Some(rootEntityNames),
+//                Some(input)
+//              )
+//              convertToSubmissionValidationValues(resultMap, input)
+//            }
+//
+//          if (resultsSeq.isEmpty) {
+//            LazyList(
+//              SubmissionValidationEntityInputs(entityName = expressionEvaluationContext.entityName.getOrElse(""),
+//                                               inputResolutions = Set.empty
+//              )
+//            )
+//          } else {
+//            CollectionUtils
+//              .groupByTuples(resultsSeq)
+//              .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
+//                SubmissionValidationEntityInputs(
+//                  entityName = entityName,
+//                  inputResolutions = values.toSet
+//                )
+//              }
+//              .to(LazyList)
+//          }
+//        }
+//      }
+//  }
 
   def parseLookups(expression: String): Seq[ExpressionLookup] = {
     val terraExpressionParser = AntlrTerraExpressionParser.getParser(expression)
@@ -378,7 +432,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
    *     up to relationLevel
    * @param relationLevel The current relation level starting with 0 and incrementing with each
    *     recursive call
-   * @return A seq of QueryPlans, which contain:
+   * @return A seq of QueryPlans, which contain: 
    *         - List of string representing the chain of relations,
    *         - Map of expression -> list of strings representing the attributes to get from the entities at the end of the chain
    */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -3,7 +3,11 @@ package org.broadinstitute.dsde.rawls.expressions
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadAction
-import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{ExpressionAndResult, LookupExpression}
+import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{
+  EntityName,
+  ExpressionAndResult,
+  LookupExpression
+}
 import org.broadinstitute.dsde.rawls.entities.base.{
   ExpressionEvaluationContext,
   ExpressionEvaluationSupport,
@@ -22,7 +26,8 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeValue,
   AttributeValueList,
   ErrorReport,
-  SubmissionValidationEntityInputs
+  SubmissionValidationEntityInputs,
+  SubmissionValidationValue
 }
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
 import slick.dbio.DBIO
@@ -135,181 +140,269 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
                           workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]] = Map.empty
   )(implicit executionContext: ExecutionContext): Future[LazyList[SubmissionValidationEntityInputs]] = {
 
-    val entityInfoFuture =
-      (expressionEvaluationContext.entityType,
-       expressionEvaluationContext.entityName,
-       expressionEvaluationContext.rootEntityType
-      ) match {
-        case (Some(entityType), Some(entityName), Some(rootEntityType)) =>
-          if (
-            expressionEvaluationContext.expression.isEmpty &&
-            entityType != rootEntityType
-          ) {
-            val whatYouGaveUs =
-              if (expressionEvaluationContext.entityType.isDefined)
-                s"an entity of type ${expressionEvaluationContext.entityType.get}"
-              else "no entity"
-            Future.failed(
-              new RawlsExceptionWithErrorReport(
-                errorReport = ErrorReport(
-                  StatusCodes.BadRequest,
-                  s"Method configuration expects an entity of type $rootEntityType, but you gave us $whatYouGaveUs."
-                )
+    //    val initialProcessingFuture: Future[
+    //      (Seq[(MethodInput, RootContext, Seq[ExpressionLookup])], Seq[EntityName], Map[String, Seq[ExpressionAndResult]])
+    //    ] =
+    (expressionEvaluationContext.entityType,
+     expressionEvaluationContext.entityName,
+     expressionEvaluationContext.rootEntityType
+    ) match {
+      // If there are exactly one or two of entity type, entity name, and root entity, fail
+      case (Some(_), None, _) =>
+        Future.failed(
+          RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.BadRequest, s"Missing entityName")
+          )
+        )
+
+      case (None, Some(_), _) =>
+        Future.failed(
+          RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.BadRequest, s"Missing entityType")
+          )
+        )
+
+      case (None, None, Some(_)) =>
+        Future.failed(
+          RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.BadRequest, s"Missing entityType and entityName")
+          )
+        )
+
+      case (Some(_), Some(_), None) =>
+        Future.failed(
+          RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.BadRequest, s"Missing rootEntityType")
+          )
+        )
+      case (Some(entityType), Some(entityName), Some(rootEntityType)) =>
+        if (
+          expressionEvaluationContext.expression.isEmpty &&
+          entityType != rootEntityType
+        ) {
+          val whatYouGaveUs =
+            if (expressionEvaluationContext.entityType.isDefined)
+              s"an entity of type ${expressionEvaluationContext.entityType.get}"
+            else "no entity"
+          Future.failed(
+            new RawlsExceptionWithErrorReport(
+              errorReport = ErrorReport(
+                StatusCodes.BadRequest,
+                s"Method configuration expects an entity of type $rootEntityType, but you gave us $whatYouGaveUs."
               )
             )
-          } else {
-            val entityLookups: Seq[ExpressionLookup] = expressionEvaluationContext.expression match {
-              case None             => Seq.empty
-              case Some(expression) => parseLookups(expression)
-            }
-
-            val inputExpressionData: Seq[(MethodInput, RootContext, Seq[ExpressionLookup])] = inputsToExpressionData(
-              gatherInputsResult
-            )
-
-            val allLookups = inputExpressionData.flatMap { case (_, _, lookups) => lookups }
-
-            // If we have an entitylookup, prepend its chain to the relation chain of the query
-            val queryPlans = if (entityType != rootEntityType && entityLookups.nonEmpty) {
-              val entityRelationChain: List[String] =
-                entityLookups.flatMap(_.relations.map(_.attributeName()).map(_.getText)).toList
-              val updatedRelationChain = entityRelationChain ++ entityLookups.flatMap(_.attributeName).toList
-              val baseQueryPlans = buildQueryPlans(allLookups)
-
-              baseQueryPlans.map { plan =>
-                plan.copy(relationChain = updatedRelationChain ++ plan.relationChain)
-              }
-            } else {
-              buildQueryPlans(allLookups)
-            }
-
-            val queryActions: Seq[ReadAction[Seq[ExpressionAndResult]]] = queryPlans.map { plan =>
-              executeQueryPlan(workspaceId, entityType, entityName, rootEntityType, plan, entityLookups)
-            }
-
-            repository.dataSource
-              .inTransaction { _ =>
-                DBIO.sequence(queryActions)
-              }
-              .map { allQueryResults =>
-                val combinedExpressionAndResults: Seq[ExpressionAndResult] = allQueryResults.flatten
-
-                val rootEntityNames = if (entityType == rootEntityType) {
-                  Seq(entityName)
-                } else {
-                  combinedExpressionAndResults.flatMap { case (_, resultMap) => resultMap.keys }.distinct
-                }
-
-                // Pre-compute a map from expression -> ExpressionAndResult for O(1) lookup
-                val entityExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
-                  combinedExpressionAndResults.groupBy { case (expression, _) => expression }
-
-                // Transform workspaceExpressionResults to the same shape and add to the map
-                val workspaceExpressionAndResults: Seq[ExpressionAndResult] = workspaceExpressionResults.map {
-                  case (lookupExpression, tryValues) =>
-                    // Create a result map with the workspace values for all root entity names
-                    val resultMap = rootEntityNames.map { entityName =>
-                      entityName -> tryValues
-                    }.toMap
-
-                    (lookupExpression, resultMap)
-                }.toSeq
-
-                val workspaceExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
-                  workspaceExpressionAndResults.groupBy { case (expression, _) => expression }
-
-                // Combine both maps, with workspace results taking precedence if there are conflicts
-                val expressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
-                  entityExpressionToResultMap ++ workspaceExpressionToResultMap
-
-                inputExpressionData.flatMap { case (input, parsedTree, inputLookups) =>
-                  // Lookup ExpressionAndResults relevant to this input
-                  val relevantResults = inputLookups.flatMap { lookup =>
-                    expressionToResultMap.getOrElse(lookup.expression, Seq.empty)
-                  }
-
-                  val resultMap = InputExpressionReassembler.constructFinalInputValues(
-                    relevantResults,
-                    parsedTree,
-                    Some(rootEntityNames),
-                    Some(input)
-                  )
-                  convertToSubmissionValidationValues(resultMap, input)
-                }
-              }
+          )
+        } else {
+          val entityLookups: Seq[ExpressionLookup] = expressionEvaluationContext.expression match {
+            case None             => Seq.empty
+            case Some(expression) => parseLookups(expression)
           }
 
-        case (None, None, None) =>
-          // No entities involved, this should be static input expressions only
           val inputExpressionData: Seq[(MethodInput, RootContext, Seq[ExpressionLookup])] = inputsToExpressionData(
             gatherInputsResult
           )
 
-          // Transform workspaceExpressionResults to the correct shape
-          val workspaceExpressionAndResults: Seq[ExpressionAndResult] = workspaceExpressionResults.map {
-            case (lookupExpression, tryValues) =>
-              // Create a result map with the workspace values for all root entity names
-              (lookupExpression, Map("" -> tryValues))
-          }.toSeq
+          val allLookups = inputExpressionData.flatMap { case (_, _, lookups) => lookups }
 
-          val workspaceExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
-            workspaceExpressionAndResults.groupBy { case (expression, _) => expression }
-
-          // Repackage the parsed expressions into the correct form without querying the database
-          Future.successful {
-            inputExpressionData.flatMap { case (input, parsedTree, _) =>
-              val resultMap = InputExpressionReassembler.constructFinalInputValues(
-                workspaceExpressionToResultMap.getOrElse(input.expression, Seq.empty),
-                parsedTree,
-                None, // No root entity names since no entities are queried
-                Some(input)
-              )
-              convertToSubmissionValidationValues(resultMap, input)
+          // If we have an entitylookup, prepend its chain to the relation chain of the query
+          val queryPlans = if (entityType != rootEntityType && entityLookups.nonEmpty) {
+            val entityRelationChain: List[String] =
+              entityLookups.flatMap(_.relations.map(_.attributeName()).map(_.getText)).toList
+            val updatedRelationChain = entityRelationChain ++ entityLookups.flatMap(_.attributeName).toList
+            if (inputExpressionData.isEmpty) {
+              Seq(QueryPlan(updatedRelationChain, Map.empty))
+            } else {
+              buildQueryPlans(allLookups).map { plan =>
+                plan.copy(relationChain = updatedRelationChain ++ plan.relationChain)
+              }
             }
+          } else {
+            buildQueryPlans(allLookups)
           }
 
-        // If there are exactly one or two of entity type, entity name, and root entity, fail
-        case (Some(_), None, _) =>
-          Future.failed(
-            RawlsExceptionWithErrorReport(
-              ErrorReport(StatusCodes.BadRequest, s"Missing entityName")
-            )
-          )
+          val queryActions: Seq[ReadAction[Seq[ExpressionAndResult]]] = queryPlans.map { plan =>
+            executeQueryPlan(workspaceId, entityType, entityName, rootEntityType, plan, entityLookups)
+          }
 
-        case (None, Some(_), _) =>
-          Future.failed(
-            RawlsExceptionWithErrorReport(
-              ErrorReport(StatusCodes.BadRequest, s"Missing entityType")
-            )
-          )
+          repository.dataSource
+            .inTransaction { _ =>
+              DBIO.sequence(queryActions)
+            }
+            .map { allQueryResults =>
+              val combinedExpressionAndResults: Seq[ExpressionAndResult] = allQueryResults.flatten
 
-        case (None, None, Some(_)) =>
-          Future.failed(
-            RawlsExceptionWithErrorReport(
-              ErrorReport(StatusCodes.BadRequest, s"Missing entityType and entityName")
-            )
-          )
+              val rootEntityNames = if (entityType == rootEntityType) {
+                Seq(entityName)
+              } else {
+                combinedExpressionAndResults.flatMap { case (_, resultMap) => resultMap.keys }.distinct
+              }
 
-        case (Some(_), Some(_), None) =>
-          Future.failed(
-            RawlsExceptionWithErrorReport(
-              ErrorReport(StatusCodes.BadRequest, s"Missing rootEntityType")
-            )
-          )
-      }
+              // Pre-compute a map from expression -> ExpressionAndResult for O(1) lookup
+              val entityExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
+                combinedExpressionAndResults.groupBy { case (expression, _) => expression }
 
-    entityInfoFuture.map { resultsSeq =>
-      CollectionUtils
-        .groupByTuples(resultsSeq)
-        .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
-          SubmissionValidationEntityInputs(
-            entityName = entityName,
-            inputResolutions = values.toSet
-          )
+              // Transform workspaceExpressionResults to the same shape and add to the map
+              val workspaceExpressionAndResults: Seq[ExpressionAndResult] = workspaceExpressionResults.map {
+                case (lookupExpression, tryValues) =>
+                  // Create a result map with the workspace values for all root entity names
+                  val resultMap = rootEntityNames.map { entityName =>
+                    entityName -> tryValues
+                  }.toMap
+
+                  (lookupExpression, resultMap)
+              }.toSeq
+
+              val workspaceExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
+                workspaceExpressionAndResults.groupBy { case (expression, _) => expression }
+
+              // Combine both maps, with workspace results taking precedence if there are conflicts
+              val expressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
+                entityExpressionToResultMap ++ workspaceExpressionToResultMap
+
+              //              (inputExpressionData, rootEntityNames, expressionToResultMap)
+              if (inputExpressionData.isEmpty) {
+                // Short-circuit if there are no inputs
+                rootEntityNames
+                  .map { rootEntityName =>
+                    SubmissionValidationEntityInputs(entityName = rootEntityName, inputResolutions = Set.empty)
+                  }
+                  .to(LazyList)
+              } else {
+                val resultsSeq =
+                  inputExpressionData.flatMap { case (input, parsedTree, inputLookups) =>
+                    // Lookup ExpressionAndResults relevant to this input
+                    val relevantResults = inputLookups.flatMap { lookup =>
+                      expressionToResultMap.getOrElse(lookup.expression, Seq.empty)
+                    }
+
+                    val resultMap = InputExpressionReassembler.constructFinalInputValues(
+                      relevantResults,
+                      parsedTree,
+                      Some(rootEntityNames),
+                      Some(input)
+                    )
+                    convertToSubmissionValidationValues(resultMap, input)
+                  }
+
+                if (resultsSeq.isEmpty) {
+                  LazyList(
+                    SubmissionValidationEntityInputs(entityName = expressionEvaluationContext.entityName.getOrElse(""),
+                                                     inputResolutions = Set.empty
+                    )
+                  )
+                } else {
+                  CollectionUtils
+                    .groupByTuples(resultsSeq)
+                    .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
+                      SubmissionValidationEntityInputs(
+                        entityName = entityName,
+                        inputResolutions = values.toSet
+                      )
+                    }
+                    .to(LazyList)
+                }
+
+              }
+            }
         }
-        .to(LazyList)
+
+      case (None, None, None) =>
+        // No entities involved, this should be static input expressions only
+        val inputExpressionData: Seq[(MethodInput, RootContext, Seq[ExpressionLookup])] = inputsToExpressionData(
+          gatherInputsResult
+        )
+
+        // Transform workspaceExpressionResults to the correct shape
+        val workspaceExpressionAndResults: Seq[ExpressionAndResult] = workspaceExpressionResults.map {
+          case (lookupExpression, tryValues) =>
+            // Create a result map with the workspace values for all root entity names
+            (lookupExpression, Map("" -> tryValues))
+        }.toSeq
+
+        val workspaceExpressionToResultMap: Map[String, Seq[ExpressionAndResult]] =
+          workspaceExpressionAndResults.groupBy { case (expression, _) => expression }
+
+        //          Future.successful((inputExpressionData, Seq.empty[EntityName], workspaceExpressionToResultMap))
+
+        // Repackage the parsed expressions into the correct form without querying the database
+        //                  Future.successful {
+        val resultsSeq =
+          inputExpressionData.flatMap { case (input, parsedTree, _) =>
+            val resultMap = InputExpressionReassembler.constructFinalInputValues(
+              workspaceExpressionToResultMap.getOrElse(input.expression, Seq.empty),
+              parsedTree,
+              None, // No root entity names since no entities are queried
+              Some(input)
+            )
+            convertToSubmissionValidationValues(resultMap, input)
+          }
+        //                  }
+        Future.successful(if (resultsSeq.isEmpty) {
+          LazyList(
+            SubmissionValidationEntityInputs(entityName = expressionEvaluationContext.entityName.getOrElse(""),
+                                             inputResolutions = Set.empty
+            )
+          )
+        } else {
+          CollectionUtils
+            .groupByTuples(resultsSeq)
+            .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
+              SubmissionValidationEntityInputs(
+                entityName = entityName,
+                inputResolutions = values.toSet
+              )
+            }
+            .to(LazyList)
+        })
     }
   }
+//
+//    initialProcessingFuture
+//      .map { case (inputExpressionData, rootEntityNames, expressionToResultMap) =>
+//        if (inputExpressionData.isEmpty) {
+//          // Short-circuit if there are no inputs
+//          rootEntityNames
+//            .map { rootEntityName =>
+//              SubmissionValidationEntityInputs(entityName = rootEntityName, inputResolutions = Set.empty)
+//            }
+//            .to(LazyList)
+//        } else {
+//          val resultsSeq =
+//            inputExpressionData.flatMap { case (input, parsedTree, inputLookups) =>
+//              // Lookup ExpressionAndResults relevant to this input
+//              val relevantResults = inputLookups.flatMap { lookup =>
+//                expressionToResultMap.getOrElse(lookup.expression, Seq.empty)
+//              }
+//
+//              val resultMap = InputExpressionReassembler.constructFinalInputValues(
+//                relevantResults,
+//                parsedTree,
+//                Some(rootEntityNames),
+//                Some(input)
+//              )
+//              convertToSubmissionValidationValues(resultMap, input)
+//            }
+//
+//          if (resultsSeq.isEmpty) {
+//            LazyList(
+//              SubmissionValidationEntityInputs(entityName = expressionEvaluationContext.entityName.getOrElse(""),
+//                                               inputResolutions = Set.empty
+//              )
+//            )
+//          } else {
+//            CollectionUtils
+//              .groupByTuples(resultsSeq)
+//              .map { case (entityName: ExpressionEvaluationSupport.EntityName, values) =>
+//                SubmissionValidationEntityInputs(
+//                  entityName = entityName,
+//                  inputResolutions = values.toSet
+//                )
+//              }
+//              .to(LazyList)
+//          }
+//        }
+//      }
+//  }
 
   def parseLookups(expression: String): Seq[ExpressionLookup] = {
     val terraExpressionParser = AntlrTerraExpressionParser.getParser(expression)
@@ -429,55 +522,67 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
         }
       }
 
-      // For each expression in this query plan, create an ExpressionAndResult
-      plan.expressionMappings.toSeq.flatMap { case (expression, attributeNames) =>
-        attributeNames.map { attrName =>
-          val attributeName = AttributeName.fromDelimitedName(attrName)
+      if (plan.expressionMappings.isEmpty) {
+        // Return entities with empty input resolutions
+        Seq(
+          ("",
+           entityRecords.values.flatten.map { entity =>
+             entity.name -> Success(Seq.empty[AttributeValue])
+           }.toMap
+          )
+        )
+      } else {
 
-          val entityToAttributeValues: Map[String, Try[Seq[AttributeValue]]] = if (entityType == rootEntityType) {
-            // Group all results under the original entityName since we want results grouped by the starting entity type
-            val allAttrs: Seq[AttributeValue] = entityRecords.values.flatten.toSeq.flatMap { record =>
-              if (
-                attributeName == AttributeName.withDefaultNS(record.entityType + Attributable.entityIdAttributeSuffix)
-              ) {
-                Seq(AttributeString(record.name))
-              } else {
-                record.toEntity.attributes.get(attributeName) match {
-                  case Some(avl: AttributeValueList) =>
-                    avl.list
-                  case Some(av: AttributeValue) =>
-                    Seq(av)
-                  case _ =>
-                    Seq.empty
+        // For each expression in this query plan, create an ExpressionAndResult
+        plan.expressionMappings.toSeq.flatMap { case (expression, attributeNames) =>
+          attributeNames.map { attrName =>
+            val attributeName = AttributeName.fromDelimitedName(attrName)
+
+            val entityToAttributeValues: Map[String, Try[Seq[AttributeValue]]] = if (entityType == rootEntityType) {
+              // Group all results under the original entityName since we want results grouped by the starting entity type
+              val allAttrs: Seq[AttributeValue] = entityRecords.values.flatten.toSeq.flatMap { record =>
+                if (
+                  attributeName == AttributeName.withDefaultNS(record.entityType + Attributable.entityIdAttributeSuffix)
+                ) {
+                  Seq(AttributeString(record.name))
+                } else {
+                  record.toEntity.attributes.get(attributeName) match {
+                    case Some(avl: AttributeValueList) =>
+                      avl.list
+                    case Some(av: AttributeValue) =>
+                      Seq(av)
+                    case _ =>
+                      Seq.empty
+                  }
+                }
+              }
+              Map(entityName -> Success(allAttrs))
+            } else {
+              entityRecords.flatMap { case (_, records) =>
+                records.map { record =>
+                  val attrs: Seq[AttributeValue] =
+                    if (
+                      attributeName == AttributeName.withDefaultNS(
+                        record.entityType + Attributable.entityIdAttributeSuffix
+                      )
+                    ) {
+                      Seq(AttributeString(record.name))
+                    } else {
+                      record.toEntity.attributes.get(attributeName) match {
+                        case Some(avl: AttributeValueList) =>
+                          avl.list
+                        case Some(av: AttributeValue) =>
+                          Seq(av)
+                        case _ =>
+                          Seq.empty
+                      }
+                    }
+                  record.name -> Success(attrs)
                 }
               }
             }
-            Map(entityName -> Success(allAttrs))
-          } else {
-            entityRecords.flatMap { case (_, records) =>
-              records.map { record =>
-                val attrs: Seq[AttributeValue] =
-                  if (
-                    attributeName == AttributeName.withDefaultNS(
-                      record.entityType + Attributable.entityIdAttributeSuffix
-                    )
-                  ) {
-                    Seq(AttributeString(record.name))
-                  } else {
-                    record.toEntity.attributes.get(attributeName) match {
-                      case Some(avl: AttributeValueList) =>
-                        avl.list
-                      case Some(av: AttributeValue) =>
-                        Seq(av)
-                      case _ =>
-                        Seq.empty
-                    }
-                  }
-                record.name -> Success(attrs)
-              }
-            }
+            (expression, entityToAttributeValues)
           }
-          (expression, entityToAttributeValues)
         }
       }
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
@@ -34,7 +34,6 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatest.concurrent.ScalaFutures
 import slick.dbio.DBIO
-import scala.concurrent.duration._
 
 import scala.util.{Random, Success}
 
@@ -46,9 +45,6 @@ class CompactExpressionEvaluatorSpec
     with TableDrivenPropertyChecks
     with TestDriverComponent
     with MethodConfigTestSupport {
-
-  implicit override val patienceConfig: PatienceConfig =
-    PatienceConfig(timeout = 300.seconds, interval = 100.millis)
 
   val compactEntityRepositoryMock: CompactEntityRepository = mock[CompactEntityRepository]
   val mockQueries: CompactEntityQuery = mock[CompactEntityQuery]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
@@ -34,6 +34,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatest.concurrent.ScalaFutures
 import slick.dbio.DBIO
+import scala.concurrent.duration._
 
 import scala.util.{Random, Success}
 
@@ -45,6 +46,9 @@ class CompactExpressionEvaluatorSpec
     with TableDrivenPropertyChecks
     with TestDriverComponent
     with MethodConfigTestSupport {
+
+  implicit override val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = 300.seconds, interval = 100.millis)
 
   val compactEntityRepositoryMock: CompactEntityRepository = mock[CompactEntityRepository]
   val mockQueries: CompactEntityQuery = mock[CompactEntityQuery]
@@ -457,6 +461,51 @@ class CompactExpressionEvaluatorSpec
         )
       )
     )
+  }
+
+  it should "return results when there are no inputs" in withConfigData {
+    when(
+      mockQueries.queryRelatedRecordsWithRelationChain(any(),
+                                                       any(),
+                                                       org.mockito.ArgumentMatchers.eq("daSampleSet"),
+                                                       any()
+      )
+    )
+      .thenReturn(
+        DBIO.successful(
+          Map(sampleSet.name -> Seq(sampleGoodAsCER, sampleMissingValueAsCER))
+        )
+      )
+
+    val methodConf = MethodConfiguration("namespace",
+                                         "name",
+                                         Some("Sample"),
+                                         None,
+                                         Map.empty,
+                                         Map.empty,
+                                         AgoraMethod("dsde", "no_input", 1)
+    )
+
+    val expressionEvaluationContext =
+      ExpressionEvaluationContext(Some(sampleSet.entityType),
+                                  Some(sampleSet.name),
+                                  Some("this.samples"),
+                                  Some(sampleGood.entityType)
+      )
+    val result = evalInputs(expressionEvaluationContext, methodConf, arrayWdl)
+    result should contain theSameElementsAs Seq(
+      SubmissionValidationEntityInputs(
+        sampleGoodAsCER.name,
+        Set(
+        )
+      ),
+      SubmissionValidationEntityInputs(
+        sampleMissingValueAsCER.name,
+        Set(
+        )
+      )
+    )
+
   }
 
   it should "return error on missing values" in withConfigData {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
@@ -34,7 +34,6 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatest.concurrent.ScalaFutures
 import slick.dbio.DBIO
-import scala.concurrent.duration._
 
 import scala.util.{Random, Success}
 
@@ -46,9 +45,6 @@ class CompactExpressionEvaluatorSpec
     with TableDrivenPropertyChecks
     with TestDriverComponent
     with MethodConfigTestSupport {
-
-  implicit override val patienceConfig: PatienceConfig =
-    PatienceConfig(timeout = 300.seconds, interval = 100.millis)
 
   val compactEntityRepositoryMock: CompactEntityRepository = mock[CompactEntityRepository]
   val mockQueries: CompactEntityQuery = mock[CompactEntityQuery]
@@ -461,51 +457,6 @@ class CompactExpressionEvaluatorSpec
         )
       )
     )
-  }
-
-  it should "return results when there are no inputs" in withConfigData {
-    when(
-      mockQueries.queryRelatedRecordsWithRelationChain(any(),
-                                                       any(),
-                                                       org.mockito.ArgumentMatchers.eq("daSampleSet"),
-                                                       any()
-      )
-    )
-      .thenReturn(
-        DBIO.successful(
-          Map(sampleSet.name -> Seq(sampleGoodAsCER, sampleMissingValueAsCER))
-        )
-      )
-
-    val methodConf = MethodConfiguration("namespace",
-                                         "name",
-                                         Some("Sample"),
-                                         None,
-                                         Map.empty,
-                                         Map.empty,
-                                         AgoraMethod("dsde", "no_input", 1)
-    )
-
-    val expressionEvaluationContext =
-      ExpressionEvaluationContext(Some(sampleSet.entityType),
-                                  Some(sampleSet.name),
-                                  Some("this.samples"),
-                                  Some(sampleGood.entityType)
-      )
-    val result = evalInputs(expressionEvaluationContext, methodConf, arrayWdl)
-    result should contain theSameElementsAs Seq(
-      SubmissionValidationEntityInputs(
-        sampleGoodAsCER.name,
-        Set(
-        )
-      ),
-      SubmissionValidationEntityInputs(
-        sampleMissingValueAsCER.name,
-        Set(
-        )
-      )
-    )
-
   }
 
   it should "return error on missing values" in withConfigData {


### PR DESCRIPTION
While working on https://broadworkbench.atlassian.net/browse/CORE-528, I discovered that legacy and quicksilver submissions differ in their behavior when there are no inputs specified in a method config.  Legacy submissions still generate a workflow per entity, but quicksilver determines that there are no workflows to be had.  In order to keep behavior consistent, this PR updates quicksilver expression parsing to also returns results for each entity so that workflows can be submitted.

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
