### PR TITLE
CORE-663: remove liquibase changesets that always error

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20190405_cleanup.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20190405_cleanup.xml
@@ -11,9 +11,6 @@
     <changeSet logicalFilePath="dummy" author="dvoet" id="drop-table-PENDING_WORKSPACE_ACCESS" failOnError="false">
         <dropTable tableName="PENDING_WORKSPACE_ACCESS"/>
     </changeSet>
-    <changeSet logicalFilePath="dummy" author="dvoet" id="drop-table-TEMP_SUBMITTER_IDS_WITH_EMAILS" failOnError="false">
-        <dropTable tableName="TEMP_SUBMITTER_IDS_WITH_EMAILS"/>
-    </changeSet>
     <changeSet logicalFilePath="dummy" author="dvoet" id="drop-table-WORKSPACE_ACCESS" failOnError="false">
         <dropTable tableName="WORKSPACE_ACCESS"/>
     </changeSet>
@@ -37,8 +34,5 @@
     </changeSet>
     <changeSet logicalFilePath="dummy" author="dvoet" id="drop-table-WORKSPACE_USER_SHARE" failOnError="false">
         <dropTable tableName="WORKSPACE_USER_SHARE"/>
-    </changeSet>
-    <changeSet logicalFilePath="dummy" author="dvoet" id="drop-column-SUBMITTER_OLD" failOnError="false">
-        <dropColumn tableName="SUBMISSION" columnName="SUBMITTER_OLD"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Ticket: CORE-663

Delete two liquibase changesets which always error. These do nothing but create noise. This is most obvious to engineers when iterating on tests; the liquibase errors always appear in the test output.

The column and table mentioned in these changesets must have been created manually at some point. They are not created anywhere else in the liquibase.