### PR TITLE
CORE-650: quicksilver case sensitivity

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -460,16 +460,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   /**
    * Get all entity attribute keys for a workspace.
    *
-   * `execution plan: Index range scan; using where. Index: idx_entity_keys_workspace_and_entity_type.`
-   */
-  def listEntityKeys(workspaceId: UUID): ReadAction[Seq[EntityTypeAndAttributeKey]] =
-    sql"""SELECT distinct entity_type, attribute_key
-      FROM ENTITY_KEYS , JSON_TABLE(attribute_keys, '$$[*]' COLUMNS(attribute_key VARCHAR(256) PATH '$$')) t
-      where workspace_id=$workspaceId;""".as[EntityTypeAndAttributeKey]
-
-  /**
-   * Get all entity attribute keys for a workspace.
-   *
    * execution plan:
    *    ENTITY: Using index condition (Using index condition; Using temporary); Using temporary
    *    t: Table function: json_table; Using temporary
@@ -506,9 +496,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * `execution plan: Index range scan; using where. Index: idx_entity_keys_workspace_and_entity_type.`
    */
   def countEntitiesGroupedByType(workspaceId: UUID): ReadAction[Seq[EntityTypeAndCount]] =
-    // ENTITY_KEYS should be smaller than ENTITY and already excludes deleted entities
     sql"""SELECT entity_type, COUNT(*)
-      FROM ENTITY_KEYS
+      FROM ENTITY
       WHERE workspace_id = $workspaceId
       GROUP BY entity_type;""".as[EntityTypeAndCount]
 
@@ -978,7 +967,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   /**
     * Determine if an attribute exists in any entity of the given type and workspace.
     *
-    * `Using index condition; Using where. Index used: idx_entity_keys_workspace_and_entity_type`
+   * `execution plan: Using index condition; Using where. Index used: idx_entity_type_name`
     */
   def attributeExists(workspaceId: UUID, entityType: String, attributeName: AttributeName): ReadAction[Boolean] =
     anyAttributeExists(workspaceId, entityType, Set(attributeName))
@@ -986,23 +975,23 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   /**
     * Determine if an attribute exists in any entity of the given type and workspace.
     *
-    * `execution plan: subquery Using index condition; Using where. Index used: idx_entity_keys_workspace_and_entity_type`
+    * `execution plan: Using index condition; Using where. Index used: idx_entity_type_name`
     */
   def anyAttributeExists(workspaceId: UUID,
                          entityType: String,
                          attributeNames: Set[AttributeName]
   ): ReadAction[Boolean] = {
-    val containsClauses = attributeNames.map { attributeName =>
-      sql"""JSON_CONTAINS(attribute_keys, JSON_QUOTE(${AttributeName.toDelimitedName(attributeName)}))"""
-    }
-    val clause = reduceSqlActionsWithDelim(containsClauses.toSeq, sql" or ")
+    // values for the attribute paths
+    val attrPaths = attributeNames.map(attr => sql"${slickAttributePath(attr)}")
 
-    val baseSql = sql"""select exists (select 1 from ENTITY_KEYS
+    val containsClause = reduceSqlActionsWithDelim(attrPaths.toSeq, sql", ")
+
+    val baseSql = sql"""select exists (select 1 from ENTITY
          where workspace_id = $workspaceId
           and entity_type = $entityType
-          and ("""
+          and JSON_CONTAINS_PATH(attributes, 'one', """
 
-    concatSqlActions(baseSql, clause, sql"))")
+    concatSqlActions(baseSql, containsClause, sql"))")
       .as[Boolean]
       .head
   }
@@ -1225,16 +1214,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
          where workspace_id = $workspaceId
          and from_entity_type = ${from.entityType}
          and from_name = ${from.entityName}""".as[EntityPointer]
-
-  // return the ENTITY_KEYS row for a given entity
-  // `execution plan: single row constant; fully indexed by primary key`
-  @VisibleForTesting
-  protected[slick] def getKeys(entityId: Long): ReadAction[Option[KeysRecord]] = {
-    val query = sql"""select id, workspace_id, entity_type, attribute_keys, last_updated
-            from ENTITY_KEYS
-            where id = $entityId;""".as[KeysRecord]
-    uniqueResult(query)
-  }
 
   @VisibleForTesting
   protected[slick] def getDeletedEntity(workspaceId: UUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -466,7 +466,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    */
   def listEntityKeysViaEntity(workspaceId: UUID): ReadAction[Seq[EntityTypeAndAttributeKey]] =
     sql"""SELECT distinct entity_type, attribute_key
-      FROM ENTITY, JSON_TABLE(JSON_KEYS(attributes, $slickAttrsPath), '$$[*]' COLUMNS(attribute_key VARCHAR(256) PATH '$$')) t
+      FROM ENTITY, JSON_TABLE(JSON_KEYS(attributes, $slickAttrsPath), '$$[*]' COLUMNS(attribute_key VARCHAR(256) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$')) t
       where workspace_id=$workspaceId and deleted = 0;""".as[EntityTypeAndAttributeKey]
 
   /**
@@ -483,7 +483,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
     concatSqlActions(
       sql"""SELECT distinct entity_type, attribute_key
-      FROM ENTITY, JSON_TABLE(JSON_KEYS(attributes, $slickAttrsPath), '$$[*]' COLUMNS(attribute_key VARCHAR(256) PATH '$$')) t
+      FROM ENTITY, JSON_TABLE(JSON_KEYS(attributes, $slickAttrsPath), '$$[*]' COLUMNS(attribute_key VARCHAR(256) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$')) t
       where workspace_id=$workspaceId and deleted = 0 and entity_type in (""",
       inClause,
       sql""");"""

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -266,36 +266,6 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     actual should contain theSameElementsAs selectedRecords
   }
 
-  behavior of "ENTITY_KEYS population triggers"
-  // the ENTITY_KEYS table is populated by triggers on the ENTITY table.
-  // these tests verify the behavior of those triggers.
-
-  it should "save a row with empty keys for an entity with no attributes" in withMinimalTestDatabase { _ =>
-    val entity = Entity("entityName", "entityType", Map())
-    val savedEntity = insertAndGet(entity)
-    // get the keys
-    val actual = runAndWait(q.getKeys(savedEntity.id))
-    actual should not be empty
-    actual.get.attributeKeys shouldBe "[]"
-  }
-
-  it should "save keys for an entity with attributes" in withMinimalTestDatabase { _ =>
-    val attributeNames = List("red", "green", "blue", "pfb:importedColumn")
-    // define an entity with attributes named according to ${attributeNames}
-    val entity = Entity(
-      "entityName",
-      "entityType",
-      attributeNames.map { attrName =>
-        AttributeName.fromDelimitedName(attrName) -> AttributeNumber(System.currentTimeMillis())
-      }.toMap
-    )
-    val savedEntity = insertAndGet(entity)
-    // get the keys
-    val actual = runAndWait(q.getKeys(savedEntity.id))
-    actual should not be empty
-    actual.get.attributeKeys.parseJson.convertTo[List[String]] should contain theSameElementsAs attributeNames
-  }
-
   behavior of "existsAll and countExisting"
 
   it should "find the entities" in withMinimalTestDatabase { _ =>
@@ -451,7 +421,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     // create entities in a different workspace to make sure they are not included
     createEntitiesWithKeys(entityType1AttributeNames, entityType2, minimalTestData.workspace2.workspaceIdAsUUID)
 
-    val actual = runAndWait(q.listEntityKeys(wsid))
+    val actual = runAndWait(q.listEntityKeysViaEntity(wsid))
     actual should contain theSameElementsAs entityType1AttributeNames.map {
       EntityTypeAndAttributeKey(entityType1, _)
     } ++ entityType2AttributeNames.map {
@@ -1386,13 +1356,13 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     )
 
     // check metadata before any renames
-    runAndWait(q.listEntityKeys(wsid)) should contain theSameElementsAs Seq(
+    runAndWait(q.listEntityKeysViaEntity(wsid)) should contain theSameElementsAs Seq(
       EntityTypeAndAttributeKey("entityType1", attr1),
       EntityTypeAndAttributeKey("entityType1", attr2),
       EntityTypeAndAttributeKey("entityType2", attr2),
       EntityTypeAndAttributeKey("entityType2", attr3)
     )
-    runAndWait(q.listEntityKeys(wsid2)) should contain theSameElementsAs Seq(
+    runAndWait(q.listEntityKeysViaEntity(wsid2)) should contain theSameElementsAs Seq(
       EntityTypeAndAttributeKey("entityType1", attr1),
       EntityTypeAndAttributeKey("entityType1", attr2),
       EntityTypeAndAttributeKey("entityType2", attr2),
@@ -1403,13 +1373,13 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val newAttr1 = AttributeName.withDefaultNS("new1")
     runAndWait(q.renameAttribute(wsid, "entityType1", attr2, AttributeRename(newAttr1))) shouldBe 1
     // check metadata
-    runAndWait(q.listEntityKeys(wsid)) should contain theSameElementsAs Seq(
+    runAndWait(q.listEntityKeysViaEntity(wsid)) should contain theSameElementsAs Seq(
       EntityTypeAndAttributeKey("entityType1", attr1),
       EntityTypeAndAttributeKey("entityType1", newAttr1),
       EntityTypeAndAttributeKey("entityType2", attr2),
       EntityTypeAndAttributeKey("entityType2", attr3)
     )
-    runAndWait(q.listEntityKeys(wsid2)) should contain theSameElementsAs Seq(
+    runAndWait(q.listEntityKeysViaEntity(wsid2)) should contain theSameElementsAs Seq(
       EntityTypeAndAttributeKey("entityType1", attr1),
       EntityTypeAndAttributeKey("entityType1", attr2),
       EntityTypeAndAttributeKey("entityType2", attr2),
@@ -3024,16 +2994,6 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       .list should contain theSameElementsAs Seq(
       newTargetEntity1.toReference
     )
-    // Verify entity keys table is updated
-    import driver.api._
-
-    val entityKeysQuery1 =
-      sql"""select entity_type from ENTITY_KEYS where workspace_id = $wsid and entity_type = $targetType""".as[String]
-    runAndWait(entityKeysQuery1).size shouldBe 0
-    val entityKeysQuery2 =
-      sql"""select entity_type from ENTITY_KEYS where workspace_id = $wsid and entity_type = $newTargetType"""
-        .as[String]
-    runAndWait(entityKeysQuery2).size shouldBe 2
   }
 
   it should "not change non references that match the old name" in withMinimalTestDatabase { _ =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
@@ -41,7 +41,6 @@ import org.broadinstitute.dsde.rawls.model.{
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
 import org.broadinstitute.dsde.rawls.webservice.EntityApiService
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceSettingRepository
-import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{when, RETURNS_SMART_NULLS}
 import org.scalatest.concurrent.ScalaFutures
@@ -53,7 +52,6 @@ import org.scalatestplus.mockito.MockitoSugar.mock
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import spray.json._
-import spray.json.DefaultJsonProtocol._
 
 class CaseSensitivitySpec
     extends AnyFreeSpec

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.{
   SlickDataSource
 }
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationContext
-import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityProviderBuilder
+import org.broadinstitute.dsde.rawls.entities.compact.{CompactEntityProviderBuilder, CompactEntitySerialization}
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityRequestArguments, EntityService}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.mock.MockSamDAO
@@ -42,7 +42,8 @@ import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
 import org.broadinstitute.dsde.rawls.webservice.EntityApiService
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceSettingRepository
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.when
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{when, RETURNS_SMART_NULLS}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -51,8 +52,15 @@ import org.scalatestplus.mockito.MockitoSugar.mock
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 
-class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverComponent with ScalaFutures {
+class CaseSensitivitySpec
+    extends AnyFreeSpec
+    with CompactEntitySerialization
+    with Matchers
+    with TestDriverComponent
+    with ScalaFutures {
 
   implicit val actorSystem: ActorSystem = ActorSystem() // needed for stream materialization
 
@@ -91,7 +99,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
       AttributeName(namespace, name) -> AttributeString(s"$namespace:$name-bar")
     )
   }.toMap
-  val exemplarAttributeNames: Iterable[ShardId] = exemplarAttributesMap.keys.map(toDelimitedName)
+  val exemplarAttributeNames: Iterable[String] = exemplarAttributesMap.keys.map(toDelimitedName)
   val caseInsensitiveAttributeData: Seq[Entity] = Seq(Entity("005", "cat", exemplarAttributesMap))
 
   // ===================================================================================================================
@@ -128,29 +136,25 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           )
 
           // assert cache is not yet populated
-          // TODO CORE-650
-          runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) shouldBe empty
+          runAndWait(compactEntityQuery.getCachedKeys(testWorkspace.workspace.workspaceIdAsUUID)) shouldBe empty
 
           // get metadata
           val metadata =
             services.entityService.entityTypeMetadata(testWorkspace.wsName, useCache = true).futureValue
           metadata.keySet shouldBe exemplarTypes
 
-          // assert cache is populated and up-to-date
-          // TODO CORE-650
-          runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) should contain(0)
+          // assert cache is populated
+          val cachedKeys = runAndWait(compactEntityQuery.getCachedKeys(testWorkspace.workspace.workspaceIdAsUUID))
+          cachedKeys should not be empty
 
           // get types from cache and verify
-          // TODO CORE-650
-          val cachedTypes = runAndWait(entityTypeStatisticsQuery.getAll(testWorkspace.workspace.workspaceIdAsUUID))
-          cachedTypes.keySet shouldBe exemplarTypes
+          val cachedTypes = cachedKeys.map(_.entityType)
+          cachedTypes shouldBe exemplarTypes
           // get metadata again, should come from cache, and verify
           val cachedMetadata =
             services.entityService.entityTypeMetadata(testWorkspace.wsName, useCache = true).futureValue
           cachedMetadata.keySet shouldBe exemplarTypes
 
-          // TODO CORE-650
-          runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) should contain(0)
         }
 
         exemplarTypes foreach { typeUnderTest =>
@@ -290,10 +294,14 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
                                             FilterOperators.And,
                                             WorkspaceFieldSpecs(None)
             )
-            // noinspection ScalaDeprecation
-            val queryResponse = provider.queryEntities(typeUnderTest, queryCriteria, testContext).futureValue
+            val queryResponse = provider
+              .queryEntitiesSource(typeUnderTest, queryCriteria, testContext)
+              .futureValue
+              ._2
+              .runWith(Sink.seq)
+              .futureValue
             // extract distinct entity types from results
-            val typesFromResults = queryResponse.results.map(_.entityType).distinct
+            val typesFromResults = queryResponse.map(_.entityType).distinct
             typesFromResults.toSet shouldBe Set(typeUnderTest)
           }
         }
@@ -532,35 +540,26 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
             // get database-level entity record for the entity containing the reference
             val entityRecordContainingReference = runAndWait(
-              // TODO CORE-650
-              entityQuery.getEntityRecords(testWorkspace.workspace.workspaceIdAsUUID,
-                                           Set(AttributeEntityReference(typeUnderTest, "001"))
+              compactEntityQuery.getEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                             Set(EntityPointer(typeUnderTest, "001"))
               )
             ).head
 
             // get database-level entity record for the entity being referenced
             val entityRecordBeingReferenced = runAndWait(
-              // TODO CORE-650
-              entityQuery.getEntityRecords(testWorkspace.workspace.workspaceIdAsUUID,
-                                           Set(AttributeEntityReference(typeUnderTest, "003"))
+              compactEntityQuery.getEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                             Set(EntityPointer(typeUnderTest, "003"))
               )
             ).head
 
-            // get database-level attribute record for the reference and find the entity id it is referencing
-            import driver.api._
-            val actualReferencedIds = runAndWait(
-              // TODO CORE-650
-              entityAttributeShardQuery(testWorkspace.workspace.workspaceIdAsUUID)
-                .findByOwnerQuery(Seq(entityRecordContainingReference.id))
-                .filter(_.name === "my-entity-reference")
-                .map(attr => attr.valueEntityRef)
-                .result
-            )
+            val sqlData = entityRecordContainingReference.attributes.map(_.parseJson.convertTo[SqlEntityData])
+            sqlData should not be empty
+            val actualReferences = sqlData.get.refs
 
             // we should have exactly one reference, and it should point to entityRecordBeingReferenced
-            actualReferencedIds.size shouldBe 1
-            actualReferencedIds.head shouldNot be(empty)
-            actualReferencedIds.head.get shouldBe entityRecordBeingReferenced.id
+            actualReferences.size shouldBe 1
+            actualReferences.head.t shouldBe entityRecordBeingReferenced.entityType
+            actualReferences.head.n shouldBe entityRecordBeingReferenced.name
           }
         }
 
@@ -682,23 +681,20 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         )
 
         // cache is empty
-        // TODO CORE-650
-        runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) shouldBe empty
+        runAndWait(compactEntityQuery.getCachedKeys(testWorkspace.workspace.workspaceIdAsUUID)) shouldBe empty
 
         // get provider
         val provider = defaultProvider
         provider.entityTypeMetadata(useCache = true, testContext).futureValue
 
         // cache is now populated
-        // TODO CORE-650
-        assert(runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)).isDefined)
+        val cachedKeys = runAndWait(compactEntityQuery.getCachedKeys(testWorkspace.workspace.workspaceIdAsUUID))
+        cachedKeys should not be empty
 
         // get column names from cache to verify
-        // TODO CORE-650
-        val cachedValues = runAndWait(entityAttributeStatisticsQuery.getAll(testWorkspace.workspace.workspaceIdAsUUID))
-        cachedValues("cat").map(toDelimitedName) should contain theSameElementsAs exemplarAttributeNames
+        val cachedValues = cachedKeys.find(_.entityType == "cat").get.attributeKeys
+        cachedValues.map(toDelimitedName) should contain theSameElementsAs exemplarAttributeNames
       }
-
       "should return all attribute names when querying entities" in withTestDataServices { _ =>
         // save case insensitive attribute data
         runAndWait(
@@ -713,38 +709,18 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
         // query all entities
         val entityQueryParameters = EntityQuery(1, 10, "name", SortDirections.Ascending, None)
-        // noinspection ScalaDeprecation
-        val queriedEntities = provider.queryEntities("cat", entityQueryParameters, testContext).futureValue
+        val queriedEntities = provider
+          .queryEntitiesSource("cat", entityQueryParameters, testContext)
+          .futureValue
+          ._2
+          .runWith(Sink.seq)
+          .futureValue
 
         // verify all attributes are returned
-        queriedEntities.results.size shouldBe 1
-        val queriedAttributes = queriedEntities.results.head.attributes
+        queriedEntities.size shouldBe 1
+        val queriedAttributes = queriedEntities.head.attributes
         exemplarAttributeNames.size should equal(queriedAttributes.size)
         queriedAttributes.keys.map(toDelimitedName) should contain theSameElementsAs exemplarAttributeNames
-      }
-
-      "should delete all associated attributes when deleting entities of any type" in withTestDataServices { _ =>
-        // save case insensitive attribute data
-        runAndWait(
-          compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
-                                                caseInsensitiveAttributeData,
-                                                insertOnly = false
-          )
-        )
-
-        // get provider
-        val provider = defaultProvider
-
-        // delete our test entity
-        provider.deleteEntities(Seq(EntityPointer("cat", "005")), testContext).futureValue shouldBe 1
-
-        // make sure all attributes are marked as deleted
-        import driver.api._
-
-        // TODO CORE-650
-        val allAttributes = runAndWait(entityAttributeShardQuery(testWorkspace.workspace).result)
-        exemplarAttributeNames.size shouldBe allAttributes.size
-        allAttributes.foreach(attr => assert(attr.deleted))
       }
 
       "should create all attributes for a new entity" in withTestDataServices { _ =>
@@ -754,15 +730,12 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         // create our entity
         provider.createEntity(caseInsensitiveAttributeData.head, testContext).futureValue // Entity
 
-        // make sure all attributes are created
-        import driver.api._
-
-        // TODO CORE-650
-        val allAttributes = runAndWait(entityAttributeShardQuery(testWorkspace.workspace).result)
+        val allAttributes = provider
+          .getEntity(caseInsensitiveAttributeData.head.entityType, caseInsensitiveAttributeData.head.name, testContext)
+          .futureValue
+          .attributes
         exemplarAttributeNames.size shouldBe allAttributes.size
-        allAttributes.map(attr =>
-          toDelimitedName(AttributeName(attr.namespace, attr.name))
-        ) should contain theSameElementsAs exemplarAttributeNames
+        allAttributes.keys should contain theSameElementsAs exemplarAttributeNames
       }
 
       "should return all attribute names when listing entities" in withTestDataServices { services =>
@@ -798,22 +771,19 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
               )
             )
 
+            // get provider
+            val provider = defaultProvider
+
             // delete column all entities
             val columnsToDelete = Set(attributeNameToDelete)
-            runAndWait(
-              // TODO CORE-650
-              entityAttributeShardQuery(testWorkspace.workspace).deleteAttributes(testWorkspace.workspace,
-                                                                                  "cat",
-                                                                                  columnsToDelete
-              )
-            )
+            provider.deleteEntityAttributes("cat", columnsToDelete, testContext).futureValue
 
             // get all attributes to verify deletion
-            import driver.api._
-
-            // TODO CORE-650
-            val allAttributes = runAndWait(entityAttributeShardQuery(testWorkspace.workspace).result)
-              .map(attr => toDelimitedName(AttributeName(attr.namespace, attr.name)))
+            val allAttributes = provider
+              .listEntities("cat")
+              .runWith(Sink.seq)
+              .futureValue
+              .flatMap(_.attributes.keys)
 
             // verify an attribute is deleted
             allAttributes.size shouldBe exemplarAttributeNames.size - 1
@@ -995,12 +965,10 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
     override val batchUpsertMaxBytes = testConf.getLong("entityUpsert.maxContentSizeBytes")
 
     // when EntityManager asks if the workspace should use Quicksilver data tables, answer yes
-    val mockWorkspaceSettingRepository = mock[WorkspaceSettingRepository]
-    when(
-      mockWorkspaceSettingRepository.getWorkspaceSettingOfType(ArgumentMatchers.any[UUID](),
-                                                               ArgumentMatchers.any[WorkspaceSettingType]()
-      )
-    )
+    val mockWorkspaceSettingRepository = mock[WorkspaceSettingRepository](RETURNS_SMART_NULLS)
+    when(mockWorkspaceSettingRepository.hasPendingSettings(any[UUID], any[WorkspaceSettingType])(any[ExecutionContext]))
+      .thenReturn(Future(false))
+    when(mockWorkspaceSettingRepository.getWorkspaceSettingOfType(any[UUID], any[WorkspaceSettingType]))
       .thenReturn(Future.successful(Option(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))))
 
     val entityServiceConstructor = EntityService.constructor(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
@@ -12,16 +12,20 @@ import org.broadinstitute.dsde.rawls.dataaccess.{
   SlickDataSource
 }
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationContext
+import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityProviderBuilder
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityRequestArguments, EntityService}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.mock.MockSamDAO
 import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, EntityUpdateDefinition}
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.CompactDataTablesConfig
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.WorkspaceSettingType
 import org.broadinstitute.dsde.rawls.model.{
   AttributeEntityReference,
   AttributeName,
   AttributeRename,
   AttributeString,
+  CompactDataTablesSetting,
   Entity,
   EntityPointer,
   EntityQuery,
@@ -37,18 +41,24 @@ import org.broadinstitute.dsde.rawls.model.{
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
 import org.broadinstitute.dsde.rawls.webservice.EntityApiService
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceSettingRepository
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Span}
+import org.scalatestplus.mockito.MockitoSugar.mock
 
-import scala.concurrent.ExecutionContext
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
 
 class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverComponent with ScalaFutures {
 
   implicit val actorSystem: ActorSystem = ActorSystem() // needed for stream materialization
 
   val testConf: Config = ConfigFactory.load()
+
+  private val providerBuilder = new CompactEntityProviderBuilder(slickDataSource)
 
   // ===================================================================================================================
   // exemplar data used in multiple tests
@@ -68,7 +78,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
   }
 
   // create three entities for each type in our list, reusing names across entity types.
-  val exemplarDataWithCommonNames: Set[Entity] = exemplarTypes flatMap { typeName =>
+  val exemplarDataWithCommonNames: Seq[Entity] = exemplarTypes.toSeq flatMap { typeName =>
     Seq(
       Entity(s"001", typeName, Map(fooAttribute -> AttributeString(s"$typeName-001"))),
       Entity(s"002", typeName, Map(fooAttribute -> AttributeString(s"$typeName-002"))),
@@ -88,20 +98,21 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
   // tests
   // ===================================================================================================================
 
-  "LocalEntityProvider case-sensitivity" - {
+  "CompactEntityProvider case-sensitivity" - {
     "for entity types" - {
       "features that depend on entity type case sensitivity only" - {
 
         "should return all types in uncached metadata requests" in withTestDataServices { _ =>
           // save exemplar data
-          runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
-          // get provider
-          val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                                 slickDataSource,
-                                                 false,
-                                                 testConf.getDuration("entities.queryTimeout"),
-                                                 "metricsBaseName"
+          runAndWait(
+            compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                  exemplarData,
+                                                  insertOnly = false
+            )
           )
+          // get provider
+          val provider = defaultProvider
+
           // get metadata
           val metadata = provider.entityTypeMetadata(useCache = false, testContext).futureValue
           metadata.keySet shouldBe exemplarTypes
@@ -109,9 +120,15 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
         "should return all types in cached metadata requests" in withTestDataServices { services =>
           // save exemplar data
-          runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
+          runAndWait(
+            compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                  exemplarData,
+                                                  insertOnly = false
+            )
+          )
 
           // assert cache is not yet populated
+          // TODO CORE-650
           runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) shouldBe empty
 
           // get metadata
@@ -120,9 +137,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           metadata.keySet shouldBe exemplarTypes
 
           // assert cache is populated and up-to-date
+          // TODO CORE-650
           runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) should contain(0)
 
           // get types from cache and verify
+          // TODO CORE-650
           val cachedTypes = runAndWait(entityTypeStatisticsQuery.getAll(testWorkspace.workspace.workspaceIdAsUUID))
           cachedTypes.keySet shouldBe exemplarTypes
           // get metadata again, should come from cache, and verify
@@ -130,6 +149,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             services.entityService.entityTypeMetadata(testWorkspace.wsName, useCache = true).futureValue
           cachedMetadata.keySet shouldBe exemplarTypes
 
+          // TODO CORE-650
           runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) should contain(0)
         }
 
@@ -145,7 +165,12 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
           s"should only rename target type [$typeUnderTest] -> [$newName]" in withTestDataServices { services =>
             // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    exemplarData,
+                                                    insertOnly = false
+              )
+            )
 
             // assert we are renaming to a new name that differs only in case
             newName should not be typeUnderTest
@@ -166,16 +191,16 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         exemplarTypes foreach { typeUnderTest =>
           s"should only delete all entities of target type [$typeUnderTest]" in withTestDataServices { _ =>
             // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    exemplarData,
+                                                    insertOnly = false
+              )
+            )
 
             // delete all entities from target type
             // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                                   slickDataSource,
-                                                   false,
-                                                   testConf.getDuration("entities.queryTimeout"),
-                                                   "metricsBaseName"
-            )
+            val provider = defaultProvider
             provider.deleteEntitiesOfType(typeUnderTest, testContext).futureValue
 
             // get actual entity types from the db
@@ -189,7 +214,12 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           s"should respect case when deleting all named attributes from target type [$typeUnderTest]" in withTestDataServices {
             services =>
               // save exemplar data
-              runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
+              runAndWait(
+                compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                      exemplarData,
+                                                      insertOnly = false
+                )
+              )
 
               // delete all attributes named "foo" from the target type
               services.entityService
@@ -213,7 +243,12 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           s"should only rename an entire column within target type [$typeUnderTest]" in withTestDataServices {
             services =>
               // save exemplar data
-              runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
+              runAndWait(
+                compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                      exemplarData,
+                                                      insertOnly = false
+                )
+              )
 
               // rename attribute from target type
               services.entityService
@@ -238,14 +273,14 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         exemplarTypes foreach { typeUnderTest =>
           s"should only query target type [$typeUnderTest]" in withTestDataServices { _ =>
             // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
-            // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                                   slickDataSource,
-                                                   false,
-                                                   testConf.getDuration("entities.queryTimeout"),
-                                                   "metricsBaseName"
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    exemplarData,
+                                                    insertOnly = false
+              )
             )
+            // get provider
+            val provider = defaultProvider
             // get results for one specific type
             val queryCriteria = EntityQuery(1,
                                             exemplarData.size,
@@ -256,7 +291,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
                                             WorkspaceFieldSpecs(None)
             )
             // noinspection ScalaDeprecation
-            val queryResponse = provider.queryEntities(typeUnderTest, queryCriteria).futureValue
+            val queryResponse = provider.queryEntities(typeUnderTest, queryCriteria, testContext).futureValue
             // extract distinct entity types from results
             val typesFromResults = queryResponse.results.map(_.entityType).distinct
             typesFromResults.toSet shouldBe Set(typeUnderTest)
@@ -266,7 +301,12 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         exemplarTypes foreach { typeUnderTest =>
           s"should list all entities only for target type [$typeUnderTest]" in withTestDataServices { services =>
             // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    exemplarData,
+                                                    insertOnly = false
+              )
+            )
 
             val listAllResponse = services.entityService
               .listEntities(testWorkspace.workspace.toWorkspaceName, typeUnderTest)
@@ -285,15 +325,15 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
         "should respect case for get-entity" in withTestDataServices { _ =>
           // save exemplar data
-          runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
+          runAndWait(
+            compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                  exemplarDataWithCommonNames,
+                                                  insertOnly = false
+            )
+          )
 
           // get provider
-          val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                                 slickDataSource,
-                                                 false,
-                                                 testConf.getDuration("entities.queryTimeout"),
-                                                 "metricsBaseName"
-          )
+          val provider = defaultProvider
           // test gets
           exemplarDataWithCommonNames foreach { entityUnderTest =>
             val actual = provider.getEntity(entityUnderTest.entityType, entityUnderTest.name, testContext).futureValue
@@ -304,15 +344,15 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         exemplarTypes foreach { typeUnderTest =>
           s"should respect case for expression evaluation type names [$typeUnderTest]" in withTestDataServices { _ =>
             // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    exemplarDataWithCommonNames,
+                                                    insertOnly = false
+              )
+            )
 
             // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                                   slickDataSource,
-                                                   false,
-                                                   testConf.getDuration("entities.queryTimeout"),
-                                                   "metricsBaseName"
-            )
+            val provider = defaultProvider
 
             // set up arguments for expression evaluation
             val expressionEvaluationContext =
@@ -340,15 +380,15 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         exemplarTypes foreach { typeUnderTest =>
           s"should resolve type + _id expressions correctly [$typeUnderTest]" in withTestDataServices { _ =>
             // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    exemplarDataWithCommonNames,
+                                                    insertOnly = false
+              )
+            )
 
             // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                                   slickDataSource,
-                                                   false,
-                                                   testConf.getDuration("entities.queryTimeout"),
-                                                   "metricsBaseName"
-            )
+            val provider = defaultProvider
 
             // set up arguments for expression evaluation, using "this.${typeUnderTest}_id"
             val expressionString = s"this.${typeUnderTest}_id"
@@ -379,15 +419,15 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           s"should resolve type + _id expressions to an empty result if the type is incorrectly cased [$typeUnderTest]" in withTestDataServices {
             _ =>
               // save exemplar data
-              runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
+              runAndWait(
+                compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                      exemplarDataWithCommonNames,
+                                                      insertOnly = false
+                )
+              )
 
               // get provider
-              val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                                     slickDataSource,
-                                                     false,
-                                                     testConf.getDuration("entities.queryTimeout"),
-                                                     "metricsBaseName"
-              )
+              val provider = defaultProvider
 
               // set up arguments for expression evaluation, using incorrect case for "this.${typeUnderTest}_id"
               val expressionString = s"this.${typeUnderTest.head.toLower}${typeUnderTest.tail.toUpperCase}_id"
@@ -419,14 +459,14 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         exemplarTypes foreach { typeUnderTest =>
           s"should respect case for delete specified entities [$typeUnderTest]" in withTestDataServices { _ =>
             // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
-            // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                                   slickDataSource,
-                                                   false,
-                                                   testConf.getDuration("entities.queryTimeout"),
-                                                   "metricsBaseName"
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    exemplarDataWithCommonNames,
+                                                    insertOnly = false
+              )
             )
+            // get provider
+            val provider = defaultProvider
 
             // delete two entities of target type
             val entRefs =
@@ -448,7 +488,12 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         exemplarTypes foreach { typeUnderTest =>
           s"should respect case for rename specified entity [$typeUnderTest]" in withTestDataServices { services =>
             // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    exemplarDataWithCommonNames,
+                                                    insertOnly = false
+              )
+            )
 
             // rename entity of target type
             services.entityService
@@ -468,14 +513,14 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         exemplarTypes foreach { typeUnderTest =>
           s"should respect case when creating an entity reference [$typeUnderTest]" in withTestDataServices { _ =>
             // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
-            // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                                   slickDataSource,
-                                                   false,
-                                                   testConf.getDuration("entities.queryTimeout"),
-                                                   "metricsBaseName"
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    exemplarDataWithCommonNames,
+                                                    insertOnly = false
+              )
             )
+            // get provider
+            val provider = defaultProvider
 
             // create a batch upsert to add an entity reference from 001 to 003
             val op = AddUpdateAttribute(AttributeName.withDefaultNS("my-entity-reference"),
@@ -487,6 +532,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
             // get database-level entity record for the entity containing the reference
             val entityRecordContainingReference = runAndWait(
+              // TODO CORE-650
               entityQuery.getEntityRecords(testWorkspace.workspace.workspaceIdAsUUID,
                                            Set(AttributeEntityReference(typeUnderTest, "001"))
               )
@@ -494,6 +540,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
             // get database-level entity record for the entity being referenced
             val entityRecordBeingReferenced = runAndWait(
+              // TODO CORE-650
               entityQuery.getEntityRecords(testWorkspace.workspace.workspaceIdAsUUID,
                                            Set(AttributeEntityReference(typeUnderTest, "003"))
               )
@@ -502,6 +549,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             // get database-level attribute record for the reference and find the entity id it is referencing
             import driver.api._
             val actualReferencedIds = runAndWait(
+              // TODO CORE-650
               entityAttributeShardQuery(testWorkspace.workspace.workspaceIdAsUUID)
                 .findByOwnerQuery(Seq(entityRecordContainingReference.id))
                 .filter(_.name === "my-entity-reference")
@@ -519,14 +567,14 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         exemplarTypes foreach { typeUnderTest =>
           s"should respect case during batchUpsert [$typeUnderTest]" in withTestDataServices { _ =>
             // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
-            // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                                   slickDataSource,
-                                                   false,
-                                                   testConf.getDuration("entities.queryTimeout"),
-                                                   "metricsBaseName"
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    exemplarDataWithCommonNames,
+                                                    insertOnly = false
+              )
             )
+            // get provider
+            val provider = defaultProvider
 
             // create a batch upsert to change the target entity's attribute
             val op = AddUpdateAttribute(fooAttribute, AttributeString("updated"))
@@ -563,14 +611,14 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         exemplarTypes foreach { typeUnderTest =>
           s"should respect case during batchUpdate [$typeUnderTest]" in withTestDataServices { _ =>
             // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
-            // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                                   slickDataSource,
-                                                   false,
-                                                   testConf.getDuration("entities.queryTimeout"),
-                                                   "metricsBaseName"
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    exemplarDataWithCommonNames,
+                                                    insertOnly = false
+              )
             )
+            // get provider
+            val provider = defaultProvider
 
             // create a batch upsert to change the target entity's attribute
             val op = AddUpdateAttribute(fooAttribute, AttributeString("updated"))
@@ -610,14 +658,14 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
     "for attribute names" - {
       "should return all attributes in uncached metadata requests" in withTestDataServices { _ =>
         // save case insensitive attribute data
-        runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
-        // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                               slickDataSource,
-                                               false,
-                                               testConf.getDuration("entities.queryTimeout"),
-                                               "metricsBaseName"
+        runAndWait(
+          compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                caseInsensitiveAttributeData,
+                                                insertOnly = false
+          )
         )
+        // get provider
+        val provider = defaultProvider
         // get metadata
         val metadata = provider.entityTypeMetadata(useCache = false, testContext).futureValue
         metadata("cat").attributeNames.size shouldEqual exemplarAttributeNames.size
@@ -626,44 +674,47 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
       "should return all attribute names in cached metadata requests" in withTestDataServices { _ =>
         // save case insensitive attribute data
-        runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
+        runAndWait(
+          compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                caseInsensitiveAttributeData,
+                                                insertOnly = false
+          )
+        )
 
         // cache is empty
+        // TODO CORE-650
         runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) shouldBe empty
 
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                               slickDataSource,
-                                               true,
-                                               testConf.getDuration("entities.queryTimeout"),
-                                               "metricsBaseName"
-        )
+        val provider = defaultProvider
         provider.entityTypeMetadata(useCache = true, testContext).futureValue
 
         // cache is now populated
+        // TODO CORE-650
         assert(runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)).isDefined)
 
         // get column names from cache to verify
+        // TODO CORE-650
         val cachedValues = runAndWait(entityAttributeStatisticsQuery.getAll(testWorkspace.workspace.workspaceIdAsUUID))
         cachedValues("cat").map(toDelimitedName) should contain theSameElementsAs exemplarAttributeNames
       }
 
       "should return all attribute names when querying entities" in withTestDataServices { _ =>
         // save case insensitive attribute data
-        runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
+        runAndWait(
+          compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                caseInsensitiveAttributeData,
+                                                insertOnly = false
+          )
+        )
 
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                               slickDataSource,
-                                               true,
-                                               testConf.getDuration("entities.queryTimeout"),
-                                               "metricsBaseName"
-        )
+        val provider = defaultProvider
 
         // query all entities
         val entityQueryParameters = EntityQuery(1, 10, "name", SortDirections.Ascending, None)
         // noinspection ScalaDeprecation
-        val queriedEntities = provider.queryEntities("cat", entityQueryParameters).futureValue
+        val queriedEntities = provider.queryEntities("cat", entityQueryParameters, testContext).futureValue
 
         // verify all attributes are returned
         queriedEntities.results.size shouldBe 1
@@ -674,15 +725,15 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
       "should delete all associated attributes when deleting entities of any type" in withTestDataServices { _ =>
         // save case insensitive attribute data
-        runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
+        runAndWait(
+          compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                caseInsensitiveAttributeData,
+                                                insertOnly = false
+          )
+        )
 
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                               slickDataSource,
-                                               true,
-                                               testConf.getDuration("entities.queryTimeout"),
-                                               "metricsBaseName"
-        )
+        val provider = defaultProvider
 
         // delete our test entity
         provider.deleteEntities(Seq(EntityPointer("cat", "005")), testContext).futureValue shouldBe 1
@@ -690,6 +741,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         // make sure all attributes are marked as deleted
         import driver.api._
 
+        // TODO CORE-650
         val allAttributes = runAndWait(entityAttributeShardQuery(testWorkspace.workspace).result)
         exemplarAttributeNames.size shouldBe allAttributes.size
         allAttributes.foreach(attr => assert(attr.deleted))
@@ -697,12 +749,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
       "should create all attributes for a new entity" in withTestDataServices { _ =>
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                               slickDataSource,
-                                               true,
-                                               testConf.getDuration("entities.queryTimeout"),
-                                               "metricsBaseName"
-        )
+        val provider = defaultProvider
 
         // create our entity
         provider.createEntity(caseInsensitiveAttributeData.head, testContext).futureValue // Entity
@@ -710,6 +757,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         // make sure all attributes are created
         import driver.api._
 
+        // TODO CORE-650
         val allAttributes = runAndWait(entityAttributeShardQuery(testWorkspace.workspace).result)
         exemplarAttributeNames.size shouldBe allAttributes.size
         allAttributes.map(attr =>
@@ -719,7 +767,12 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
       "should return all attribute names when listing entities" in withTestDataServices { services =>
         // save case insensitive attribute data
-        runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
+        runAndWait(
+          compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                caseInsensitiveAttributeData,
+                                                insertOnly = false
+          )
+        )
 
         // list all entities
         val entityList = services.entityService
@@ -738,11 +791,17 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         s"should delete the correct column based on case when deleting column [${toDelimitedName(attributeNameToDelete)}]" in withTestDataServices {
           _ =>
             // save case insensitive attribute data
-            runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    caseInsensitiveAttributeData,
+                                                    insertOnly = false
+              )
+            )
 
             // delete column all entities
             val columnsToDelete = Set(attributeNameToDelete)
             runAndWait(
+              // TODO CORE-650
               entityAttributeShardQuery(testWorkspace.workspace).deleteAttributes(testWorkspace.workspace,
                                                                                   "cat",
                                                                                   columnsToDelete
@@ -752,6 +811,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             // get all attributes to verify deletion
             import driver.api._
 
+            // TODO CORE-650
             val allAttributes = runAndWait(entityAttributeShardQuery(testWorkspace.workspace).result)
               .map(attr => toDelimitedName(AttributeName(attr.namespace, attr.name)))
 
@@ -767,15 +827,15 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
       "should get all attribute names when getting an entity" in withTestDataServices { _ =>
         // save case insensitive attribute data
-        runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
+        runAndWait(
+          compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                caseInsensitiveAttributeData,
+                                                insertOnly = false
+          )
+        )
 
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                               slickDataSource,
-                                               true,
-                                               testConf.getDuration("entities.queryTimeout"),
-                                               "metricsBaseName"
-        )
+        val provider = defaultProvider
 
         // get our entity
         val entity = provider.getEntity("cat", "005", testContext).futureValue // Entity
@@ -810,12 +870,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
       "should add all attributes when batch upserting entities" in withTestDataServices { _ =>
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                               slickDataSource,
-                                               true,
-                                               testConf.getDuration("entities.queryTimeout"),
-                                               "metricsBaseName"
-        )
+        val provider = defaultProvider
 
         val updateDefinition = caseInsensitiveAttributeData.map { entity =>
           val attributeUpdates = entity.attributes.map { case (attributeName, attributeValue) =>
@@ -835,15 +890,15 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
       "should update all attributes correctly when batch updating entities" in withTestDataServices { _ =>
         // save case insensitive attribute data
-        runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
+        runAndWait(
+          compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                caseInsensitiveAttributeData,
+                                                insertOnly = false
+          )
+        )
 
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                               slickDataSource,
-                                               true,
-                                               testConf.getDuration("entities.queryTimeout"),
-                                               "metricsBaseName"
-        )
+        val provider = defaultProvider
 
         // Update all attributes
         val updateDefinition = caseInsensitiveAttributeData.map { entity =>
@@ -868,15 +923,15 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         s"should respect case for expression evaluation attribute names [$attributeUnderTest]" in withTestDataServices {
           _ =>
             // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
+            runAndWait(
+              compactEntityQuery.batchWriteEntities(testWorkspace.workspace.workspaceIdAsUUID,
+                                                    caseInsensitiveAttributeData,
+                                                    insertOnly = false
+              )
+            )
 
             // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
-                                                   slickDataSource,
-                                                   false,
-                                                   testConf.getDuration("entities.queryTimeout"),
-                                                   "metricsBaseName"
-            )
+            val provider = defaultProvider
 
             // set up arguments for expression evaluation
             val expressionEvaluationContext =
@@ -910,8 +965,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
   implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(500, Millis)), interval = scaled(Span(15, Millis)))
 
+  private def defaultProvider = providerBuilder.build(EntityRequestArguments(testWorkspace.workspace, testContext)).get
+
   private def getAllEntities(workspace: Workspace): Seq[Entity] =
-    runAndWait(entityQuery.listActiveEntities(workspace)).iterator.toSeq
+    runAndWait(compactEntityQuery.listAllEntities(workspace.workspaceIdAsUUID, deleted = false))
+      .map(_.toEntity)
 
   private def getAllEntityTypes(workspace: Workspace): Set[String] = {
     val actualEntities = getAllEntities(workspace)
@@ -936,13 +994,22 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
     override val batchUpsertMaxBytes = testConf.getLong("entityUpsert.maxContentSizeBytes")
 
+    // when EntityManager asks if the workspace should use Quicksilver data tables, answer yes
+    val mockWorkspaceSettingRepository = mock[WorkspaceSettingRepository]
+    when(
+      mockWorkspaceSettingRepository.getWorkspaceSettingOfType(ArgumentMatchers.any[UUID](),
+                                                               ArgumentMatchers.any[WorkspaceSettingType]()
+      )
+    )
+      .thenReturn(Future.successful(Option(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))))
+
     val entityServiceConstructor = EntityService.constructor(
       slickDataSource,
       samDAO,
       workbenchMetricBaseName = "test",
       EntityManager.defaultEntityManager(
         dataSource,
-        new WorkspaceSettingRepository(dataSource),
+        mockWorkspaceSettingRepository,
         testConf.getBoolean("entityStatisticsCache.enabled"),
         testConf.getDuration("entities.queryTimeout"),
         "testMetricBaseName"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
@@ -149,7 +149,7 @@ class CaseSensitivitySpec
 
           // get types from cache and verify
           val cachedTypes = cachedKeys.map(_.entityType)
-          cachedTypes shouldBe exemplarTypes
+          cachedTypes should contain theSameElementsAs exemplarTypes
           // get metadata again, should come from cache, and verify
           val cachedMetadata =
             services.entityService.entityTypeMetadata(testWorkspace.wsName, useCache = true).futureValue
@@ -667,7 +667,6 @@ class CaseSensitivitySpec
         val provider = defaultProvider
         // get metadata
         val metadata = provider.entityTypeMetadata(useCache = false, testContext).futureValue
-        metadata("cat").attributeNames.size shouldEqual exemplarAttributeNames.size
         metadata("cat").attributeNames should contain theSameElementsAs exemplarAttributeNames
       }
 
@@ -734,8 +733,7 @@ class CaseSensitivitySpec
           .getEntity(caseInsensitiveAttributeData.head.entityType, caseInsensitiveAttributeData.head.name, testContext)
           .futureValue
           .attributes
-        exemplarAttributeNames.size shouldBe allAttributes.size
-        allAttributes.keys should contain theSameElementsAs exemplarAttributeNames
+        allAttributes.keys.map(AttributeName.toDelimitedName) should contain theSameElementsAs exemplarAttributeNames
       }
 
       "should return all attribute names when listing entities" in withTestDataServices { services =>
@@ -787,11 +785,11 @@ class CaseSensitivitySpec
 
             // verify an attribute is deleted
             allAttributes.size shouldBe exemplarAttributeNames.size - 1
-            allAttributes shouldNot contain(toDelimitedName(attributeNameToDelete))
+            allAttributes shouldNot contain(attributeNameToDelete)
 
             // verify the correct attributes remain
             val remainingAttributeNames = exemplarAttributeNames.toSet - toDelimitedName(attributeNameToDelete)
-            allAttributes should contain theSameElementsAs remainingAttributeNames
+            allAttributes.map(AttributeName.toDelimitedName) should contain theSameElementsAs remainingAttributeNames
         }
       }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.entities.local
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.scaladsl.{Sink, Source}
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.client.model.{ToolInputParameter, ValueType}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.{
@@ -48,18 +48,18 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
   implicit val actorSystem: ActorSystem = ActorSystem() // needed for stream materialization
 
-  val testConf = ConfigFactory.load()
+  val testConf: Config = ConfigFactory.load()
 
   // ===================================================================================================================
   // exemplar data used in multiple tests
   // ===================================================================================================================
 
-  val exemplarTypes = Set("cat", "Cat", "CAT", "dog", "rat")
+  val exemplarTypes: Set[ShardId] = Set("cat", "Cat", "CAT", "dog", "rat")
   val testWorkspace = new EmptyWorkspace
-  val fooAttribute = AttributeName.withDefaultNS("foo")
+  val fooAttribute: AttributeName = AttributeName.withDefaultNS("foo")
 
   // create three entities for each type in our list, using unique names for each entity.
-  val exemplarData = exemplarTypes.toSeq.zipWithIndex flatMap { case (typeName, index) =>
+  val exemplarData: Seq[Entity] = exemplarTypes.toSeq.zipWithIndex flatMap { case (typeName, index) =>
     Seq(
       Entity(s"$typeName-$index-001", typeName, Map(fooAttribute -> AttributeString(s"$typeName-001"))),
       Entity(s"$typeName-$index-002", typeName, Map(fooAttribute -> AttributeString(s"$typeName-002"))),
@@ -68,7 +68,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
   }
 
   // create three entities for each type in our list, reusing names across entity types.
-  val exemplarDataWithCommonNames = exemplarTypes flatMap { typeName =>
+  val exemplarDataWithCommonNames: Set[Entity] = exemplarTypes flatMap { typeName =>
     Seq(
       Entity(s"001", typeName, Map(fooAttribute -> AttributeString(s"$typeName-001"))),
       Entity(s"002", typeName, Map(fooAttribute -> AttributeString(s"$typeName-002"))),
@@ -81,8 +81,8 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
       AttributeName(namespace, name) -> AttributeString(s"$namespace:$name-bar")
     )
   }.toMap
-  val exemplarAttributeNames = exemplarAttributesMap.keys.map(toDelimitedName)
-  val caseInsensitiveAttributeData = Seq(Entity("005", "cat", exemplarAttributesMap))
+  val exemplarAttributeNames: Iterable[ShardId] = exemplarAttributesMap.keys.map(toDelimitedName)
+  val caseInsensitiveAttributeData: Seq[Entity] = Seq(Entity("005", "cat", exemplarAttributesMap))
 
   // ===================================================================================================================
   // tests
@@ -103,7 +103,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
                                                  "metricsBaseName"
           )
           // get metadata
-          val metadata = provider.entityTypeMetadata(false, testContext).futureValue
+          val metadata = provider.entityTypeMetadata(useCache = false, testContext).futureValue
           metadata.keySet shouldBe exemplarTypes
         }
 
@@ -141,7 +141,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           } else {
             lastChar.toLower
           }
-          val newName = (newLastChar + typeUnderTest.reverse.tail).reverse
+          val newName = (newLastChar.toString + typeUnderTest.reverse.tail).reverse
 
           s"should only rename target type [$typeUnderTest] -> [$newName]" in withTestDataServices { services =>
             // save exemplar data
@@ -255,6 +255,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
                                             FilterOperators.And,
                                             WorkspaceFieldSpecs(None)
             )
+            // noinspection ScalaDeprecation
             val queryResponse = provider.queryEntities(typeUnderTest, queryCriteria).futureValue
             // extract distinct entity types from results
             val typesFromResults = queryResponse.results.map(_.entityType).distinct
@@ -618,7 +619,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
                                                "metricsBaseName"
         )
         // get metadata
-        val metadata = provider.entityTypeMetadata(false, testContext).futureValue
+        val metadata = provider.entityTypeMetadata(useCache = false, testContext).futureValue
         metadata("cat").attributeNames.size shouldEqual exemplarAttributeNames.size
         metadata("cat").attributeNames should contain theSameElementsAs exemplarAttributeNames
       }
@@ -637,7 +638,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
                                                testConf.getDuration("entities.queryTimeout"),
                                                "metricsBaseName"
         )
-        provider.entityTypeMetadata(true, testContext).futureValue
+        provider.entityTypeMetadata(useCache = true, testContext).futureValue
 
         // cache is now populated
         assert(runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)).isDefined)
@@ -661,6 +662,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
         // query all entities
         val entityQueryParameters = EntityQuery(1, 10, "name", SortDirections.Ascending, None)
+        // noinspection ScalaDeprecation
         val queriedEntities = provider.queryEntities("cat", entityQueryParameters).futureValue
 
         // verify all attributes are returned
@@ -858,7 +860,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         // make sure all attributes are created
         exemplarAttributeNames.size should equal(entity.attributes.size)
         exemplarAttributesMap.keys.foreach { attr =>
-          entity.attributes.get(attr).get shouldBe AttributeString(s"${toDelimitedName(attr)}: new-attribute")
+          entity.attributes(attr) shouldBe AttributeString(s"${toDelimitedName(attr)}: new-attribute")
         }
       }
 


### PR DESCRIPTION
Ticket: CORE-650

* Refactor `CaseSensivitySpec` to use Quicksilver
* move queries away from `ENTITY_KEYS` to use `ENTITY` instead; this avoids any case-sensitivity issues with `ENTITY_KEYS` (this helps with CORE-618)
* add a case-sensitive character set and collation to the metadata query that calculates attribute names

The biggest problem we had was the third bullet above: the `listEntityKeysViaEntity` methods ignored case on attribute names.

in my example workspace, here is the before/after of the entity type metadata response:

### Before
```json
{
  "MyType": {
    "attributeNames": [
      "CASE",
      "notes"
    ],
    "count": 3,
    "idName": "MyType_id"
  },
  "nametest": {
    "attributeNames": [
      "foo"
    ],
    "count": 1,
    "idName": "nametest_id"
  },
  "program": {
    "attributeNames": [
      "myNewColumn",
      "program_name"
    ],
    "count": 1,
    "idName": "program_id"
  }
}
```

### After
 ```json
{
  "MyType": {
    "attributeNames": [
      "CASE",
      "notes"
    ],
    "count": 2,
    "idName": "MyType_id"
  },
  "mytype": {
    "attributeNames": [
      "CASE",
      "case",
      "notes"
    ],
    "count": 1,
    "idName": "mytype_id"
  },
  "nametest": {
    "attributeNames": [
      "foo"
    ],
    "count": 1,
    "idName": "nametest_id"
  },
  "program": {
    "attributeNames": [
      "myNewColumn",
      "program_name"
    ],
    "count": 1,
    "idName": "program_id"
  }
}
``` 


