### PR TITLE
[CORE-566] Add admin getWorkspaceByGoogleProjectId

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -954,6 +954,37 @@ paths:
                 $ref: '#/components/schemas/ErrorReport'
         500:
           $ref: '#/components/responses/RawlsInternalError'
+  /api/admin/workspaces/googleProject/{googleProjectId}:
+    get:
+      tags:
+        - admin
+        - workspaces
+      summary: get workspace by google project id
+      description: Returns the workspace identified by google project id
+      operationId: adminGetWorkspaceByGoogleProjectId
+      parameters:
+        - $ref: '#/components/parameters/googleProjectIdPathParam'
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/WorkspaceAdminResponse'
+        404:
+          description: Workspace not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: You must be an admin to get a workspace ID
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
   /api/admin/submissions/queueStatusByUser:
     get:
       tags:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -128,6 +128,15 @@ trait AdminApiService extends UserInfoDirectives {
               }
             }
         } ~
+          path("googleProject" / Segment) { googleProjectId =>
+            get {
+              complete {
+                workspaceAdminServiceConstructor(ctx)
+                  .getWorkspaceByGoogleProjectId(GoogleProjectId(googleProjectId))
+                  .map(StatusCodes.OK -> _)
+              }
+            }
+          } ~
           path(Segment) { workspaceId =>
             get {
               complete {
@@ -137,6 +146,7 @@ trait AdminApiService extends UserInfoDirectives {
               }
             }
           }
+
       }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
   ErrorReportSource,
+  GoogleProjectId,
   RawlsRequestContext,
   SamResourceTypeAdminActions,
   SamResourceTypeName,
@@ -195,6 +196,24 @@ class WorkspaceAdminService(
         )
       workspaceOpt <- workspaceRepository.getWorkspaceId(workspaceName)
     } yield workspaceOpt.map(_.toString)
+
+  def getWorkspaceByGoogleProjectId(googleProjectId: GoogleProjectId): Future[WorkspaceAdminResponse] =
+    for {
+      userIsAdmin <- samDAO.admin
+        .userHasResourceTypeAdminPermission(SamResourceTypeNames.workspace,
+                                            SamResourceTypeAdminActions.readSummaryInformation,
+                                            ctx
+        )
+      _ = if (!userIsAdmin)
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.Forbidden, "You must be an admin to call this API.")
+        )
+      workspaceOpt <- workspaceRepository.getWorkspaceByGoogleProject(googleProjectId)
+      workspace = workspaceOpt.getOrElse(throw NoSuchWorkspaceException(googleProjectId.toString))
+      settings <- workspaceSettingRepository.getWorkspaceSettings(workspace.workspaceIdAsUUID)
+    } yield WorkspaceAdminResponse(WorkspaceDetails.fromWorkspaceAndOptions(workspace, None, useAttributes = false),
+                                   settings
+    )
 
   // moved out of WorkspaceSupport because the only usage was in this file,
   // and it has raw datasource/dataAccess usage, which is being refactored out of WorkspaceSupport

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -329,6 +329,29 @@ class AdminApiServiceSpec extends ApiServiceSpec {
     verify(workspaceAdminService).getWorkspaceById(workspaceId)
   }
 
+  it should "get a workspace with its current settings by googleProjectId" in {
+    val googleProjectId = GoogleProjectId("google-project-id")
+    val workspaceAdminService = mock[WorkspaceAdminService]
+
+    when(workspaceAdminService.getWorkspaceByGoogleProjectId(googleProjectId)).thenReturn(
+      Future.successful(
+        WorkspaceAdminResponse(
+          WorkspaceDetails.fromWorkspaceAndOptions(compactConstantData.workspace, None, useAttributes = false),
+          List.empty
+        )
+      )
+    )
+    val service = new MockApiService(workspaceAdminServiceConstructor = _ => workspaceAdminService)
+
+    Get(
+      s"/admin/workspaces/googleProject/$googleProjectId"
+    ) ~> service.testRoutes ~> check {
+      assertResult(StatusCodes.OK)(status)
+    }
+
+    verify(workspaceAdminService).getWorkspaceByGoogleProjectId(googleProjectId)
+  }
+
   it should "get a billing project with a list of its workspaces" in {
     val billingProjectName = RawlsBillingProjectName("project")
     val billingAdminService = mock[BillingAdminService]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
@@ -156,7 +156,8 @@ class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
     val googleProjectId = workspace.googleProjectId
 
     val workspaceRepository = mock[WorkspaceRepository]
-    when(workspaceRepository.getWorkspaceByGoogleProject(googleProjectId)).thenReturn(Future.successful(Option(workspace)))
+    when(workspaceRepository.getWorkspaceByGoogleProject(googleProjectId))
+      .thenReturn(Future.successful(Option(workspace)))
 
     val workspaceSettingRepository = mock[WorkspaceSettingRepository]
     when(workspaceSettingRepository.getWorkspaceSettings(workspaceId)).thenReturn(Future.successful(List.empty))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamAdminDAO, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
+  GoogleProjectId,
   RawlsRequestContext,
   RawlsUserEmail,
   RawlsUserSubjectId,
@@ -147,6 +148,86 @@ class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
 
     intercept[NoSuchWorkspaceException] {
       Await.result(service.getWorkspaceById(workspaceId), Duration.Inf)
+    }
+  }
+
+  "getWorkspaceByGoogleProjectId" should "return the workspace with its settings if the user is an admin" in {
+    val workspaceId = workspace.workspaceIdAsUUID
+    val googleProjectId = workspace.googleProjectId
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspaceByGoogleProject(googleProjectId)).thenReturn(Future.successful(Option(workspace)))
+
+    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
+    when(workspaceSettingRepository.getWorkspaceSettings(workspaceId)).thenReturn(Future.successful(List.empty))
+
+    val samAdminDAO = mock[SamAdminDAO]
+    when(
+      samAdminDAO.userHasResourceTypeAdminPermission(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(SamResourceTypeAdminActions.readSummaryInformation),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(true))
+    val samDAO = mock[SamDAO]
+    when(samDAO.admin).thenReturn(samAdminDAO)
+
+    val service =
+      workspaceAdminServiceConstructor(samDAO = samDAO,
+                                       workspaceRepository = workspaceRepository,
+                                       workspaceSettingRepository = workspaceSettingRepository
+      )
+
+    val returnedWorkspace = Await.result(service.getWorkspaceByGoogleProjectId(googleProjectId), Duration.Inf)
+    returnedWorkspace shouldEqual WorkspaceAdminResponse(
+      WorkspaceDetails.fromWorkspaceAndOptions(workspace, None, false),
+      List.empty
+    )
+  }
+
+  it should "throw if the user is not an admin" in {
+    val samAdminDAO = mock[SamAdminDAO]
+    when(
+      samAdminDAO.userHasResourceTypeAdminPermission(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(SamResourceTypeAdminActions.readSummaryInformation),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(false))
+    val samDAO = mock[SamDAO]
+    when(samDAO.admin).thenReturn(samAdminDAO)
+
+    val service = workspaceAdminServiceConstructor(samDAO = samDAO)
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(service.getWorkspaceByGoogleProjectId(GoogleProjectId("random-google-project-id")), Duration.Inf)
+    }
+    exception.errorReport.statusCode shouldEqual Some(StatusCodes.Forbidden)
+  }
+
+  it should "throw if the workspace is not found" in {
+    val workspaceId = workspace.workspaceIdAsUUID
+    val googleProjectId = workspace.googleProjectId
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspaceByGoogleProject(googleProjectId)).thenReturn(Future.successful(None))
+
+    val samAdminDAO = mock[SamAdminDAO]
+    when(
+      samAdminDAO.userHasResourceTypeAdminPermission(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(SamResourceTypeAdminActions.readSummaryInformation),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(true))
+    val samDAO = mock[SamDAO]
+    when(samDAO.admin).thenReturn(samAdminDAO)
+
+    val service =
+      workspaceAdminServiceConstructor(samDAO = samDAO, workspaceRepository = workspaceRepository)
+
+    intercept[NoSuchWorkspaceException] {
+      Await.result(service.getWorkspaceByGoogleProjectId(googleProjectId), Duration.Inf)
     }
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-566
<Put notes here to help reviewer understand this PR>

---
Adds an admin API that can get workspace details by its google project id.  To be used on the support page.

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
