### PR TITLE
AN-711 Remove retry on estimated cost query

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAO.scala
@@ -133,7 +133,9 @@ class HttpExecutionServiceDAO(executionServiceURL: String, override val workbenc
 
   override def getCost(id: String, userInfo: UserInfo): Future[WorkflowCostBreakdown] = {
     val url = executionServiceURL + s"/api/workflows/v1/$id/cost"
-    retry(when5xx)(() => pipeline[WorkflowCostBreakdown](userInfo) apply Get(url))
+    // In rare cases of many subworkflows, this query can get very slow & overwhelm Cromwell.
+    // Don't retry; doing so amplifies load but does not actually help the query succeed.
+    pipeline[WorkflowCostBreakdown](userInfo) apply Get(url)
   }
 
   override def version(): Future[ExecutionServiceVersion] = {


### PR DESCRIPTION
In [PROD-1025](https://broadworkbench.atlassian.net/browse/PROD-1025) Cromwell crashed under heavy load from cost requests. It probably did not help that we retry each failed request 3 times with almost no delay:

https://github.com/broadinstitute/rawls/blob/885608b490e9b1418f7edc5622fb7fc3bb716962/util/src/main/scala/org/broadinstitute/dsde/rawls/util/Retry.scala#L97

This could cause pernicious "piling up" of database queries where four HTTP requests time out in quick succession, but their associated queries keep running in parallel. That can keep the DB overloaded and cause all future requests to keep timing out.

Because this call does not side-effect [0] and automatically [repeats every minute](https://github.com/broadinstitute/rawls/blob/develop/core/src/main/resources/reference.conf#L55) anyway, I propose that we make only the one attempt.

[0] In the sense of submit, abort, etc. where if we fail the request, the user intention is irretrievably lost.

**Alternatives considered:**

- Create a custom retry strategy that retries e.g. once after 15 seconds. But that's already a good part of the way to the next 1-minute tick.
- If the cost request fails, make a status-only request. This has the potential to keep statuses a bit more up to date during high load, but I'm not that confident the status endpoint will be working either.

[PROD-1025]: https://broadworkbench.atlassian.net/browse/PROD-1025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ