### PR TITLE
[CORE-647] recognize "name" as id column

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -492,7 +492,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
                     if (
                       attributeName == AttributeName.withDefaultNS(
                         record.entityType + Attributable.entityIdAttributeSuffix
-                      )
+                      ) || attributeName == AttributeName.withDefaultNS(nameReservedAttribute)
                     ) {
                       Seq(AttributeString(record.name))
                     } else {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -3,32 +3,16 @@ package org.broadinstitute.dsde.rawls.expressions
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadAction
-import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{
-  EntityName,
-  ExpressionAndResult,
-  LookupExpression
-}
-import org.broadinstitute.dsde.rawls.entities.base.{
-  ExpressionEvaluationContext,
-  ExpressionEvaluationSupport,
-  InputExpressionReassembler
-}
+import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{EntityName, ExpressionAndResult, LookupExpression}
+import org.broadinstitute.dsde.rawls.entities.base.{ExpressionEvaluationContext, ExpressionEvaluationSupport, InputExpressionReassembler}
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
 import org.broadinstitute.dsde.rawls.expressions.parser.antlr.{AntlrTerraExpressionParser, CompactEvaluateVisitor}
 import org.broadinstitute.dsde.rawls.expressions.parser.antlr.CompactEvaluateVisitor.ExpressionLookup
 import org.broadinstitute.dsde.rawls.expressions.parser.antlr.TerraExpressionParser.RootContext
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
-import org.broadinstitute.dsde.rawls.model.{
-  Attributable,
-  AttributeName,
-  AttributeString,
-  AttributeValue,
-  AttributeValueList,
-  ErrorReport,
-  SubmissionValidationEntityInputs,
-  SubmissionValidationValue
-}
+import org.broadinstitute.dsde.rawls.model.Attributable.nameReservedAttribute
+import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeName, AttributeString, AttributeValue, AttributeValueList, ErrorReport, SubmissionValidationEntityInputs, SubmissionValidationValue}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
 import slick.dbio.DBIO
 
@@ -467,7 +451,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
               // Group all results under the original entityName since we want results grouped by the starting entity type
               val allAttrs: Seq[AttributeValue] = entityRecords.values.flatten.toSeq.flatMap { record =>
                 if (
-                  attributeName == AttributeName.withDefaultNS(record.entityType + Attributable.entityIdAttributeSuffix)
+                  attributeName == AttributeName.withDefaultNS(record.entityType + Attributable.entityIdAttributeSuffix) || attributeName == AttributeName.withDefaultNS(nameReservedAttribute)
                 ) {
                   Seq(AttributeString(record.name))
                 } else {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -3,8 +3,16 @@ package org.broadinstitute.dsde.rawls.expressions
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadAction
-import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{EntityName, ExpressionAndResult, LookupExpression}
-import org.broadinstitute.dsde.rawls.entities.base.{ExpressionEvaluationContext, ExpressionEvaluationSupport, InputExpressionReassembler}
+import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{
+  EntityName,
+  ExpressionAndResult,
+  LookupExpression
+}
+import org.broadinstitute.dsde.rawls.entities.base.{
+  ExpressionEvaluationContext,
+  ExpressionEvaluationSupport,
+  InputExpressionReassembler
+}
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
 import org.broadinstitute.dsde.rawls.expressions.parser.antlr.{AntlrTerraExpressionParser, CompactEvaluateVisitor}
 import org.broadinstitute.dsde.rawls.expressions.parser.antlr.CompactEvaluateVisitor.ExpressionLookup
@@ -12,7 +20,16 @@ import org.broadinstitute.dsde.rawls.expressions.parser.antlr.TerraExpressionPar
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.model.Attributable.nameReservedAttribute
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeName, AttributeString, AttributeValue, AttributeValueList, ErrorReport, SubmissionValidationEntityInputs, SubmissionValidationValue}
+import org.broadinstitute.dsde.rawls.model.{
+  Attributable,
+  AttributeName,
+  AttributeString,
+  AttributeValue,
+  AttributeValueList,
+  ErrorReport,
+  SubmissionValidationEntityInputs,
+  SubmissionValidationValue
+}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
 import slick.dbio.DBIO
 
@@ -451,7 +468,9 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
               // Group all results under the original entityName since we want results grouped by the starting entity type
               val allAttrs: Seq[AttributeValue] = entityRecords.values.flatten.toSeq.flatMap { record =>
                 if (
-                  attributeName == AttributeName.withDefaultNS(record.entityType + Attributable.entityIdAttributeSuffix) || attributeName == AttributeName.withDefaultNS(nameReservedAttribute)
+                  attributeName == AttributeName.withDefaultNS(
+                    record.entityType + Attributable.entityIdAttributeSuffix
+                  ) || attributeName == AttributeName.withDefaultNS(nameReservedAttribute)
                 ) {
                   Seq(AttributeString(record.name))
                 } else {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -1036,7 +1036,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       Some("Sample"),
       prerequisites = Some(Map.empty[String, AttributeString]),
       inputs =
-        Map("three_step.cgrep.pattern" -> AttributeString("this.type")), // TODO CORE-647 Change back to this.name
+        Map("three_step.cgrep.pattern" -> AttributeString("this.name")),
       outputs = Map.empty,
       AgoraMethod("dsde", "three_step", 1)
     )
@@ -1073,7 +1073,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       Some("Sample"),
       prerequisites = Some(Map.empty[String, AttributeString]),
       inputs =
-        Map("three_step.cgrep.pattern" -> AttributeString("this.type")), // TODO CORE-647 Change back to this.name
+        Map("three_step.cgrep.pattern" -> AttributeString("this.name")),
       outputs = Map("three_step.cgrep.count" -> AttributeString("")),
       AgoraMethod("dsde", "three_step", 1)
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -1035,8 +1035,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       "GoodMethodConfig",
       Some("Sample"),
       prerequisites = Some(Map.empty[String, AttributeString]),
-      inputs =
-        Map("three_step.cgrep.pattern" -> AttributeString("this.name")),
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this.name")),
       outputs = Map.empty,
       AgoraMethod("dsde", "three_step", 1)
     )
@@ -1072,8 +1071,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       "EmptyOutputsMethodConfig",
       Some("Sample"),
       prerequisites = Some(Map.empty[String, AttributeString]),
-      inputs =
-        Map("three_step.cgrep.pattern" -> AttributeString("this.name")),
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this.name")),
       outputs = Map("three_step.cgrep.count" -> AttributeString("")),
       AgoraMethod("dsde", "three_step", 1)
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
@@ -1493,11 +1493,28 @@ class CompactExpressionEvaluatorSpec
         .executeQueryPlan(workspace.workspaceIdAsUUID, "sampleset", "daSampleSet", "sampleset", queryPlan)
     )
 
-    result.size shouldBe 2
-    //  type ExpressionAndResult = (LookupExpression, Map[EntityName, Try[Iterable[AttributeValue]]])
     result should contain theSameElementsAs Seq(
       (expression1, Map("daSampleSet" -> Success(Seq(AttributeString("sampleGood"), AttributeString("sampleGood2"))))),
       (expression2, Map("daSampleSet" -> Success(Seq(AttributeString("sampleGood"), AttributeString("sampleGood2")))))
+    )
+
+    val queryPlan2 = QueryPlan(List(), Map(expression1 -> Set("name"), expression2 -> Set("Sample_id")))
+
+    when(
+      mockQueries.getEntity(any(), any(), any())
+    )
+      .thenReturn(
+        DBIO.successful(
+          Some(sampleGoodAsCER)
+        )
+      )
+    val result2 = runAndWait(
+      compactExpressionEvaluator
+        .executeQueryPlan(workspace.workspaceIdAsUUID, "sample", sampleGood.name, "sample", queryPlan2)
+    )
+    result2 should contain theSameElementsAs Seq(
+      (expression1, Map(sampleGood.name -> Success(Seq(AttributeString("sampleGood"))))),
+      (expression2, Map(sampleGood.name -> Success(Seq(AttributeString("sampleGood")))))
     )
 
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
@@ -1475,4 +1475,31 @@ class CompactExpressionEvaluatorSpec
 
   }
 
+  it should "recognize the id column" in withConfigData {
+    val expression1 = "this.name"
+    val expression2 = "this.sample_id"
+    val queryPlan = QueryPlan(List("samples"), Map(expression1 -> Set("name"), expression2 -> Set("Sample_id")))
+
+    when(
+      mockQueries.queryRelatedRecordsWithRelationChain(any(), any(), any(), any())
+    )
+      .thenReturn(
+        DBIO.successful(
+          Map(sampleSet.name -> Seq(sampleGoodAsCER, sampleGood2AsCER))
+        )
+      )
+    val result = runAndWait(
+      compactExpressionEvaluator
+        .executeQueryPlan(workspace.workspaceIdAsUUID, "sampleset", "daSampleSet", "sampleset", queryPlan)
+    )
+
+    result.size shouldBe 2
+    //  type ExpressionAndResult = (LookupExpression, Map[EntityName, Try[Iterable[AttributeValue]]])
+    result should contain theSameElementsAs Seq(
+      (expression1, Map("daSampleSet" -> Success(Seq(AttributeString("sampleGood"), AttributeString("sampleGood2"))))),
+      (expression2, Map("daSampleSet" -> Success(Seq(AttributeString("sampleGood"), AttributeString("sampleGood2")))))
+    )
+
+  }
+
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-647
<Put notes here to help reviewer understand this PR>

---
Checks `name` as well as `<entitytype>_id` in expression evaluation and adds a test.

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
