### PR TITLE
CORE-640: query timer utility

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/QueryTiming.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/QueryTiming.scala
@@ -1,0 +1,33 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+import org.slf4j.{Logger, LoggerFactory}
+import slick.dbio.{DBIO, DBIOAction, Effect, NoStream}
+
+import scala.annotation.unused
+import scala.concurrent.ExecutionContext
+
+trait QueryTiming {
+
+  protected val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  /**
+   * Time a DBIOAction and log its duration.
+   * 
+   * @param hint a string to include in the log message to help identify the operation being timed
+   * @param op the query to time
+   * @param executionContext implicit; the execution context to run the query in.
+   *                         Annotated as @unused to avoid IntelliJ warnings but
+   *                         actually used implicitly.
+   */
+  def withTiming[T, U](hint: String)(
+    op: => DBIOAction[T, NoStream, U with Effect]
+  )(implicit @unused executionContext: ExecutionContext): DBIOAction[T, NoStream, U with Effect] =
+    for {
+      startTime <- DBIO.successful(System.nanoTime())
+      queryResults <- op
+      elapsed <- DBIO.successful(System.nanoTime() - startTime)
+    } yield {
+      logger.info(s"query timer: $hint completed in ${elapsed / 1000000} ms")
+      queryResults
+    }
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.expressions
 
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
-import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadAction
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{QueryTiming, ReadAction}
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{
   EntityName,
   ExpressionAndResult,
@@ -42,7 +42,9 @@ case class QueryPlan(
   expressionMappings: Map[String, Set[String]] // expression -> attributes it needs from this query
 )
 
-class CompactExpressionEvaluator(repository: CompactEntityRepository) extends ExpressionEvaluationSupport {
+class CompactExpressionEvaluator(repository: CompactEntityRepository)
+    extends ExpressionEvaluationSupport
+    with QueryTiming {
 
   /**
    * Evaluates a single expression against a specific entity and returns the resulting attribute values.
@@ -426,7 +428,13 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository) extends Ex
             )
         }
       } else {
-        repository.queries.queryRelatedRecordsWithRelationChain(workspaceId, entityType, entityName, plan.relationChain)
+        withTiming("queryRelatedRecordsWithRelationChain") {
+          repository.queries.queryRelatedRecordsWithRelationChain(workspaceId,
+                                                                  entityType,
+                                                                  entityName,
+                                                                  plan.relationChain
+          )
+        }
       }
 
     queryAction.map { entityRecords =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -96,7 +96,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
 
   def withLargeSubmissionApiServices[T](testCode: TestApiService => T): T =
     withCustomTestDatabase(largeSampleTestData) { dataSource: SlickDataSource =>
-      withApiServices(dataSource, legacy = true) { services =>
+      withApiServices(dataSource) { services =>
         try {
           // Simulate a large submission in the mock Cromwell server by making it return
           // numSamples workflows for submission requests.
@@ -503,7 +503,6 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
 
   val numSamples = 10000
 
-  // TODO CORE-640 Convert to quicksilver
   it should "create and abort a large submission" in withLargeSubmissionApiServices { services =>
     val wsName = largeSampleTestData.wsName
     val mcName = MethodConfigurationName("no_input", "dsde", wsName)
@@ -844,9 +843,9 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
       DBIO.seq(
         rawlsBillingProjectQuery.create(billingProject),
         workspaceQuery.createOrUpdate(workspace),
-        entityQuery.save(
-          workspace,
-          lotsOfSamples :+ sampleSet
+        compactEntityQuery.batchWriteEntities(workspace.workspaceIdAsUUID,
+                                              lotsOfSamples :+ sampleSet,
+                                              insertOnly = false
         )
       )
     }


### PR DESCRIPTION
Ticket: CORE-640

Helped with CORE-640; does not complete that ticket.

Add a new utility to wrap a single `DBIOAction` query in a timer and log that query's duration. As developers, we can use this to quickly analyze latencies during the development phase.