### PR TITLE
CORE-652: batch upsert validation

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -84,22 +84,23 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
     allowInsert: Boolean
   ): Flow[Seq[EntityUpdateDefinition], ReadWriteAction[Int], _] =
     Flow[Seq[EntityUpdateDefinition]].map { updates =>
-      // validate entity type, entity name, and attribute names
-      updates foreach { update =>
+      // Extract the entity type and name from each update
+      val updateIdentifiers = updates.map(update => EntityPointer(update.entityType, update.name))
+      val uniqueUpdateIdentifiers = updateIdentifiers.toSet
+
+      // validate entity type and entity name
+      uniqueUpdateIdentifiers foreach { update =>
         EntityUtils.validateEntityType(update.entityType)
-        EntityUtils.validateEntityName(update.name)
+        EntityUtils.validateEntityName(update.entityName)
       }
 
+      // validate the attribute names in all operations
       val attributeNamesToCheck: Seq[AttributeName] = for {
         update <- updates
         operation <- update.operations
       } yield operation.name
       // noop function to validate attribute names
       withAttributeNamespaceCheck(attributeNamesToCheck) {}
-
-      // Extract the entity type and name from each update
-      val updateIdentifiers = updates.map(update => EntityPointer(update.entityType, update.name))
-      val uniqueUpdateIdentifiers = updateIdentifiers.toSet
 
       for {
         // Query the database for any pre-existing entities being updated

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.{
   ReadWriteAction,
   RefMapping
 }
+import org.broadinstitute.dsde.rawls.entities.EntityUtils
 import org.broadinstitute.dsde.rawls.entities.compact.{
   CompactEntityProvider,
   CompactEntityProviderConfig,
@@ -16,7 +17,7 @@ import org.broadinstitute.dsde.rawls.entities.compact.{
 }
 import org.broadinstitute.dsde.rawls.entities.exceptions.{EntityNotFoundException, EntityReferenceNotFoundException}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
-import org.broadinstitute.dsde.rawls.model.{Entity, EntityPointer, RawlsRequestContext}
+import org.broadinstitute.dsde.rawls.model.{AttributeName, Entity, EntityPointer, RawlsRequestContext}
 import org.broadinstitute.dsde.rawls.util.AttributeSupport
 import slick.dbio.DBIO
 
@@ -83,6 +84,19 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
     allowInsert: Boolean
   ): Flow[Seq[EntityUpdateDefinition], ReadWriteAction[Int], _] =
     Flow[Seq[EntityUpdateDefinition]].map { updates =>
+      // validate entity type, entity name, and attribute names
+      updates foreach { update =>
+        EntityUtils.validateEntityType(update.entityType)
+        EntityUtils.validateEntityName(update.name)
+      }
+
+      val attributeNamesToCheck: Seq[AttributeName] = for {
+        update <- updates
+        operation <- update.operations
+      } yield operation.name
+      // noop function to validate attribute names
+      withAttributeNamespaceCheck(attributeNamesToCheck) {}
+
       // Extract the entity type and name from each update
       val updateIdentifiers = updates.map(update => EntityPointer(update.entityType, update.name))
       val uniqueUpdateIdentifiers = updateIdentifiers.toSet

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -13,6 +13,7 @@ import fs2.concurrent.SignallingRef
 import io.circe.fs2._
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.entities.EntityService
+import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
@@ -492,9 +493,16 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
                 logger.warn(
                   s"upsert batch #$idx for jobId ${jobId.toString} contained errors. The first 100 errors are: $loggedErrors"
                 )
+              case Failure(de: DataEntityException) =>
+                val loggedErrors = de.getMessage
+                logger.warn(
+                  s"upsert batch #$idx for jobId ${jobId.toString} contained errors. The error is: $loggedErrors"
+                )
               case _ => // noop; here for completeness of matching
             }
-            logger.info(s"completed upsert batch #$idx for jobId ${jobId.toString}...")
+            logger.info(
+              s"completed upsert batch #$idx for jobId ${jobId.toString} with ${attempt.getClass.getSimpleName}..."
+            )
             attempt
           }
         }
@@ -512,6 +520,8 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
         case Failure(regrets: RawlsExceptionWithErrorReport) if regrets.errorReport.causes.nonEmpty =>
           regrets.errorReport.causes
         case Failure(regrets: RawlsExceptionWithErrorReport) => Seq(regrets.errorReport)
+        case Failure(de: DataEntityException) =>
+          Seq(RawlsErrorReport(StatusCodes.BadRequest, de.getMessage))
       } flatten
 
       // this could be a LOT of error reports, we don't want to send an enormous packet back to the caller.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -4,8 +4,7 @@ import akka.actor.SupervisorStrategy.{Escalate, Stop}
 import akka.actor._
 import akka.http.scaladsl.model.StatusCodes
 import akka.pattern._
-import akka.stream.scaladsl.{Sink, Source}
-import akka.util.ByteString
+import akka.stream.scaladsl.Source
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.typesafe.scalalogging.LazyLogging
@@ -19,7 +18,6 @@ import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.ImportStatuses.ImportStatus
 import org.broadinstitute.dsde.rawls.model.{
-  Entity,
   ErrorReport => RawlsErrorReport,
   ImportStatuses,
   RawlsRequestContext,
@@ -493,11 +491,12 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
                 logger.warn(
                   s"upsert batch #$idx for jobId ${jobId.toString} contained errors. The first 100 errors are: $loggedErrors"
                 )
-              case Failure(de: DataEntityException) =>
-                val loggedErrors = de.getMessage
+              // CompactEntityProvider will throw a DataEntityException, which gets caught by this Throwable case
+              case Failure(t: Throwable) =>
                 logger.warn(
-                  s"upsert batch #$idx for jobId ${jobId.toString} contained errors. The error is: $loggedErrors"
+                  s"upsert batch #$idx for jobId ${jobId.toString} contained errors. The error is: ${t.getMessage}"
                 )
+
               case _ => // noop; here for completeness of matching
             }
             logger.info(
@@ -521,7 +520,9 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
           regrets.errorReport.causes
         case Failure(regrets: RawlsExceptionWithErrorReport) => Seq(regrets.errorReport)
         case Failure(de: DataEntityException) =>
-          Seq(RawlsErrorReport(StatusCodes.BadRequest, de.getMessage))
+          Seq(RawlsErrorReport(de.code, de.getMessage))
+        case Failure(t: Throwable) =>
+          Seq(RawlsErrorReport(StatusCodes.InternalServerError, t.getMessage))
       } flatten
 
       // this could be a LOT of error reports, we don't want to send an enormous packet back to the caller.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.entities.compact
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.scaladsl.{Sink, Source}
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponentWithFlatSpecAndMatchers
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityNotFoundException}
@@ -366,7 +367,7 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
     metadataBefore shouldBe empty
 
     // perform the batchUpsert
-    intercept[SQLException] {
+    intercept[RawlsExceptionWithErrorReport] {
       Await.result(provider.batchUpsertEntities(Source(updates), defaultRequestContext), atMost)
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -81,11 +81,6 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
       withApiServices(dataSource)(testCode)
     }
 
-  def withLegacyTestDataApiServices[T](testCode: TestApiService => T): T =
-    withLegacyDefaultTestDatabase { dataSource: SlickDataSource =>
-      withApiServices(dataSource)(testCode)
-    }
-
   def this() = this(ActorSystem("AvroUpsertMonitorSpec"))
 
   override def beforeAll(): Unit =
@@ -144,7 +139,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
       Duration.apply(10, TimeUnit.SECONDS)
     )
 
-  def setUp(services: TestApiService, useLegacy: Boolean = false) = {
+  def setUp(services: TestApiService) = {
     setUpPubSub(services)
 
     val workspaceSettingRepository = new WorkspaceSettingRepository(slickDataSource)
@@ -158,7 +153,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
       )
     val mockEntityManager = EntityManager.defaultEntityManager(
       slickDataSource,
-      if (useLegacy) workspaceSettingRepository else spyWorkspaceSettingRepository,
+      spyWorkspaceSettingRepository,
       services.testConf.getBoolean("entityStatisticsCache.enabled"),
       services.testConf.getDuration("entities.queryTimeout"),
       workbenchMetricBaseName
@@ -536,15 +531,14 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
     }
   }
 
-  // TODO CORE-652 Switch this test to quicksilver once the entities are properly validated
-  it should "publish pubsub message to mark import job as Error if upserts result in partial failure" in withLegacyTestDataApiServices {
+  it should "publish pubsub message to mark import job as Error if upserts result in partial failure" in withTestDataApiServices {
     services =>
       val timeout = 30000 milliseconds
       val interval = 250 milliseconds
       val importId1 = UUID.randomUUID()
 
       // add the imports and their statuses to the mock cwdsDAO
-      val mockCwdsDAO = setUp(services, useLegacy = true)
+      val mockCwdsDAO = setUp(services)
       mockCwdsDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
       val successfulBatch = createUpsertOpsList(upsertRange(1000))
@@ -570,7 +564,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
       // Publish message on the request topic
       services.gpsDAO.publishMessages(
         importReadPubSubTopic,
-        List(MessageRequest(importId1.toString, testAttributes(importId1, legacyTestData.workspace.workspaceIdAsUUID)))
+        List(MessageRequest(importId1.toString, testAttributes(importId1)))
       )
 
       // check if correct message was posted on request topic. This will start the upsert attempt.
@@ -593,15 +587,14 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
       }
   }
 
-  // TODO CORE-652 Switch this test to quicksilver once the entities are properly validated
-  it should "bubble up useful error message if upserts result in partial failure" in withLegacyTestDataApiServices {
+  it should "bubble up useful error message if upserts result in partial failure" in withTestDataApiServices {
     services =>
       val timeout = 30000 milliseconds
       val interval = 250 milliseconds
       val importId1 = UUID.randomUUID()
 
       // add the imports and their statuses to the mock cwdsDAO
-      val mockCwdsDAO = setUp(services, useLegacy = true)
+      val mockCwdsDAO = setUp(services)
       mockCwdsDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
       val successfulBatch = createUpsertOpsList(upsertRange(1000))
 
@@ -634,7 +627,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
       // Publish message on the request topic
       services.gpsDAO.publishMessages(
         importReadPubSubTopic,
-        List(MessageRequest(importId1.toString, testAttributes(importId1, legacyTestData.workspace.workspaceIdAsUUID)))
+        List(MessageRequest(importId1.toString, testAttributes(importId1)))
       )
 
       // check if correct message was posted on request topic. This will start the upsert attempt.
@@ -659,15 +652,14 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
       }
   }
 
-  // TODO CORE-652 Switch this test to quicksilver once the entities are properly validated
-  it should "bubble up useful error message if upserts result in complete failure" in withLegacyTestDataApiServices {
+  it should "bubble up useful error message if upserts result in complete failure" in withTestDataApiServices {
     services =>
       val timeout = 30000 milliseconds
       val interval = 250 milliseconds
       val importId1 = UUID.randomUUID()
 
       // add the imports and their statuses to the mock cwdsDAO
-      val mockCwdsDAO = setUp(services, useLegacy = true)
+      val mockCwdsDAO = setUp(services)
       mockCwdsDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
       // failure creates an entity that refers to a non-existent entity
@@ -699,7 +691,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
       // Publish message on the request topic
       services.gpsDAO.publishMessages(
         importReadPubSubTopic,
-        List(MessageRequest(importId1.toString, testAttributes(importId1, legacyTestData.workspace.workspaceIdAsUUID)))
+        List(MessageRequest(importId1.toString, testAttributes(importId1)))
       )
 
       // check if correct message was posted on request topic. This will start the upsert attempt.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -103,8 +103,8 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
   val entityType = "test-type"
   val failImportStatusUUID = UUID.randomUUID()
 
-  def testAttributes(importId: UUID, wsId: UUID = workspaceId): Map[String, String] = Map(
-    "workspaceId" -> wsId.toString,
+  def testAttributes(importId: UUID): Map[String, String] = Map(
+    "workspaceId" -> workspaceId.toString,
     "userEmail" -> userInfo.userEmail.toString,
     "upsertFile" -> s"$bucketName/${importId.toString}",
     "jobId" -> importId.toString

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -646,7 +646,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
           msg
             .attributes("errorMessage")
             .contains(
-              "Successfully updated 1000 entities; 1 updates failed. First 100 failures are: test-type this-entity-does-not-exist not found"
+              "Successfully updated 1000 entities; 1 updates failed."
             )
         })
       }
@@ -712,8 +712,8 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
       }
 
       withClue("Text in the pubsub error message was incorrect:") {
-        errorMsg.attributes("errorMessage") shouldBe
-          "All entities failed to update. There were 1 errors in total. Error messages: test-type this-entity-does-not-exist not found"
+        errorMsg.attributes("errorMessage") should contain
+        "All entities failed to update. There were 1 errors in total."
       }
   }
 


### PR DESCRIPTION
Ticket: CORE-652

* In Quicksilver batchUpsert/batchUpdate, validate the incoming entity type, entity name, and attribute names before attempting to write to the database.
* In the AvroUpsertMonitor (async TSV/snapshot/PFB import), handle the DataEntityExceptions thrown by Quicksilver as well as the RawlsExceptionWithErrorReport thrown by legacy.