### PR TITLE
CORE-649: soft conflict response for copy-entities

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -145,7 +145,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
                         destWorkspaceContext.workspaceIdAsUUID
                       )
                     } else {
-                      unmergedSoftConflicts(entityReferenceMap, softConflicts)
+                      unmergedSoftConflicts(entityReferenceMap, softConflicts, entitiesToCopyRefs)
                     }
                 }
               }
@@ -202,12 +202,13 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
   }
 
   /**
-   * For each entity in the entityReferenceMap, check any of the entites that it references
+   * For each entity in the entityReferenceMap, check any of the entities that it references
    * are in the set of soft conflicts. If so, create an EntitySoftConflict for that entity
    */
-  def unmergedSoftConflicts(entityReferenceMap: Set[RefMapping],
-                            softConflicts: Set[EntityPointer]
+  def unmergedSoftConflictsOLD(entityReferenceMap: Set[RefMapping],
+                               softConflicts: Set[EntityPointer]
   ): DBIOAction[EntityCopyResponse, NoStream, Effect] = {
+
     val unmergedSoftConflicts = entityReferenceMap.flatMap { refMapping =>
       val conflicts = refMapping.to
         .intersect(softConflicts)
@@ -220,6 +221,70 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
       }
     }.toSeq
     DBIO.successful(EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts))
+  }
+
+  /**
+   * Build the response payload for unmerged soft conflicts.
+   *
+   * A soft conflict occurs when an entity to be copied references another entity which already exists. The entity being
+   * referenced is the soft conflict. (A hard conflict is when the entity to be copied itself already exists.)
+   *
+   * This response contains the full reference path from each entity in the original copy request to each soft conflict;
+   * this path may include transitive references which are not themselves soft conflicts. If an entity is both a
+   * transitive member of a reference chain and a soft conflict.
+   *
+   * Assume a source workspace with entity A which references B which references C.
+   * Assume a destination workspace which already has B and C.
+   * If the user requests to copy A, both B and C are soft conflicts and the response will be:
+   *  A -> B
+   *  A -> B -> C
+   *
+   * @param entityReferenceMap known parent->child references
+   * @param softConflicts the soft conflicts
+   * @param originalCopyRequest the original set of entities the user requested to copy
+   * @return the soft-conflict response
+   */
+  def unmergedSoftConflicts(entityReferenceMap: Set[RefMapping],
+                            softConflicts: Set[EntityPointer],
+                            originalCopyRequest: Set[EntityPointer]
+  ): DBIOAction[EntityCopyResponse, NoStream, Effect] = {
+    // Build a map from each entity to its children
+    val childrenMap: Map[EntityPointer, Set[EntityPointer]] =
+      entityReferenceMap
+        .groupBy(_.from)
+        .view
+        .mapValues(_.flatMap(_.to).toSet)
+        .toMap
+
+    // Roots are those in the original deletion request that are not children of any mapping
+    val allChildren = entityReferenceMap.flatMap(_.to)
+    val roots = originalCopyRequest -- allChildren
+
+    // Leaves are those in the map which are not the parent of any other entity
+    val allLeaves = childrenMap.values.flatten.toSet -- childrenMap.keySet
+
+    // Recursive function to build the hierarchy downwards from a parent
+    def buildHierarchyDown(node: EntityPointer): EntitySoftConflict = {
+      val children = childrenMap.getOrElse(node, Set.empty)
+
+      val childConflicts = children.toSeq.flatMap { childNode =>
+        // if this child is itself a soft conflict - and not a leaf, start a new EntitySoftConflict for that child.
+        // Any children which are NOT themselves a soft conflict are only mentioned as part of the path to a conflict.
+        val startNewTree = softConflicts.contains(childNode) && !allLeaves.contains(childNode)
+        val extraConflict = if (startNewTree) {
+          Seq(EntitySoftConflict(childNode.entityType, childNode.entityName, Seq.empty))
+        } else {
+          Seq.empty[EntitySoftConflict]
+        }
+        extraConflict :+ buildHierarchyDown(childNode)
+      }
+
+      EntitySoftConflict(node.entityType, node.entityName, childConflicts)
+    }
+
+    val unmergedSoftConflicts = roots.map(buildHierarchyDown)
+
+    DBIO.successful(EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts.toSeq))
   }
 
   override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -209,7 +209,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
    *
    * This response contains the full reference path from each entity in the original copy request to each soft conflict;
    * this path may include transitive references which are not themselves soft conflicts. If an entity is both a
-   * transitive member of a reference chain and a soft conflict.
+   * transitive member of a reference chain and a soft conflict, it will be represented twice in the response.
    *
    * Assume a source workspace with entity A which references B which references C.
    * Assume a destination workspace which already has B and C.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -202,28 +202,6 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
   }
 
   /**
-   * For each entity in the entityReferenceMap, check any of the entities that it references
-   * are in the set of soft conflicts. If so, create an EntitySoftConflict for that entity
-   */
-  def unmergedSoftConflictsOLD(entityReferenceMap: Set[RefMapping],
-                               softConflicts: Set[EntityPointer]
-  ): DBIOAction[EntityCopyResponse, NoStream, Effect] = {
-
-    val unmergedSoftConflicts = entityReferenceMap.flatMap { refMapping =>
-      val conflicts = refMapping.to
-        .intersect(softConflicts)
-        .map(conflict => EntitySoftConflict(conflict.entityType, conflict.entityName, Seq.empty))
-        .toSeq
-      if (conflicts.nonEmpty) {
-        Some(EntitySoftConflict(refMapping.from.entityType, refMapping.from.entityName, conflicts))
-      } else {
-        None
-      }
-    }.toSeq
-    DBIO.successful(EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts))
-  }
-
-  /**
    * Build the response payload for unmerged soft conflicts.
    *
    * A soft conflict occurs when an entity to be copied references another entity which already exists. The entity being

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -2535,24 +2535,20 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   // TODO CORE-649 Switch to Quicksilver once the behavior is updated
-  it should "return 409 for soft conflicts multiple levels down" in withLegacyTestDataApiServices { services =>
-    val sourceWorkspace = WorkspaceName(legacyTestData.workspace.namespace, legacyTestData.workspace.name)
-    val newWorkspace = WorkspaceName(legacyTestData.workspace.namespace, "my-brand-new-workspace")
+  it should "return 409 for soft conflicts multiple levels down" in withTestDataApiServices { services =>
+    val sourceWorkspace = WorkspaceName(testData.workspace.namespace, testData.workspace.name)
+    val newWorkspace = WorkspaceName(testData.workspace.namespace, "my-brand-new-workspace")
 
     val newWorkspaceCreate = WorkspaceRequest(newWorkspace.namespace, newWorkspace.name, Map.empty)
 
     val copyAliquot1 =
       EntityCopyDefinition(sourceWorkspace,
                            newWorkspace,
-                           legacyTestData.aliquot1.entityType,
+                           testData.aliquot1.entityType,
                            Seq(legacyTestData.aliquot1.name)
       )
     val copySample3 =
-      EntityCopyDefinition(sourceWorkspace,
-                           newWorkspace,
-                           legacyTestData.sample3.entityType,
-                           Seq(legacyTestData.sample3.name)
-      )
+      EntityCopyDefinition(sourceWorkspace, newWorkspace, testData.sample3.entityType, Seq(testData.sample3.name))
 
     Post("/workspaces", httpJson(newWorkspaceCreate)) ~>
       sealRoute(services.workspaceRoutes(userInfo = userInfo)) ~>
@@ -2571,7 +2567,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
         val copyResponse = responseAs[EntityCopyResponse]
 
-        assertSameElements(Seq(legacyTestData.aliquot1).map(_.toReference), copyResponse.entitiesCopied)
+        assertSameElements(Seq(testData.aliquot1).map(_.toReference), copyResponse.entitiesCopied)
         assertSameElements(Seq.empty, copyResponse.hardConflicts)
         assertSameElements(Seq.empty, copyResponse.softConflicts)
       }
@@ -2589,13 +2585,13 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         assertSameElements(Seq.empty, copyResponse.hardConflicts)
         val expectedSoftConflicts = Seq(
           EntitySoftConflict(
-            legacyTestData.sample3.entityType,
-            legacyTestData.sample3.name,
+            testData.sample3.entityType,
+            testData.sample3.name,
             Seq(
               EntitySoftConflict(
-                legacyTestData.sample1.entityType,
-                legacyTestData.sample1.name,
-                Seq(EntitySoftConflict(legacyTestData.aliquot1.entityType, legacyTestData.aliquot1.name, Seq.empty))
+                testData.sample1.entityType,
+                testData.sample1.name,
+                Seq(EntitySoftConflict(testData.aliquot1.entityType, testData.aliquot1.name, Seq.empty))
               )
             )
           )
@@ -2607,19 +2603,19 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   // TODO CORE-649 Switch to Quicksilver once the behavior is updated
-  it should "return 409 for copying entities into a workspace with subtree conflicts, but successfully copy when asked to" in withLegacyTestDataApiServices {
+  it should "return 409 for copying entities into a workspace with subtree conflicts, but successfully copy when asked to" in withTestDataApiServices {
     services =>
-      val sourceWorkspace = WorkspaceName(legacyTestData.workspace.namespace, legacyTestData.workspace.name)
+      val sourceWorkspace = WorkspaceName(testData.workspace.namespace, testData.workspace.name)
       val entityCopyDefinition1 = EntityCopyDefinition(sourceWorkspace,
-                                                       legacyTestData.controlledWorkspace.toWorkspaceName,
-                                                       legacyTestData.sample1.entityType,
-                                                       Seq(legacyTestData.sample1.name)
+                                                       testData.controlledWorkspace.toWorkspaceName,
+                                                       testData.sample1.entityType,
+                                                       Seq(testData.sample1.name)
       )
       // this will cause a soft conflict because it references sample1
       val entityCopyDefinition2 = EntityCopyDefinition(sourceWorkspace,
-                                                       legacyTestData.controlledWorkspace.toWorkspaceName,
-                                                       legacyTestData.sample3.entityType,
-                                                       Seq(legacyTestData.sample3.name)
+                                                       testData.controlledWorkspace.toWorkspaceName,
+                                                       testData.sample3.entityType,
+                                                       Seq(testData.sample3.name)
       )
 
       withStatsD {
@@ -2632,9 +2628,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
             val copyResponse = responseAs[EntityCopyResponse]
 
-            assertSameElements(Seq(legacyTestData.sample1, legacyTestData.aliquot1).map(_.toReference),
-                               copyResponse.entitiesCopied
-            )
+            assertSameElements(Seq(testData.sample1, testData.aliquot1).map(_.toReference), copyResponse.entitiesCopied)
             assertSameElements(Seq.empty, copyResponse.hardConflicts)
             assertSameElements(Seq.empty, copyResponse.softConflicts)
           }
@@ -2648,14 +2642,14 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         Seq.empty,
         Seq(
           EntitySoftConflict(
-            legacyTestData.sample3.entityType,
-            legacyTestData.sample3.name,
+            testData.sample3.entityType,
+            testData.sample3.name,
             Seq(
-              EntitySoftConflict(legacyTestData.sample1.entityType, legacyTestData.sample1.name, Seq.empty),
+              EntitySoftConflict(testData.sample1.entityType, testData.sample1.name, Seq.empty),
               EntitySoftConflict(
-                legacyTestData.sample1.entityType,
-                legacyTestData.sample1.name,
-                Seq(EntitySoftConflict(legacyTestData.aliquot1.entityType, legacyTestData.aliquot1.name, Seq.empty))
+                testData.sample1.entityType,
+                testData.sample1.name,
+                Seq(EntitySoftConflict(testData.aliquot1.entityType, testData.aliquot1.name, Seq.empty))
               )
             )
           )
@@ -2701,7 +2695,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           assertResult(StatusCodes.Created) {
             status
           }
-          assertResult(EntityCopyResponse(Seq(legacyTestData.sample3).map(_.toReference), Seq.empty, Seq.empty)) {
+          assertResult(EntityCopyResponse(Seq(testData.sample3).map(_.toReference), Seq.empty, Seq.empty)) {
             responseAs[EntityCopyResponse]
           }
         }


### PR DESCRIPTION
Ticket: CORE-649

In the copy-entities response payload, Quicksilver now mimics the legacy behavior for soft conflicts.