### PR TITLE
CORE-639: update sam-client, which updates okio

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -132,7 +132,7 @@ object Dependencies {
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.593.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.150-SNAPSHOT")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "0.1.23-SNAPSHOT" classifier "plain"))
-  val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.407")
+  val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.415")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-2e87300"
   val policyService = clientLibExclusions("bio.terra" % "terra-policy-client" % "1.0.23-SNAPSHOT")
 


### PR DESCRIPTION
Ticket: CORE-639

Updates sam-client to latest, which updates the transitive dependency `okio`.

Here's the output of `sbt dependencyBrowseTree` showing the okio update:
<img width="688" height="817" alt="Screenshot 2025-08-05 at 1 17 14 PM" src="https://github.com/user-attachments/assets/9e093709-a52b-4239-94a8-fd336c0607c1" />
