### PR TITLE
[AN-663] Add new workspace setting to configure log bucket retention period

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5898,6 +5898,7 @@ components:
             - GcpBucketLifecycle
             - GcpBucketSoftDelete
             - GcpBucketRequesterPays
+            - GcpLogBucketRetention
             - SeparateSubmissionFinalOutputs
             - UseCromwellGcpBatchBackend
             - PubliclyReadable
@@ -5907,6 +5908,7 @@ components:
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketLifecycleConfig'
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketSoftDeleteConfig'
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketRequesterPaysConfig'
+            - $ref: '#/components/schemas/WorkspaceSettingGcpLogBucketRetentionConfig'
             - $ref: '#/components/schemas/WorkspaceSettingSeparateSubmissionFinalOutputsConfig'
             - $ref: '#/components/schemas/WorkspaceSettingUseCromwellGcpBatchBackendConfig'
             - $ref: '#/components/schemas/WorkspaceSettingPubliclyReadableConfig'
@@ -5969,6 +5971,14 @@ components:
         enabled:
           type: boolean
           description: Enabled status to set for requester pays
+    WorkspaceSettingGcpLogBucketRetentionConfig:
+      required:
+        - retentionDurationInDays
+      type: object
+      properties:
+        retentionDurationInDays:
+          type: integer
+          description: The length of time, in days, to retain logs in _Default bucket
     WorkspaceSettingSeparateSubmissionFinalOutputsConfig:
       required:
         - enabled

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -76,6 +76,8 @@ trait GoogleServicesDAO extends ErrorReportable {
 
   def setRequesterPays(bucketName: String, requesterPaysEnabled: Boolean, userProject: GoogleProjectId): Future[Unit]
 
+  def setLogBucketRetentionPeriod(userProject: GoogleProjectId, retentionDays: Int): Future[Unit]
+
   def isAdmin(userEmail: String): Future[Boolean]
 
   def hasGoogleRole(roleGroupName: String, userEmail: String): Future[Boolean]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -33,6 +33,8 @@ import com.google.api.services.genomics.v2alpha1.{Genomics, GenomicsScopes}
 import com.google.api.services.iam.v1.Iam
 import com.google.api.services.iamcredentials.v1.IAMCredentials
 import com.google.api.services.lifesciences.v2beta.{CloudLifeSciences, CloudLifeSciencesScopes}
+import com.google.api.services.logging.v2.{Logging, LoggingScopes}
+import com.google.api.services.logging.v2.model.LogBucket
 import com.google.api.services.oauth2.Oauth2.Builder
 import com.google.api.services.storage.model.Bucket.Lifecycle
 import com.google.api.services.storage.model.Bucket.Lifecycle.Rule.{Action, Condition}
@@ -134,6 +136,7 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
   val lifesciencesScopes = Seq(CloudLifeSciencesScopes.CLOUD_PLATFORM)
   val billingScopes = Seq("https://www.googleapis.com/auth/cloud-billing")
   val serviceUsageScopes = Seq(ServiceUsageScopes.CLOUD_PLATFORM_READ_ONLY)
+  val loggingBucketScopes = Seq(LoggingScopes.LOGGING_ADMIN)
 
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
   val jsonFactory = GsonFactory.getDefaultInstance
@@ -361,6 +364,28 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
       .compile
       .drain
       .unsafeToFuture()
+
+  override def setLogBucketRetentionPeriod(userProject: GoogleProjectId, retentionDays: Int): Future[Unit] = {
+    implicit val service: GoogleInstrumentedService.Value = GoogleInstrumentedService.Logging
+
+    // logs are sent to _Default bucket which is in global region
+    val bucketName = s"projects/${userProject.value}/locations/global/buckets/_Default"
+    val logBucket = new LogBucket().setRetentionDays(retentionDays)
+
+    val patchRequest = getLogging(getLoggingServiceAccountCredential)
+      .projects()
+      .locations()
+      .buckets()
+      .patch(bucketName, logBucket)
+      .setUpdateMask("retention_days")
+
+    retryWithRecoverWhen500orGoogleError { () =>
+      executeGoogleRequest(patchRequest)
+      ()
+    } { case e =>
+      throw new RawlsException(s"Failed to update retention period for bucket $bucketName: ${e.getMessage}", e)
+    }
+  }
 
   override def isAdmin(userEmail: String): Future[Boolean] =
     hasGoogleRole(adminGroupName, userEmail)
@@ -1104,6 +1129,9 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
   def getStorage(credential: Credential) =
     new Storage.Builder(httpTransport, jsonFactory, credential).setApplicationName(appName).build()
 
+  def getLogging(credential: Credential): Logging =
+    new Logging.Builder(httpTransport, jsonFactory, credential).setApplicationName(appName).build()
+
   override def getBucketMetrics(
     projectId: GoogleProjectId
   ): BucketMetricsResponse = {
@@ -1228,6 +1256,17 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
       .setJsonFactory(jsonFactory)
       .setServiceAccountScopes(serviceUsageScopes.asJava)
       .setServiceAccountId(clientEmail)
+      .setServiceAccountPrivateKeyFromPemFile(new java.io.File(pemFile))
+      .build()
+
+  def getLoggingServiceAccountCredential: Credential =
+    new GoogleCredential.Builder()
+      .setTransport(httpTransport)
+      .setJsonFactory(jsonFactory)
+      .setServiceAccountId(clientEmail)
+      .setServiceAccountScopes(
+        loggingBucketScopes.asJava
+      ) // grant log bucket admin powers to be able to update log bucket configuration
       .setServiceAccountPrivateKeyFromPemFile(new java.io.File(pemFile))
       .build()
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{
   GcpBucketLifecycleConfigFormat,
   GcpBucketRequesterPaysConfigFormat,
   GcpBucketSoftDeleteConfigFormat,
+  GcpLogBucketRetentionConfigFormat,
   PubliclyReadableConfigFormat,
   SeparateSubmissionFinalOutputsConfigFormat,
   UseCromwellGcpBatchBackendConfigFormat
@@ -14,6 +15,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleConfig,
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
+  GcpLogBucketRetentionConfig,
   PubliclyReadableConfig,
   SeparateSubmissionFinalOutputsConfig,
   UseCromwellGcpBatchBackendConfig
@@ -73,6 +75,8 @@ object WorkspaceSettingRecord {
         GcpBucketSoftDeleteSetting(workspaceSettingRecord.config.parseJson.convertTo[GcpBucketSoftDeleteConfig])
       case WorkspaceSettingTypes.GcpBucketRequesterPays =>
         GcpBucketRequesterPaysSetting(workspaceSettingRecord.config.parseJson.convertTo[GcpBucketRequesterPaysConfig])
+      case WorkspaceSettingTypes.GcpLogBucketRetention =>
+        GcpLogBucketRetentionSetting(workspaceSettingRecord.config.parseJson.convertTo[GcpLogBucketRetentionConfig])
       case WorkspaceSettingTypes.SeparateSubmissionFinalOutputs =>
         SeparateSubmissionFinalOutputsSetting(
           workspaceSettingRecord.config.parseJson.convertTo[SeparateSubmissionFinalOutputsConfig]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -20,6 +20,7 @@ import org.broadinstitute.dsde.rawls.model.{
   GcpBucketLifecycleSetting,
   GcpBucketRequesterPaysSetting,
   GcpBucketSoftDeleteSetting,
+  GcpLogBucketRetentionSetting,
   PubliclyReadableSetting,
   RawlsRequestContext,
   SamResourceTypeNames,
@@ -129,7 +130,18 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
                 )
               case _ => None
             }
-          case GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(_))                 => None
+          case GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(_)) => None
+          case GcpLogBucketRetentionSetting(GcpLogBucketRetentionConfig(retentionDuration)) =>
+            retentionDuration match {
+              case duration if duration < 1.days.toDays || duration > 3650.days.toDays =>
+                Some(
+                  validationErrorReport(
+                    setting.settingType,
+                    "retention duration must be between 1 day and 10 years (3650 days)"
+                  )
+                )
+              case _ => None
+            }
           case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) => None
           case UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(_))         => None
           case PubliclyReadableSetting(PubliclyReadableConfig(_))                             => None
@@ -201,6 +213,9 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
 
         case GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(enabled)) =>
           gcsDAO.setRequesterPays(workspace.bucketName, enabled, workspace.googleProjectId)
+
+        case GcpLogBucketRetentionSetting(GcpLogBucketRetentionConfig(retentionDurationInDays)) =>
+          gcsDAO.setLogBucketRetentionPeriod(workspace.googleProjectId, retentionDurationInDays)
 
         case PubliclyReadableSetting(PubliclyReadableConfig(enabled)) =>
           applyPublicReadableSetting(workspace, enabled)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -137,7 +137,7 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
                 Some(
                   validationErrorReport(
                     setting.settingType,
-                    "retention duration must be between 1 day and 10 years (3650 days)"
+                    "retention duration must be between 1 and 3650 days (10 years)"
                   )
                 )
               case _ => None

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -142,7 +142,8 @@ class MockGoogleServicesDAO(groupsPrefix: String,
                                 userProject: GoogleProjectId
   ): Future[Unit] = ???
 
-  override def setLogBucketRetentionPeriod(userProject: GoogleProjectId, retentionDays: Int): Future[Unit] = Future.successful(())
+  override def setLogBucketRetentionPeriod(userProject: GoogleProjectId, retentionDays: Int): Future[Unit] =
+    Future.successful(())
 
   override def getBucket(bucketName: String, userProject: Option[GoogleProjectId])(implicit
     executionContext: ExecutionContext

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -142,6 +142,8 @@ class MockGoogleServicesDAO(groupsPrefix: String,
                                 userProject: GoogleProjectId
   ): Future[Unit] = ???
 
+  override def setLogBucketRetentionPeriod(userProject: GoogleProjectId, retentionDays: Int): Future[Unit] = Future.successful(())
+
   override def getBucket(bucketName: String, userProject: Option[GoogleProjectId])(implicit
     executionContext: ExecutionContext
   ): Future[Either[String, Bucket]] = Future.successful(Right(new Bucket))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
@@ -3,9 +3,28 @@ package org.broadinstitute.dsde.rawls.workspace
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{TestDriverComponent, WorkspaceSettingRecord}
-import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{GcpBucketLifecycleAction, GcpBucketLifecycleCondition, GcpBucketLifecycleConfig, GcpBucketLifecycleRule, GcpBucketRequesterPaysConfig, GcpBucketSoftDeleteConfig, GcpLogBucketRetentionConfig, SeparateSubmissionFinalOutputsConfig, UseCromwellGcpBatchBackendConfig}
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
+  GcpBucketLifecycleAction,
+  GcpBucketLifecycleCondition,
+  GcpBucketLifecycleConfig,
+  GcpBucketLifecycleRule,
+  GcpBucketRequesterPaysConfig,
+  GcpBucketSoftDeleteConfig,
+  GcpLogBucketRetentionConfig,
+  SeparateSubmissionFinalOutputsConfig,
+  UseCromwellGcpBatchBackendConfig
+}
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.{CompactDataTables, GcpBucketSoftDelete}
-import org.broadinstitute.dsde.rawls.model.{GcpBucketLifecycleSetting, GcpBucketRequesterPaysSetting, GcpBucketSoftDeleteSetting, GcpLogBucketRetentionSetting, SeparateSubmissionFinalOutputsSetting, UseCromwellGcpBatchBackendSetting, Workspace, WorkspaceSettingTypes}
+import org.broadinstitute.dsde.rawls.model.{
+  GcpBucketLifecycleSetting,
+  GcpBucketRequesterPaysSetting,
+  GcpBucketSoftDeleteSetting,
+  GcpLogBucketRetentionSetting,
+  SeparateSubmissionFinalOutputsSetting,
+  UseCromwellGcpBatchBackendSetting,
+  Workspace,
+  WorkspaceSettingTypes
+}
 import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
@@ -3,26 +3,9 @@ package org.broadinstitute.dsde.rawls.workspace
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{TestDriverComponent, WorkspaceSettingRecord}
-import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
-  GcpBucketLifecycleAction,
-  GcpBucketLifecycleCondition,
-  GcpBucketLifecycleConfig,
-  GcpBucketLifecycleRule,
-  GcpBucketRequesterPaysConfig,
-  GcpBucketSoftDeleteConfig,
-  SeparateSubmissionFinalOutputsConfig,
-  UseCromwellGcpBatchBackendConfig
-}
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{GcpBucketLifecycleAction, GcpBucketLifecycleCondition, GcpBucketLifecycleConfig, GcpBucketLifecycleRule, GcpBucketRequesterPaysConfig, GcpBucketSoftDeleteConfig, GcpLogBucketRetentionConfig, SeparateSubmissionFinalOutputsConfig, UseCromwellGcpBatchBackendConfig}
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.{CompactDataTables, GcpBucketSoftDelete}
-import org.broadinstitute.dsde.rawls.model.{
-  GcpBucketLifecycleSetting,
-  GcpBucketRequesterPaysSetting,
-  GcpBucketSoftDeleteSetting,
-  SeparateSubmissionFinalOutputsSetting,
-  UseCromwellGcpBatchBackendSetting,
-  Workspace,
-  WorkspaceSettingTypes
-}
+import org.broadinstitute.dsde.rawls.model.{GcpBucketLifecycleSetting, GcpBucketRequesterPaysSetting, GcpBucketSoftDeleteSetting, GcpLogBucketRetentionSetting, SeparateSubmissionFinalOutputsSetting, UseCromwellGcpBatchBackendSetting, Workspace, WorkspaceSettingTypes}
 import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -109,6 +92,7 @@ class WorkspaceSettingRepositorySpec
       GcpBucketLifecycleSetting(GcpBucketLifecycleConfig(List())),
       GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(0)),
       GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)),
+      GcpLogBucketRetentionSetting(GcpLogBucketRetentionConfig(60)),
       SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(true)),
       UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(true))
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -9,46 +9,11 @@ import com.google.cloud.Identity
 import com.google.cloud.storage.BucketInfo.{LifecycleRule, SoftDeletePolicy}
 import com.google.cloud.storage.BucketInfo.LifecycleRule.{LifecycleAction, LifecycleCondition}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.QuicksilverMigrationResult
-import org.broadinstitute.dsde.rawls.{
-  NoSuchWorkspaceException,
-  RawlsExceptionWithErrorReport,
-  WorkspaceAccessDeniedException
-}
+import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, WorkspaceAccessDeniedException}
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
 import org.broadinstitute.dsde.rawls.entities.EntityService
-import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
-  CompactDataTablesConfig,
-  GcpBucketLifecycleAction,
-  GcpBucketLifecycleCondition,
-  GcpBucketLifecycleConfig,
-  GcpBucketLifecycleRule,
-  GcpBucketRequesterPaysConfig,
-  GcpBucketSoftDeleteConfig,
-  PubliclyReadableConfig,
-  SeparateSubmissionFinalOutputsConfig,
-  UseCromwellGcpBatchBackendConfig
-}
-import org.broadinstitute.dsde.rawls.model.{
-  CompactDataTablesSetting,
-  ErrorReport,
-  GcpBucketLifecycleSetting,
-  GcpBucketRequesterPaysSetting,
-  GcpBucketSoftDeleteSetting,
-  PubliclyReadableSetting,
-  RawlsRequestContext,
-  RawlsUserEmail,
-  RawlsUserSubjectId,
-  SamResourceTypeNames,
-  SamUserStatusResponse,
-  SamWorkspaceActions,
-  SamWorkspacePolicyNames,
-  SeparateSubmissionFinalOutputsSetting,
-  UseCromwellGcpBatchBackendSetting,
-  UserInfo,
-  Workspace,
-  WorkspaceName,
-  WorkspaceSettingTypes
-}
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{CompactDataTablesConfig, GcpBucketLifecycleAction, GcpBucketLifecycleCondition, GcpBucketLifecycleConfig, GcpBucketLifecycleRule, GcpBucketRequesterPaysConfig, GcpBucketSoftDeleteConfig, GcpLogBucketRetentionConfig, PubliclyReadableConfig, SeparateSubmissionFinalOutputsConfig, UseCromwellGcpBatchBackendConfig}
+import org.broadinstitute.dsde.rawls.model.{CompactDataTablesSetting, ErrorReport, GcpBucketLifecycleSetting, GcpBucketRequesterPaysSetting, GcpBucketSoftDeleteSetting, GcpLogBucketRetentionSetting, PubliclyReadableSetting, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, SamResourceTypeNames, SamUserStatusResponse, SamWorkspaceActions, SamWorkspacePolicyNames, SeparateSubmissionFinalOutputsSetting, UseCromwellGcpBatchBackendSetting, UserInfo, Workspace, WorkspaceName, WorkspaceSettingTypes}
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.workbench.google2.{GoogleStorageService, StorageRole}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
@@ -56,7 +21,7 @@ import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{verify, when, RETURNS_SMART_NULLS}
+import org.mockito.Mockito.{RETURNS_SMART_NULLS, verify, when}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.must.Matchers.{contain, include}
@@ -262,6 +227,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
       GcpBucketLifecycleSetting(GcpBucketLifecycleConfig(List.empty)),
       GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(7.days.toSeconds)),
       GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)),
+      GcpLogBucketRetentionSetting(GcpLogBucketRetentionConfig(60)),
       SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(true)),
       UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(true))
     )
@@ -305,6 +271,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
       )
     ).thenReturn(Future.successful())
     when(gcsDAO.setRequesterPays(workspace.bucketName, requesterPaysEnabled = true, workspace.googleProjectId))
+      .thenReturn(Future.successful())
+    when(gcsDAO.setLogBucketRetentionPeriod(workspace.googleProjectId, 60))
       .thenReturn(Future.successful())
 
     val service =
@@ -730,6 +698,36 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
     exception.errorReport.message should include("Invalid settings requested.")
     assert(exception.errorReport.causes.exists(_.message.matches("Invalid GcpBucketSoftDelete.*retention duration.*")))
+  }
+
+  it should "require a retention duration no shorter than 1 day for GcpLogBucketRetention settings" in {
+    val shortDurationSetting = GcpLogBucketRetentionSetting(
+      GcpLogBucketRetentionConfig(0)
+    )
+
+    val service = workspaceSettingServiceConstructor()
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(service.setWorkspaceSettings(workspace.toWorkspaceName, List(shortDurationSetting)), Duration.Inf)
+    }
+    exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
+    exception.errorReport.message should include("Invalid settings requested.")
+    exception.errorReport.causes.head.message shouldBe "Invalid GcpLogBucketRetention configuration: retention duration must be between 1 day and 10 years (3650 days)."
+  }
+
+  it should "require a retention duration no more than 3650 days for GcpLogBucketRetention settings" in {
+    val longDurationSetting = GcpLogBucketRetentionSetting(
+      GcpLogBucketRetentionConfig(36912)
+    )
+
+    val service = workspaceSettingServiceConstructor()
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(service.setWorkspaceSettings(workspace.toWorkspaceName, List(longDurationSetting)), Duration.Inf)
+    }
+    exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
+    exception.errorReport.message should include("Invalid settings requested.")
+    exception.errorReport.causes.head.message shouldBe "Invalid GcpLogBucketRetention configuration: retention duration must be between 1 day and 10 years (3650 days)."
   }
 
   "publicly readable setting" should "set public in sam and add all users to bucket" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -9,11 +9,48 @@ import com.google.cloud.Identity
 import com.google.cloud.storage.BucketInfo.{LifecycleRule, SoftDeletePolicy}
 import com.google.cloud.storage.BucketInfo.LifecycleRule.{LifecycleAction, LifecycleCondition}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.QuicksilverMigrationResult
-import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, WorkspaceAccessDeniedException}
+import org.broadinstitute.dsde.rawls.{
+  NoSuchWorkspaceException,
+  RawlsExceptionWithErrorReport,
+  WorkspaceAccessDeniedException
+}
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
 import org.broadinstitute.dsde.rawls.entities.EntityService
-import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{CompactDataTablesConfig, GcpBucketLifecycleAction, GcpBucketLifecycleCondition, GcpBucketLifecycleConfig, GcpBucketLifecycleRule, GcpBucketRequesterPaysConfig, GcpBucketSoftDeleteConfig, GcpLogBucketRetentionConfig, PubliclyReadableConfig, SeparateSubmissionFinalOutputsConfig, UseCromwellGcpBatchBackendConfig}
-import org.broadinstitute.dsde.rawls.model.{CompactDataTablesSetting, ErrorReport, GcpBucketLifecycleSetting, GcpBucketRequesterPaysSetting, GcpBucketSoftDeleteSetting, GcpLogBucketRetentionSetting, PubliclyReadableSetting, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, SamResourceTypeNames, SamUserStatusResponse, SamWorkspaceActions, SamWorkspacePolicyNames, SeparateSubmissionFinalOutputsSetting, UseCromwellGcpBatchBackendSetting, UserInfo, Workspace, WorkspaceName, WorkspaceSettingTypes}
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
+  CompactDataTablesConfig,
+  GcpBucketLifecycleAction,
+  GcpBucketLifecycleCondition,
+  GcpBucketLifecycleConfig,
+  GcpBucketLifecycleRule,
+  GcpBucketRequesterPaysConfig,
+  GcpBucketSoftDeleteConfig,
+  GcpLogBucketRetentionConfig,
+  PubliclyReadableConfig,
+  SeparateSubmissionFinalOutputsConfig,
+  UseCromwellGcpBatchBackendConfig
+}
+import org.broadinstitute.dsde.rawls.model.{
+  CompactDataTablesSetting,
+  ErrorReport,
+  GcpBucketLifecycleSetting,
+  GcpBucketRequesterPaysSetting,
+  GcpBucketSoftDeleteSetting,
+  GcpLogBucketRetentionSetting,
+  PubliclyReadableSetting,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  SamResourceTypeNames,
+  SamUserStatusResponse,
+  SamWorkspaceActions,
+  SamWorkspacePolicyNames,
+  SeparateSubmissionFinalOutputsSetting,
+  UseCromwellGcpBatchBackendSetting,
+  UserInfo,
+  Workspace,
+  WorkspaceName,
+  WorkspaceSettingTypes
+}
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.workbench.google2.{GoogleStorageService, StorageRole}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
@@ -21,7 +58,7 @@ import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, verify, when}
+import org.mockito.Mockito.{verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.must.Matchers.{contain, include}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -749,7 +749,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     }
     exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
     exception.errorReport.message should include("Invalid settings requested.")
-    exception.errorReport.causes.head.message shouldBe "Invalid GcpLogBucketRetention configuration: retention duration must be between 1 day and 10 years (3650 days)."
+    exception.errorReport.causes.head.message shouldBe "Invalid GcpLogBucketRetention configuration: retention duration must be between 1 and 3650 days (10 years)."
   }
 
   it should "require a retention duration no more than 3650 days for GcpLogBucketRetention settings" in {
@@ -764,7 +764,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     }
     exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
     exception.errorReport.message should include("Invalid settings requested.")
-    exception.errorReport.causes.head.message shouldBe "Invalid GcpLogBucketRetention configuration: retention duration must be between 1 day and 10 years (3650 days)."
+    exception.errorReport.causes.head.message shouldBe "Invalid GcpLogBucketRetention configuration: retention duration must be between 1 and 3650 days (10 years)."
   }
 
   "publicly readable setting" should "set public in sam and add all users to bucket" in {

--- a/google/src/main/scala/org/broadinstitute/dsde/rawls/metrics/GoogleInstrumentedService.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/rawls/metrics/GoogleInstrumentedService.scala
@@ -6,7 +6,7 @@ package org.broadinstitute.dsde.rawls.metrics
 object GoogleInstrumentedService extends Enumeration {
   type GoogleInstrumentedService = Value
   val Billing, Storage, Genomics, Groups, PubSub, CloudResourceManager, OAuth, IamCredentials, AccessContextManager,
-    LifeSciences = Value
+    LifeSciences, Logging = Value
 
   /**
     * Expansion for GoogleInstrumentedService which uses the default toString implementation.

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -18,6 +18,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleRule,
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
+  GcpLogBucketRetentionConfig,
   PubliclyReadableConfig,
   SeparateSubmissionFinalOutputsConfig,
   UseCromwellGcpBatchBackendConfig
@@ -27,6 +28,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.{
   GcpBucketLifecycle,
   GcpBucketRequesterPays,
   GcpBucketSoftDelete,
+  GcpLogBucketRetention,
   PubliclyReadable,
   SeparateSubmissionFinalOutputs,
   UseCromwellGcpBatchBackend,
@@ -608,6 +610,9 @@ case class GcpBucketSoftDeleteSetting(override val config: GcpBucketSoftDeleteCo
 case class GcpBucketRequesterPaysSetting(override val config: GcpBucketRequesterPaysConfig)
     extends WorkspaceSetting(settingType = WorkspaceSettingTypes.GcpBucketRequesterPays, config)
 
+case class GcpLogBucketRetentionSetting(override val config: GcpLogBucketRetentionConfig)
+    extends WorkspaceSetting(settingType = WorkspaceSettingTypes.GcpLogBucketRetention, config)
+
 case class SeparateSubmissionFinalOutputsSetting(override val config: SeparateSubmissionFinalOutputsConfig)
     extends WorkspaceSetting(settingType = WorkspaceSettingTypes.SeparateSubmissionFinalOutputs, config)
 
@@ -630,6 +635,7 @@ object WorkspaceSettingTypes {
     case "gcpbucketlifecycle"             => GcpBucketLifecycle
     case "gcpbucketsoftdelete"            => GcpBucketSoftDelete
     case "gcpbucketrequesterpays"         => GcpBucketRequesterPays
+    case "gcplogbucketretention"          => GcpLogBucketRetention
     case "separatesubmissionfinaloutputs" => SeparateSubmissionFinalOutputs
     case "usecromwellgcpbatchbackend"     => UseCromwellGcpBatchBackend
     case "publiclyreadable"               => PubliclyReadable
@@ -642,6 +648,8 @@ object WorkspaceSettingTypes {
   case object GcpBucketSoftDelete extends WorkspaceSettingType
 
   case object GcpBucketRequesterPays extends WorkspaceSettingType
+
+  case object GcpLogBucketRetention extends WorkspaceSettingType
 
   case object SeparateSubmissionFinalOutputs extends WorkspaceSettingType
 
@@ -665,6 +673,8 @@ object WorkspaceSettingConfig {
   case class GcpBucketSoftDeleteConfig(retentionDurationInSeconds: Seconds) extends WorkspaceSettingConfig
 
   case class GcpBucketRequesterPaysConfig(enabled: Boolean) extends WorkspaceSettingConfig
+
+  case class GcpLogBucketRetentionConfig(retentionDurationInDays: Days) extends WorkspaceSettingConfig
 
   case class SeparateSubmissionFinalOutputsConfig(enabled: Boolean) extends WorkspaceSettingConfig
 
@@ -1287,6 +1297,9 @@ class WorkspaceJsonSupport extends JsonSupport {
   implicit val GcpBucketRequesterPaysConfigFormat: RootJsonFormat[GcpBucketRequesterPaysConfig] = jsonFormat1(
     GcpBucketRequesterPaysConfig.apply
   )
+  implicit val GcpLogBucketRetentionConfigFormat: RootJsonFormat[GcpLogBucketRetentionConfig] = jsonFormat1(
+    GcpLogBucketRetentionConfig.apply
+  )
   implicit val SeparateSubmissionFinalOutputsConfigFormat: RootJsonFormat[SeparateSubmissionFinalOutputsConfig] =
     jsonFormat1(
       SeparateSubmissionFinalOutputsConfig.apply
@@ -1317,6 +1330,7 @@ class WorkspaceJsonSupport extends JsonSupport {
       case config: GcpBucketLifecycleConfig             => config.toJson
       case config: GcpBucketSoftDeleteConfig            => config.toJson
       case config: GcpBucketRequesterPaysConfig         => config.toJson
+      case config: GcpLogBucketRetentionConfig          => config.toJson
       case config: SeparateSubmissionFinalOutputsConfig => config.toJson
       case config: UseCromwellGcpBatchBackendConfig     => config.toJson
       case config: PubliclyReadableConfig               => config.toJson
@@ -1344,6 +1358,8 @@ class WorkspaceJsonSupport extends JsonSupport {
         case GcpBucketSoftDelete => GcpBucketSoftDeleteSetting(fields("config").convertTo[GcpBucketSoftDeleteConfig])
         case GcpBucketRequesterPays =>
           GcpBucketRequesterPaysSetting(fields("config").convertTo[GcpBucketRequesterPaysConfig])
+        case GcpLogBucketRetention =>
+          GcpLogBucketRetentionSetting(fields("config").convertTo[GcpLogBucketRetentionConfig])
         case SeparateSubmissionFinalOutputs =>
           SeparateSubmissionFinalOutputsSetting(fields("config").convertTo[SeparateSubmissionFinalOutputsConfig])
         case UseCromwellGcpBatchBackend =>

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -4,16 +4,7 @@ import akka.http.scaladsl.model.StatusCodes.BadRequest
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{MethodRepoMethodFormat, WorkspaceSettingFormat}
-import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
-  GcpBucketLifecycleAction,
-  GcpBucketLifecycleCondition,
-  GcpBucketLifecycleConfig,
-  GcpBucketLifecycleRule,
-  GcpBucketRequesterPaysConfig,
-  GcpBucketSoftDeleteConfig,
-  SeparateSubmissionFinalOutputsConfig,
-  UseCromwellGcpBatchBackendConfig
-}
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{GcpBucketLifecycleAction, GcpBucketLifecycleCondition, GcpBucketLifecycleConfig, GcpBucketLifecycleRule, GcpBucketRequesterPaysConfig, GcpBucketSoftDeleteConfig, GcpLogBucketRetentionConfig, SeparateSubmissionFinalOutputsConfig, UseCromwellGcpBatchBackendConfig}
 import org.joda.time.DateTime
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -1092,6 +1083,76 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
             |  }""".stripMargin.parseJson
         intercept[DeserializationException] {
           WorkspaceSettingFormat.read(requesterPaysSettingBadConfig)
+        }
+      }
+    }
+
+    "GcpLogBucketRetentionSetting" - {
+      "serializes properly" in {
+        val logBucketRetentionSettingJson =
+          """{
+            |    "settingType": "GcpLogBucketRetention",
+            |    "config": {
+            |      "retentionDurationInDays": 50
+            |    }
+            |  }""".stripMargin.parseJson
+        assertResult(logBucketRetentionSettingJson) {
+          WorkspaceSettingFormat.write(
+            GcpLogBucketRetentionSetting(
+              GcpLogBucketRetentionConfig(50)
+            )
+          )
+        }
+      }
+
+      "parses log bucket retention setting with retentionDurationInDays" in {
+        val logBucketRetentionSetting =
+          """{
+            |    "settingType": "GcpLogBucketRetention",
+            |    "config": {
+            |      "retentionDurationInDays": 60
+            |    }
+            |  }""".stripMargin.parseJson
+        assertResult {
+          GcpLogBucketRetentionSetting(
+            GcpLogBucketRetentionConfig(60)
+          )
+        } {
+          WorkspaceSettingFormat.read(logBucketRetentionSetting)
+        }
+      }
+
+      "throws an exception for missing retentionDurationInDays" in {
+        val logBucketRetentionSettingNoDuration =
+          """{
+            |    "settingType": "GcpLogBucketRetention",
+            |    "config": {}
+            |  }""".stripMargin.parseJson
+        intercept[DeserializationException] {
+          WorkspaceSettingFormat.read(logBucketRetentionSettingNoDuration)
+        }
+      }
+
+      "throws an exception for missing config" in {
+        val logBucketRetentionSettingNoConfig =
+          """{
+            |    "settingType": "GcpLogBucketRetention"
+            |  }""".stripMargin.parseJson
+        intercept[NoSuchElementException] {
+          WorkspaceSettingFormat.read(logBucketRetentionSettingNoConfig)
+        }
+      }
+
+      "throws an exception for incorrect format" in {
+        val logBucketRetentionSettingBadConfig =
+          """{
+            |    "settingType": "GcpLogBucketRetention",
+            |    "config": {
+            |      "retentionDurationInDays": "not a number"
+            |    }
+            |  }""".stripMargin.parseJson
+        intercept[DeserializationException] {
+          WorkspaceSettingFormat.read(logBucketRetentionSettingBadConfig)
         }
       }
     }

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -4,7 +4,17 @@ import akka.http.scaladsl.model.StatusCodes.BadRequest
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{MethodRepoMethodFormat, WorkspaceSettingFormat}
-import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{GcpBucketLifecycleAction, GcpBucketLifecycleCondition, GcpBucketLifecycleConfig, GcpBucketLifecycleRule, GcpBucketRequesterPaysConfig, GcpBucketSoftDeleteConfig, GcpLogBucketRetentionConfig, SeparateSubmissionFinalOutputsConfig, UseCromwellGcpBatchBackendConfig}
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
+  GcpBucketLifecycleAction,
+  GcpBucketLifecycleCondition,
+  GcpBucketLifecycleConfig,
+  GcpBucketLifecycleRule,
+  GcpBucketRequesterPaysConfig,
+  GcpBucketSoftDeleteConfig,
+  GcpLogBucketRetentionConfig,
+  SeparateSubmissionFinalOutputsConfig,
+  UseCromwellGcpBatchBackendConfig
+}
 import org.joda.time.DateTime
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AN-663

This PR adds a new workspace setting to allow user to configure the log bucket retention period. PR that will give Rawls SA to perform the action - https://github.com/broadinstitute/terraform-ap-deployments/pull/1938

Note: retention duration is in days and should be between 1 and 3650

Tested in a BEE:
Example PUT request:
```
curl -X 'PUT' \
  'https://rawls.sshah.bee.envs-terra.bio/api/workspaces/v2/sshah-bee-bp-06-03-2025/sshah-log-retention-test/settings' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>' \
  -H 'Content-Type: application/json' \
  -d '[
  {
    "settingType": "GcpLogBucketRetention",
    "config": {
     "retentionDurationInDays": 45
    }
}]'
```

Response
```
{
  "failures": {},
  "successes": [
    {
      "config": {
        "retentionDurationInDays": 45
      },
      "settingType": "GcpLogBucketRetention"
    }
  ]
}
```

Changing retention to 1 day
<img width="520" height="486" alt="Screenshot 2025-07-31 at 4 54 38 PM" src="https://github.com/user-attachments/assets/c5a2c13d-a412-4c79-bc91-2554c46b9cf5" />

Changing retention to 45 days
<img width="582" height="507" alt="Screenshot 2025-07-31 at 4 54 11 PM" src="https://github.com/user-attachments/assets/57b02e70-5676-4220-9014-b73fbe1e4d79" />


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
