### PR TITLE
CORE-636: omit false nulls in Quicksilver entityQuery field selection

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -1178,7 +1178,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         // else create an empty JSON_OBJECT. These objects are all merged together below;
         // this ensures that if a field is missing in the db, it will not be present in the result.
         val fieldObjects = fields.map { field =>
-          sql"IF(JSON_CONTAINS_PATH(e.attributes, 'one', ${slickAttributePath(field)}), JSON_OBJECT($field, ${slickAttributePath(field)}), JSON_OBJECT())"
+          sql"IF(JSON_CONTAINS_PATH(e.attributes, 'one', ${slickAttributePath(field)}), JSON_OBJECT($field, e.attributes -> ${slickAttributePath(field)}), JSON_OBJECT())"
         }
         concatSqlActions(
           sql"""JSON_OBJECT(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -1173,16 +1173,20 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    */
   private def filteredAttributesColumn(entityQuery: EntityQuery) =
     entityQuery.fields.fields match {
-      case Some(fields) =>
-        val fieldSqls = fields.map { field =>
-          sql"$field, e.attributes -> ${slickAttributePath(field)}"
+      case Some(fields) if fields.nonEmpty =>
+        // For each field, create a JSON_OBJECT that contains the field if it exists;
+        // else create an empty JSON_OBJECT. These objects are all merged together below;
+        // this ensures that if a field is missing in the db, it will not be present in the result.
+        val fieldObjects = fields.map { field =>
+          sql"IF(JSON_CONTAINS_PATH(e.attributes, 'one', ${slickAttributePath(field)}), JSON_OBJECT($field, ${slickAttributePath(field)}), JSON_OBJECT())"
         }
         concatSqlActions(
           sql"""JSON_OBJECT(
                '#${CompactEntitySerialization.VERSION_KEY}', e.attributes -> '$$.#${CompactEntitySerialization.VERSION_KEY}',
                '#${CompactEntitySerialization.REFS_KEY}', e.attributes -> '$$.#${CompactEntitySerialization.REFS_KEY}',
-               '#${CompactEntitySerialization.ATTRS_KEY}', JSON_OBJECT(""",
-          reduceSqlActionsWithDelim(fieldSqls.toSeq, sql","),
+               '#${CompactEntitySerialization.ATTRS_KEY}', JSON_MERGE_PATCH(
+                  JSON_OBJECT(),""",
+          reduceSqlActionsWithDelim(fieldObjects.toSeq, sql","),
           sql"))"
         )
       case _ => sql"attributes"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -3361,11 +3361,9 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     val actual = runAndWait(testQuery(entityType, entityQuery))
 
     actual should contain theSameElementsAs List(
-      entity1.copy(attributes = Map(desiredColumnAttr1 -> AttributeString("bar"), desiredColumnAttr2 -> AttributeNull)),
+      entity1.copy(attributes = Map(desiredColumnAttr1 -> AttributeString("bar"))),
       entity2.copy(attributes =
-        Map(desiredColumnAttr1 -> AttributeNull,
-            desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux")))
-        )
+        Map(desiredColumnAttr2 -> AttributeValueList(Seq(AttributeString("baz"), AttributeString("qux"))))
       )
     )
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -4004,7 +4004,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   // *********** START entityQuery field-selection tests
 
   // creates 30 entities, in groups of 10; each group has different attributes, with some overlap.
-  class FieldSelectionTestData(legacy: Boolean = false) extends TestData {
+  class FieldSelectionTestData() extends TestData {
     val userOwner = RawlsUser(
       UserInfo(RawlsUserEmail("owner-access"),
                OAuth2BearerToken("token"),
@@ -4050,25 +4050,16 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
       DBIO.seq(
         workspaceQuery.createOrUpdate(workspace),
-        if (legacy) { entityQuery.save(workspace, entities) }
-        else {
-          compactEntityRepository.queries.batchWriteEntities(workspace.workspaceIdAsUUID, entities, true)
-        }
+        compactEntityRepository.queries.batchWriteEntities(workspace.workspaceIdAsUUID, entities, true)
       )
     }
   }
 
   val fieldSelectionTestData = new FieldSelectionTestData()
-  val legacyFieldSelectionTestData = new FieldSelectionTestData(true)
 
   def withFieldSelectionTestDataApiServices[T](testCode: TestApiService => T): T =
     withCustomTestDatabase(fieldSelectionTestData) { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
-    }
-
-  def withLegacyFieldSelectionTestDataApiServices[T](testCode: TestApiService => T): T =
-    withCustomTestDatabase(legacyFieldSelectionTestData) { dataSource: SlickDataSource =>
-      withApiServices(dataSource, legacy = true)(testCode)
     }
 
   val fieldSelectionApiPath =
@@ -4203,8 +4194,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  // TODO CORE-636 Update quicksilver to have same behavior as legacy, then update test to use quicksilver
-  it should "return no attributes if requested field exists, but not in this page of results" in withLegacyFieldSelectionTestDataApiServices {
+  it should "return no attributes if requested field exists, but not in this page of results" in withFieldSelectionTestDataApiServices {
     services =>
       // get the first page of results, but request a field from the second page
       Get(s"$fieldSelectionApiPath?pageSize=10&page=1&fields=violet") ~>
@@ -4216,8 +4206,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
   }
 
-  // TODO CORE-636 Update quicksilver to have same behavior as legacy, then update test to use quicksilver
-  it should "return no attributes if unrecognized field names in parameter" in withLegacyFieldSelectionTestDataApiServices {
+  it should "return no attributes if unrecognized field names in parameter" in withFieldSelectionTestDataApiServices {
     services =>
       // request a totally nonexistent field
       Get(s"$fieldSelectionApiPath?pageSize=10&page=1&fields=nonexistent") ~>
@@ -4229,8 +4218,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
   }
 
-  // TODO CORE-636 Update quicksilver to have same behavior as legacy, then update test to use quicksilver
-  it should "return requested fields in conjunction with sort and filter" in withLegacyFieldSelectionTestDataApiServices {
+  it should "return requested fields in conjunction with sort and filter" in withFieldSelectionTestDataApiServices {
     services =>
       // request all 30 results, but use a filter term that should only return the third page.
       // request fields from all pages, but expect only the third page's fields back.
@@ -4246,8 +4234,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
   }
 
-  // TODO CORE-636 Update quicksilver to have same behavior as legacy, then update test to use quicksilver
-  it should "return no attributes if field list is empty, i.e. 'fields='" in withLegacyFieldSelectionTestDataApiServices {
+  it should "return no attributes if field list is empty, i.e. 'fields='" in withFieldSelectionTestDataApiServices {
     services =>
       // query for all entities
       Get(s"$fieldSelectionApiPath?pageSize=${fieldSelectionTestData.entities.size}&fields=") ~>


### PR DESCRIPTION
Ticket: CORE-636

In quicksilver, when using the `fields` parameter on the `entityQuery` API, if you specified a field that did not exist on an entity, the result would contain that field with a value of null.

In legacy, the result does not contain that field at all.

This PR updates Quicksilver to behave like legacy: the field is now omitted.