### PR TITLE
CORE-638: update TCL, which updates protobuf-java

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -131,7 +131,7 @@ object Dependencies {
 
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.593.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.150-SNAPSHOT")
-  val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "0.1.23-SNAPSHOT" classifier "plain"))
+  val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "1.1.42-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.415")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-2e87300"
   val policyService = clientLibExclusions("bio.terra" % "terra-policy-client" % "1.0.23-SNAPSHOT")


### PR DESCRIPTION
Ticket: CORE-638

Update `terra-common-lib`, which updates its transitive dependency `protobuf-java` from 3.25.3 to 4.29.3

Here's the output of sbt dependencyBrowseTree showing the protobuf-java update:

<img width="774" height="823" alt="Screenshot 2025-08-05 at 2 54 28 PM" src="https://github.com/user-attachments/assets/0140f575-9263-4de5-af4b-1c5debd3fafa" />


