### PR TITLE
CORE-650: ignore soft-deleted entities when counting types in metadata

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -990,6 +990,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     val baseSql = sql"""select exists (select 1 from ENTITY
          where workspace_id = $workspaceId
           and entity_type = $entityType
+          and deleted = 0
           and JSON_CONTAINS_PATH(attributes, 'one', """
 
     concatSqlActions(baseSql, containsClause, sql"))")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -499,6 +499,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     sql"""SELECT entity_type, COUNT(*)
       FROM ENTITY
       WHERE workspace_id = $workspaceId
+      AND deleted = 0
       GROUP BY entity_type;""".as[EntityTypeAndCount]
 
   /**

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -1520,6 +1520,29 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     actual should contain theSameElementsAs List(EntityTypeAndCount(entityType1, 2), EntityTypeAndCount(entityType2, 1))
   }
 
+  it should "ignore soft-deleted entities in the count of entities grouped by type" in withMinimalTestDatabase { _ =>
+    // insert an entity with attributes
+    val entityType1 = "entityType1"
+    val entityType2 = "entityType2"
+    val entity1 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity2 = Entity(UUID.randomUUID().toString, entityType2, Map())
+    val entity3 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    val entity4 = Entity(UUID.randomUUID().toString, entityType1, Map())
+    insertAndGet(entity1)
+    insertAndGet(entity2)
+    insertAndGet(entity3)
+    insertAndGet(entity4, minimalTestData.workspace2.workspaceIdAsUUID) // different workspace
+
+    // now soft-delete entity1 and entity2
+    runAndWait(q.batchHide(wsid, Seq(entity1.toPointer, entity2.toPointer)))
+
+    // get the count of entities grouped by type
+    val actual = runAndWait(q.countEntitiesGroupedByType(wsid))
+    // only entity3 should be counted. entity1 and entity2 are soft-deleted, entity4 is in a different workspace
+    actual should contain theSameElementsAs List(EntityTypeAndCount(entityType1, 1))
+
+  }
+
   behavior of "batchHide"
 
   it should "mark the entities as deleted and remove attributes" in withMinimalTestDatabase { _ =>


### PR DESCRIPTION
Ticket: CORE-650

Fixes a regression from #3436: when returning the list of types and their counts from the entity type metadata API, ignore soft-deleted entities.