### PR TITLE
CORE-631: serializable transaction for writing submissions

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -497,40 +497,42 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     // This is why it's important to attach the outputs before updating the status -- if you update the status to Successful first, and the attach
     // outputs fails, we'll stop querying for the workflow status and never attach the outputs.
     datasource
-      .inTransactionWithAttrTempTable { dataAccess =>
-        (execServiceOutputsOption match {
-          case Some(execServiceOutputs) =>
-            // this workflow has Cromwell outputs. Persist those outputs.
-            handleOutputs(Seq((workflowRec, execServiceOutputs)), dataAccess, tracingContext)
-          case None => DBIO.successful(())
-        }).flatMap { _ =>
-          for {
-            // refetch the workflow record; this ensures that 1) its record version is up to date, and 2) that we can
-            // check its status to see if handleOutputs marked it as failed
-            currentRec <- dataAccess.workflowQuery.findWorkflowById(workflowRec.id).result.head
-            // No need to update statuses for any workflows that are in terminal statuses.
-            // Doing so would potentially overwrite them with the execution service status if they'd been marked as failed by handleOutputs.
-            doRecordUpdate = !WorkflowStatuses.terminalStatuses.contains(WorkflowStatuses.withName(currentRec.status))
-            numRowsUpdated <-
-              if (doRecordUpdate) {
-                for {
-                  updateResult <-
-                    if (config.enableCostEstimatesForAllWorkflows || perWorkflowCostCap.isDefined) {
-                      dataAccess.workflowQuery.updateStatusAndCost(currentRec,
-                                                                   WorkflowStatuses.withName(workflowRec.status),
-                                                                   workflowRec.cost.getOrElse(BigDecimal(0))
-                      )
-                    } else {
-                      dataAccess.workflowQuery.updateStatus(currentRec, WorkflowStatuses.withName(workflowRec.status))
-                    }
-                  _ = logger.info(
-                    s"workflow ${externalId(currentRec)} status change ${currentRec.status} -> ${workflowRec.status} in submission ${submissionId}"
-                  )
-                } yield updateResult
-              } else DBIO.successful(0)
-          } yield numRowsUpdated
-        }
-      }
+      .inTransactionWithAttrTempTable(
+        dataAccess =>
+          (execServiceOutputsOption match {
+            case Some(execServiceOutputs) =>
+              // this workflow has Cromwell outputs. Persist those outputs.
+              handleOutputs(Seq((workflowRec, execServiceOutputs)), dataAccess, tracingContext)
+            case None => DBIO.successful(())
+          }).flatMap { _ =>
+            for {
+              // refetch the workflow record; this ensures that 1) its record version is up to date, and 2) that we can
+              // check its status to see if handleOutputs marked it as failed
+              currentRec <- dataAccess.workflowQuery.findWorkflowById(workflowRec.id).result.head
+              // No need to update statuses for any workflows that are in terminal statuses.
+              // Doing so would potentially overwrite them with the execution service status if they'd been marked as failed by handleOutputs.
+              doRecordUpdate = !WorkflowStatuses.terminalStatuses.contains(WorkflowStatuses.withName(currentRec.status))
+              numRowsUpdated <-
+                if (doRecordUpdate) {
+                  for {
+                    updateResult <-
+                      if (config.enableCostEstimatesForAllWorkflows || perWorkflowCostCap.isDefined) {
+                        dataAccess.workflowQuery.updateStatusAndCost(currentRec,
+                                                                     WorkflowStatuses.withName(workflowRec.status),
+                                                                     workflowRec.cost.getOrElse(BigDecimal(0))
+                        )
+                      } else {
+                        dataAccess.workflowQuery.updateStatus(currentRec, WorkflowStatuses.withName(workflowRec.status))
+                      }
+                    _ = logger.info(
+                      s"workflow ${externalId(currentRec)} status change ${currentRec.status} -> ${workflowRec.status} in submission ${submissionId}"
+                    )
+                  } yield updateResult
+                } else DBIO.successful(0)
+            } yield numRowsUpdated
+          },
+        isolationLevel = _root_.slick.jdbc.TransactionIsolation.Serializable
+      )
       .recoverWith {
         // fatal error writing outputs for this workflow. Mark it as failed.
         case fatal: RawlsFatalExceptionWithErrorReport =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -2315,16 +2315,10 @@ class SubmissionMonitorSpec(_system: ActorSystem)
 
     withWorkspaceContext(manySubmissionsTestData.workspace) { ctx =>
       val indiv1 = runAndWait(
-        compactEntityQuery.getEntity(ctx.workspaceIdAsUUID,
-                                     legacyTestData.indiv1.entityType,
-                                     legacyTestData.indiv1.name
-        )
+        compactEntityQuery.getEntity(ctx.workspaceIdAsUUID, testData.indiv1.entityType, testData.indiv1.name)
       ).get.toEntity
       val indiv2 = runAndWait(
-        compactEntityQuery.getEntity(ctx.workspaceIdAsUUID,
-                                     legacyTestData.indiv2.entityType,
-                                     legacyTestData.indiv2.name
-        )
+        compactEntityQuery.getEntity(ctx.workspaceIdAsUUID, testData.indiv2.entityType, testData.indiv2.name)
       ).get.toEntity
 
       // calculate the attribute keys for indiv1 and indiv2
@@ -2346,18 +2340,16 @@ class SubmissionMonitorSpec(_system: ActorSystem)
 
     val (submissions, methodConfigs) = (1 to numSubmissions).map { subNumber =>
       val methodConfig =
-        legacyTestData.methodConfigEntityUpdate.copy(name = s"this.sub_$subNumber",
-                                                     outputs = Map("o1" -> AttributeString(s"this.sub_$subNumber"))
+        testData.methodConfigEntityUpdate.copy(name = s"this.sub_$subNumber",
+                                               outputs = Map("o1" -> AttributeString(s"this.sub_$subNumber"))
         )
       val testSub = createTestSubmission(
-        legacyTestData.workspace,
+        testData.workspace,
         methodConfig,
-        legacyTestData.indiv1,
-        WorkbenchEmail(legacyTestData.userOwner.userEmail.value),
-        Seq(legacyTestData.indiv1, legacyTestData.indiv2),
-        Map(legacyTestData.indiv1 -> legacyTestData.inputResolutions,
-            legacyTestData.indiv2 -> legacyTestData.inputResolutions
-        ),
+        testData.indiv1,
+        WorkbenchEmail(testData.userOwner.userEmail.value),
+        Seq(testData.indiv1, testData.indiv2),
+        Map(testData.indiv1 -> testData.inputResolutions, testData.indiv2 -> testData.inputResolutions),
         Seq(),
         Map()
       )
@@ -2372,26 +2364,26 @@ class SubmissionMonitorSpec(_system: ActorSystem)
             compactEntityQuery.batchWriteEntities(
               ctx.workspaceIdAsUUID,
               Seq(
-                legacyTestData.aliquot1,
-                legacyTestData.aliquot2,
-                legacyTestData.sample1,
-                legacyTestData.sample2,
-                legacyTestData.sample3,
-                legacyTestData.sample4,
-                legacyTestData.sample5,
-                legacyTestData.sample6,
-                legacyTestData.sample7,
-                legacyTestData.sample8,
-                legacyTestData.pair1,
-                legacyTestData.pair2,
-                legacyTestData.ps1,
-                legacyTestData.sset1,
-                legacyTestData.sset2,
-                legacyTestData.sset3,
-                legacyTestData.sset4,
-                legacyTestData.sset_empty,
-                legacyTestData.indiv1,
-                legacyTestData.indiv2
+                testData.aliquot1,
+                testData.aliquot2,
+                testData.sample1,
+                testData.sample2,
+                testData.sample3,
+                testData.sample4,
+                testData.sample5,
+                testData.sample6,
+                testData.sample7,
+                testData.sample8,
+                testData.pair1,
+                testData.pair2,
+                testData.ps1,
+                testData.sset1,
+                testData.sset2,
+                testData.sset3,
+                testData.sset4,
+                testData.sset_empty,
+                testData.indiv1,
+                testData.indiv2
               ),
               insertOnly = false
             ),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -8,7 +8,7 @@ import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
 import org.broadinstitute.dsde.rawls.coordination.{DataSourceAccess, UncoordinatedDataSourceAccess}
 import org.broadinstitute.dsde.rawls.dataaccess._
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{TestDriverComponent, WorkflowRecord}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{SubmissionRecord, TestDriverComponent, WorkflowRecord}
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.expressions.{BoundOutputExpression, OutputExpression}
 import org.broadinstitute.dsde.rawls.jobexec.SubmissionMonitorActor.{
@@ -28,6 +28,7 @@ import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{doReturn, never, spy, verify}
+import org.scalatest.Assertions._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -2280,25 +2281,10 @@ class SubmissionMonitorSpec(_system: ActorSystem)
       }
   }
 
-  // TODO CORE-631 Switch this test to quicksilver (by updating ManySubmissionsTestData and removing the use of entityServiceConstructorWithoutSpy)
   val manySubmissionsTestData = new ManySubmissionsTestData
   it should "attach outputs and not deadlock with multiple submissions all updating the same entity at once" in withCustomTestDatabase(
     manySubmissionsTestData
   ) { dataSource: SlickDataSource =>
-    val entityServiceConstructorWithoutSpy = EntityService.constructor(
-      slickDataSource,
-      mockSamDAO,
-      workbenchMetricBaseName,
-      EntityManager.defaultEntityManager(
-        slickDataSource,
-        workspaceSettingRepository, // Use the original repository, not the spy
-        false,
-        java.time.Duration.ofMinutes(2),
-        workbenchMetricBaseName
-      ),
-      1000
-    ) _
-
     val submissions = manySubmissionsTestData.submissions
     val numSubmissions = submissions.length
     submissions.foreach(sub =>
@@ -2306,17 +2292,18 @@ class SubmissionMonitorSpec(_system: ActorSystem)
         dataSource,
         sub,
         manySubmissionsTestData.wsName,
-        new SubmissionTestExecutionServiceDAO(WorkflowStatuses.Succeeded.toString),
-        entityServiceConstructor = entityServiceConstructorWithoutSpy // Pass the new constructor
+        new SubmissionTestExecutionServiceDAO(WorkflowStatuses.Succeeded.toString)
       )
     )
 
     // they're all being monitored. they should all complete just fine, without deadlocking forever or otherwise barfing
     awaitCond(
       {
-        val submissionList = runAndWait(DBIO.sequence(submissions map { sub: Submission =>
-          submissionQuery.findById(UUID.fromString(sub.submissionId)).result
-        })).flatten
+        val submissionList: Seq[SubmissionRecord] =
+          runAndWait[Seq[Seq[SubmissionRecord]]](DBIO.sequence(submissions map { sub: Submission =>
+            submissionQuery.findById(UUID.fromString(sub.submissionId)).result
+          })).flatten
+
         submissionList.forall(_.status == SubmissionStatuses.Done.toString) && submissionList.length == numSubmissions
       },
       max = 60 seconds,
@@ -2328,14 +2315,28 @@ class SubmissionMonitorSpec(_system: ActorSystem)
 
     withWorkspaceContext(manySubmissionsTestData.workspace) { ctx =>
       val indiv1 = runAndWait(
-        entityQuery.get(ctx, legacyTestData.indiv1.entityType, legacyTestData.indiv1.name)
-      ).get
+        compactEntityQuery.getEntity(ctx.workspaceIdAsUUID,
+                                     legacyTestData.indiv1.entityType,
+                                     legacyTestData.indiv1.name
+        )
+      ).get.toEntity
       val indiv2 = runAndWait(
-        entityQuery.get(ctx, legacyTestData.indiv2.entityType, legacyTestData.indiv2.name)
-      ).get
+        compactEntityQuery.getEntity(ctx.workspaceIdAsUUID,
+                                     legacyTestData.indiv2.entityType,
+                                     legacyTestData.indiv2.name
+        )
+      ).get.toEntity
 
-      indiv1.attributes.keys.filter(an => an.name.startsWith("sub_")) should contain theSameElementsAs subKeys
-      indiv2.attributes.keys.filter(an => an.name.startsWith("sub_")) should contain theSameElementsAs subKeys
+      // calculate the attribute keys for indiv1 and indiv2
+      val keys1 = indiv1.attributes.keys.filter(an => an.name.startsWith("sub_"))
+      val keys2 = indiv2.attributes.keys.filter(an => an.name.startsWith("sub_"))
+
+      withClue(s"indiv1 is missing keys: ${keys1.size} vs ${subKeys.size} ") {
+        keys1 should contain theSameElementsAs subKeys
+      }
+      withClue(s"indiv2 is missing keys: ${keys2.size} vs ${subKeys.size} ") {
+        keys2 should contain theSameElementsAs subKeys
+      }
     }
   }
 
@@ -2368,8 +2369,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
       super.save() flatMap { _ =>
         withWorkspaceContext(workspace) { ctx =>
           DBIO.seq(
-            entityQuery.save(
-              ctx,
+            compactEntityQuery.batchWriteEntities(
+              ctx.workspaceIdAsUUID,
               Seq(
                 legacyTestData.aliquot1,
                 legacyTestData.aliquot2,
@@ -2391,7 +2392,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
                 legacyTestData.sset_empty,
                 legacyTestData.indiv1,
                 legacyTestData.indiv2
-              )
+              ),
+              insertOnly = false
             ),
             DBIO.sequence(methodConfigs.map(m => methodConfigurationQuery.create(ctx, m)).toSeq),
             DBIO.sequence(submissions.map(s => submissionQuery.create(ctx, s)).toSeq),


### PR DESCRIPTION
Ticket: CORE-631

In the SubmissionMonitorActor, when calculating and saving entity outputs, use a `Serializable` transaction. 

Before this PR, it used `RepeatableRead` and the end result was that, under heavy concurrency, updates would overwrite each other.

This wasn't a problem in the legacy implementation because the legacy implementation is much heavier and includes a lot of logic to retrieve the entity being updated instead of trusting what the caller sent in.

I am open to feedback on this: what would be better? Should we make the `saveWorkflowOutputEntities` implementation heavier and continue to use `RepeatableRead`? Or use `Serializable` and leave the implementation slimmer?