### PR TITLE
[CORE-640] Improve expression evaluation query

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -708,61 +708,59 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     if (relationChain.isEmpty) {
       DBIO.successful(Map.empty[String, Seq[CompactEntityRecord]])
     } else {
-      // Build the SQL with explicit joins for each relation in the chain
-      // Start with the base entity
-      val sqlBuilder = sql"""
-        SELECT DISTINCT
-          e1.name as rootEntityName,
-          e#${relationChain.length}.id,
-          e#${relationChain.length}.name,
-          e#${relationChain.length}.entity_type,
-          e#${relationChain.length}.workspace_id,
-          e#${relationChain.length}.record_version,
-          e#${relationChain.length}.deleted,
-          e#${relationChain.length}.attributes
-        FROM ENTITY e0
-      """
+      // Start with the root entity
+      val initialEntities = Set(EntityPointer(startingEntityType, startingEntityName))
 
-      // Add joins for each relation in the chain
-      val joinsSql = relationChain.zipWithIndex.foldLeft(sqlBuilder) { case (sql, (relation, idx)) =>
-        val nextIdx = idx + 1
-        concatSqlActions(
-          sql,
-          sql"""
-          JOIN JSON_TABLE(
-            JSON_EXTRACT(e#$idx.attributes, '$$.refs'),
-            '$$[*]' COLUMNS (
-              attributeName#$idx VARCHAR(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.a',
-              entityType#$idx VARCHAR(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.t',
-              entityName#$idx VARCHAR(255) PATH '$$.n'
-            )
-          ) jt#$idx ON jt#$idx.attributeName#$idx = $relation
-          JOIN ENTITY e#$nextIdx ON e#$nextIdx.entity_type = jt#$idx.entityType#$idx
-            AND e#$nextIdx.name = jt#$idx.entityName#$idx
-            AND e#$nextIdx.workspace_id = $workspaceId
-            AND e#$nextIdx.deleted = 0
-          """
-        )
-      }
+      // Traverse each relation step by step
+      relationChain
+        .foldLeft(DBIO.successful(initialEntities): ReadAction[Set[EntityPointer]]) { (entitiesFuture, relation) =>
+          entitiesFuture.flatMap { currentEntities =>
+            if (currentEntities.isEmpty) {
+              DBIO.successful(Set.empty[EntityPointer]): ReadAction[Set[EntityPointer]]
+            } else {
+              traverseOneStep(workspaceId, currentEntities, relation)
+            }
+          }
+        }
+        .flatMap { finalEntityPointers =>
+          // Get the full records for the final entities
+          getEntities(workspaceId, finalEntityPointers).map { entities =>
+            Map(startingEntityName -> entities)
+          }
+        }
+    }
 
-      // Add the WHERE clause for the starting entity
-      val finalSql = concatSqlActions(
-        joinsSql,
+  private def traverseOneStep(
+    workspaceId: UUID,
+    currentEntities: Set[EntityPointer],
+    relation: String
+  ): ReadAction[Set[EntityPointer]] =
+    if (currentEntities.isEmpty) {
+      DBIO.successful(Set.empty[EntityPointer])
+    } else {
+      val typeNameClauses = generateTypeNameSql(currentEntities)
+      val query = concatSqlActions(
         sql"""
-        WHERE e0.workspace_id = $workspaceId
-          AND e0.entity_type = $startingEntityType
-          AND e0.name = $startingEntityName
-          AND e0.deleted = 0
-        """
+    SELECT DISTINCT jt.ref_type, jt.ref_name
+    FROM ENTITY e
+    JOIN JSON_TABLE(
+      e.attributes,
+      '$$.refs[*]' COLUMNS (
+        attr_name VARCHAR(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.a',
+        ref_type VARCHAR(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.t',
+        ref_name VARCHAR(255) PATH '$$.n'
+      )
+    ) jt ON jt.attr_name = ${relation}
+    WHERE e.workspace_id = ${workspaceId}
+      AND e.deleted = 0
+      AND (
+    """,
+        reduceSqlActionsWithDelim(typeNameClauses.toSeq, sql" OR "),
+        sql")"
       )
 
-      case class RootNameAndEntity(rootEntityName: String, entity: CompactEntityRecord)
-      implicit val getRootNameAndEntity: GetResult[RootNameAndEntity] =
-        GetResult(r => RootNameAndEntity(r.<<, CompactEntityRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)))
-
-      finalSql.as[RootNameAndEntity].map { results =>
-        results.groupMap(_.rootEntityName)(_.entity)
-      }
+      // Convert SqlStreamingAction to ReadAction and collect results into a Set
+      query.as[EntityPointer].map(_.toSet)
     }
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -696,7 +696,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * @param startingEntityType  The type of the root entity to start the query from.
    * @param startingEntityName    The name of the root entity to start the query from.
    * @param relationChain   A chain of strings representing the relation columns between entities
-   * @return                 A `ReadAction` that resolves to a map of starting entity name to a Seq[`CompactEntityRecord`]
+   * @return                 A `ReadAction` that resolves to a map of entity name to a Seq[`CompactEntityRecord`]
    *                         that includes all entities found by traversing the specified relationships.
    */
   def queryRelatedRecordsWithRelationChain(
@@ -705,30 +705,64 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     startingEntityName: String,
     relationChain: Seq[String]
   ): ReadAction[Map[String, Seq[CompactEntityRecord]]] =
-    if (relationChain.isEmpty) {
+    if (relationChain.isEmpty) { // The method shouldn't have been called in this case
       DBIO.successful(Map.empty[String, Seq[CompactEntityRecord]])
     } else {
       // Start with the root entity
       val initialEntities = Set(EntityPointer(startingEntityType, startingEntityName))
 
-      // Traverse each relation step by step
-      relationChain
-        .foldLeft(DBIO.successful(initialEntities): ReadAction[Set[EntityPointer]]) { (entitiesFuture, relation) =>
+      // First step: get the first-level entities (these will be our grouping keys)
+      traverseOneStep(workspaceId, initialEntities, relationChain.head).flatMap { firstStepEntities =>
+        if (firstStepEntities.isEmpty) {
+          DBIO.successful(Map.empty[String, Seq[CompactEntityRecord]])
+        } else if (relationChain.length == 1) {
+          // Only one relation - group by first step entities
+          getEntities(workspaceId, firstStepEntities).map { entities =>
+            entities.groupBy(_.name)
+          }
+        } else {
+          // Multiple relations - traverse the rest but track which first-step entity each result came from
+          val remainingChain = relationChain.tail
+          traverseOneStepWithGrouping(workspaceId, firstStepEntities, remainingChain).flatMap { groupedFinalEntities =>
+            // Get full records for all final entities
+            val allFinalEntities = groupedFinalEntities.values.flatten.toSet
+            getEntities(workspaceId, allFinalEntities).map { entities =>
+              val entitiesByPointer = entities.groupBy(e => EntityPointer(e.entityType, e.name))
+
+              // Map each first-step entity to its corresponding final entities
+              groupedFinalEntities.view.mapValues { entityPointers =>
+                entityPointers.flatMap(entitiesByPointer.get).flatten.toSeq
+              }.toMap
+            }
+          }
+        }
+      }
+    }
+
+  private def traverseOneStepWithGrouping(
+    workspaceId: UUID,
+    firstStepEntities: Set[EntityPointer],
+    remainingChain: Seq[String]
+  ): ReadAction[Map[String, Set[EntityPointer]]] = {
+    // For each first-step entity, traverse the remaining relations independently
+    val traversalFutures = firstStepEntities.map { firstEntity =>
+      // Start with just this first entity and traverse the remaining chain
+      remainingChain
+        .foldLeft(DBIO.successful(Set(firstEntity)): ReadAction[Set[EntityPointer]]) { (entitiesFuture, relation) =>
           entitiesFuture.flatMap { currentEntities =>
             if (currentEntities.isEmpty) {
-              DBIO.successful(Set.empty[EntityPointer]): ReadAction[Set[EntityPointer]]
+              DBIO.successful(Set.empty[EntityPointer])
             } else {
               traverseOneStep(workspaceId, currentEntities, relation)
             }
           }
         }
-        .flatMap { finalEntityPointers =>
-          // Get the full records for the final entities
-          getEntities(workspaceId, finalEntityPointers).map { entities =>
-            Map(startingEntityName -> entities)
-          }
-        }
+        .map(finalEntities => firstEntity.entityName -> finalEntities)
     }
+
+    // Convert Set to Seq before calling DBIO.sequence
+    DBIO.sequence(traversalFutures.toSeq).map(_.toMap)
+  }
 
   private def traverseOneStep(
     workspaceId: UUID,
@@ -750,8 +784,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         ref_type VARCHAR(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.t',
         ref_name VARCHAR(255) PATH '$$.n'
       )
-    ) jt ON jt.attr_name = ${relation}
-    WHERE e.workspace_id = ${workspaceId}
+    ) jt ON jt.attr_name = $relation
+    WHERE e.workspace_id = $workspaceId
       AND e.deleted = 0
       AND (
     """,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -12,6 +12,8 @@ import java.util.{Date, UUID}
 import org.broadinstitute.dsde.rawls.model.FilterOperators.FilterOperator
 import org.broadinstitute.dsde.rawls.model.{
   Attributable,
+  AttributeEntityReference,
+  AttributeEntityReferenceList,
   AttributeName,
   AttributeRename,
   Entity,
@@ -772,29 +774,20 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     if (currentEntities.isEmpty) {
       DBIO.successful(Set.empty[EntityPointer])
     } else {
-      val typeNameClauses = generateTypeNameSql(currentEntities)
-      val query = concatSqlActions(
-        sql"""
-    SELECT DISTINCT jt.ref_type, jt.ref_name
-    FROM ENTITY e
-    JOIN JSON_TABLE(
-      e.attributes,
-      '$$.refs[*]' COLUMNS (
-        attr_name VARCHAR(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.a',
-        ref_type VARCHAR(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.t',
-        ref_name VARCHAR(255) PATH '$$.n'
-      )
-    ) jt ON jt.attr_name = $relation
-    WHERE e.workspace_id = $workspaceId
-      AND e.deleted = 0
-      AND (
-    """,
-        reduceSqlActionsWithDelim(typeNameClauses.toSeq, sql" OR "),
-        sql")"
-      )
-
-      // Convert SqlStreamingAction to ReadAction and collect results into a Set
-      query.as[EntityPointer].map(_.toSet)
+      // retrieve the current entities to get their attributes
+      getEntities(workspaceId, currentEntities).flatMap { entities =>
+        // find all references in the specified relation attribute
+        // TODO: should this reuse CompactEntityProvider.findAllReferences ?
+        val references = entities.flatMap { entityRecord =>
+          val attrValue = entityRecord.toEntity.attributes.get(AttributeName.fromDelimitedName(relation))
+          attrValue match {
+            case Some(rel: AttributeEntityReference)      => Seq(rel.toPointer)
+            case Some(rels: AttributeEntityReferenceList) => rels.list.map(_.toPointer)
+            case _                                        => Seq.empty[EntityPointer]
+          }
+        }
+        DBIO.successful(references.toSet)
+      }
     }
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
@@ -38,7 +38,11 @@ case class WorkflowMessageRecord(workflowId: Long, message: String)
 case class WorkflowId(id: Long)
 
 trait WorkflowComponent {
-  this: DriverComponent with EntityComponent with SubmissionComponent with AttributeComponent =>
+  this: DriverComponent
+    with CompactEntityComponent
+    with EntityComponent
+    with SubmissionComponent
+    with AttributeComponent =>
 
   import driver.api._
 
@@ -126,9 +130,9 @@ trait WorkflowComponent {
     )(implicit wfStatusCounter: WorkflowStatus => Option[Counter]): ReadWriteAction[Seq[Workflow]] = {
       def insertWorkflowRecs(submissionId: UUID,
                              workflows: Seq[Workflow],
-                             localEntityRecs: Seq[EntityRecord]
+                             localEntityRecs: Seq[CompactEntityRefRecord]
       ): ReadWriteAction[Map[Option[AttributeEntityReference], WorkflowRecord]] = {
-        val localEntityRecsMap = localEntityRecs.map(e => e.toReference -> e.id).toMap
+        val localEntityRecsMap = localEntityRecs.map(e => e.toAttributeEntityReference -> e.id).toMap
         val recsToInsert = workflows.map { workflow =>
           val entityId = workflow.workflowEntity.flatMap(localEntityRecsMap.get)
           // if entity does not exist locally (i.e. we don't have an id) then workflowEntity must be external
@@ -240,7 +244,9 @@ trait WorkflowComponent {
             DBIO.successful(Seq.empty)
           case None =>
             // externalEntityInfo does not exist: lookup local entities
-            entityQuery.getEntityRecords(workspaceContext.workspaceIdAsUUID, workflows.flatMap(_.workflowEntity).toSet)
+            compactEntityQuery.getEntityRefs(workspaceContext.workspaceIdAsUUID,
+                                             workflows.flatMap(_.workflowEntity).map(_.toPointer).toSet
+            )
         }
 
       for {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -69,7 +69,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
 
   // increase the route timeout slightly for this test as the "large submission" tests sometimes
   // bump up against the default 5 second timeout.
-  implicit override val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(40.seconds)
+  implicit override val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(30.seconds)
 
   def withApiServices[T](dataSource: SlickDataSource, legacy: Boolean = false)(testCode: TestApiService => T): T = {
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -69,7 +69,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
 
   // increase the route timeout slightly for this test as the "large submission" tests sometimes
   // bump up against the default 5 second timeout.
-  implicit override val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(30.seconds)
+  implicit override val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(40.seconds)
 
   def withApiServices[T](dataSource: SlickDataSource, legacy: Boolean = false)(testCode: TestApiService => T): T = {
 
@@ -503,7 +503,6 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
 
   val numSamples = 10000
 
-  // TODO CORE-640 Convert to quicksilver
   it should "create and abort a large submission" in withLargeSubmissionApiServices { services =>
     val wsName = largeSampleTestData.wsName
     val mcName = MethodConfigurationName("no_input", "dsde", wsName)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -96,7 +96,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
 
   def withLargeSubmissionApiServices[T](testCode: TestApiService => T): T =
     withCustomTestDatabase(largeSampleTestData) { dataSource: SlickDataSource =>
-      withApiServices(dataSource, legacy = true) { services =>
+      withApiServices(dataSource) { services =>
         try {
           // Simulate a large submission in the mock Cromwell server by making it return
           // numSamples workflows for submission requests.
@@ -844,9 +844,10 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
       DBIO.seq(
         rawlsBillingProjectQuery.create(billingProject),
         workspaceQuery.createOrUpdate(workspace),
-        entityQuery.save(
-          workspace,
-          lotsOfSamples :+ sampleSet
+        compactEntityRepository.queries.batchWriteEntities(
+          workspace.workspaceIdAsUUID,
+          lotsOfSamples :+ sampleSet,
+          true
         )
       )
     }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-640
<Put notes here to help reviewer understand this PR>

---
Large submissions were timing out in tests.  Investigation showed that the query used to fetch records in expression evaluation took about 10x as long as legacy expression evaluation.  This PR changes that query to a more efficient one and converts the large submission unit test to use quicksilver.

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
