### PR TITLE
CORE-633: batch upsert error handling

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -767,6 +767,12 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
             case None            => throw new EntityNotFoundException()
           }
         }
+      } recover {
+        // batchUpdateEntities throws a 400 BadRequest if the entities it is updating do not exist.
+        // however, for this updateEntity method, which only updates one entity, we want to throw a 404 NotFound instead.
+        // So, look for a thrown EntityNotFoundException (which will have code=400) and re-throw it with its default code=404.
+        case _: EntityNotFoundException =>
+          throw new EntityNotFoundException("Requested entity does not exist in this workspace.")
       }
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -1,9 +1,11 @@
 package org.broadinstitute.dsde.rawls.entities.compact.batch
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.StatusCodes
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{
   RawlsConcurrentModificationException,
   ReadWriteAction,
@@ -17,12 +19,13 @@ import org.broadinstitute.dsde.rawls.entities.compact.{
 }
 import org.broadinstitute.dsde.rawls.entities.exceptions.{EntityNotFoundException, EntityReferenceNotFoundException}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
-import org.broadinstitute.dsde.rawls.model.{AttributeName, Entity, EntityPointer, RawlsRequestContext}
+import org.broadinstitute.dsde.rawls.model.{AttributeName, Entity, EntityPointer, ErrorReport, RawlsRequestContext}
 import org.broadinstitute.dsde.rawls.util.AttributeSupport
 import slick.dbio.DBIO
 
 import scala.annotation.tailrec
 import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
 
 /**
   * Support for batchUpsert/batchUpdate; to be mixed in to CompactEntityProvider
@@ -112,7 +115,8 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
             existingEntities.size != uniqueUpdateIdentifiers.size || (uniqueUpdateIdentifiers diff actualPointers).nonEmpty
           )
             throw new EntityNotFoundException(
-              s"expected ${uniqueUpdateIdentifiers.size} entities to be updated, but found ${existingEntities.size}"
+              s"expected ${uniqueUpdateIdentifiers.size} entities to be updated, but found ${existingEntities.size}",
+              code = StatusCodes.BadRequest
             )
         }
 
@@ -183,17 +187,21 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
     @tailrec
     def applyOne(updates: Seq[EntityUpdateDefinition],
                  existingEntitiesByIdentifier: Map[EntityPointer, Entity],
-                 accum: Seq[Entity]
-    ): Seq[Entity] =
+                 accum: Seq[Try[Entity]]
+    ): Seq[Try[Entity]] =
       if (updates.isEmpty) {
         // end of updates.
-        // now that everything has been applied, de-duplicate the entities.
-        // If the same entity appears multiple times in our update, take the last one.
+        // now that everything has been applied, collect and handle any errors.
+        val failures = accum.collect { case Failure(ex) =>
+          ErrorReport(ex)
+        }
+        if (failures.nonEmpty) {
+          logger.warn(s"**************** ${failures.size} failures; throwing")
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.BadRequest, "Some entities could not be updated.", failures)
+          )
+        }
         accum
-          .groupBy(_.toPointer)
-          .values
-          .map(_.last)
-          .toSeq
       } else {
         val thisUpdate = updates.head
 
@@ -207,19 +215,34 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
             Entity(thisUpdate.name, thisUpdate.entityType, Map())
           )
 
-        val updatedEntity = applyOperationsToEntity(thisBaseEntity, thisUpdate.operations)
+        val updatedEntityTrial = Try(applyOperationsToEntity(thisBaseEntity, thisUpdate.operations))
 
-        // If the entity has not changed and already exists, we can skip it.
-        val newAccum = if (isPreExisting && thisBaseEntity == updatedEntity) {
-          accum
-        } else {
-          accum :+ updatedEntity
+        updatedEntityTrial match {
+          case Failure(_) =>
+            applyOne(updates.tail, existingEntitiesByIdentifier, accum :+ updatedEntityTrial)
+          case Success(updatedEntity) =>
+            // If the entity has not changed and already exists, we can skip it.
+            val newAccum = if (isPreExisting && thisBaseEntity == updatedEntity) {
+              accum
+            } else {
+              accum :+ updatedEntityTrial
+            }
+            applyOne(updates.tail, existingEntitiesByIdentifier + (updatedEntity.toPointer -> updatedEntity), newAccum)
         }
-
-        applyOne(updates.tail, existingEntitiesByIdentifier + (updatedEntity.toPointer -> updatedEntity), newAccum)
       }
 
-    applyOne(updates, existingEntitiesByIdentifier, Seq())
+    // applyOne() will throw on invalid updates; if we get a result back from it we can assume
+    // that all updates were valid and applied successfully.
+    val trials = applyOne(updates, existingEntitiesByIdentifier, Seq())
+
+    // De-duplicate the entities.
+    // If the same entity appears multiple times in our update, take the last one.
+    trials
+      .map(_.get)
+      .groupBy(_.toPointer)
+      .values
+      .map(_.last)
+      .toSeq
 
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/batch/BatchHandling.scala
@@ -115,7 +115,7 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
             existingEntities.size != uniqueUpdateIdentifiers.size || (uniqueUpdateIdentifiers diff actualPointers).nonEmpty
           )
             throw new EntityNotFoundException(
-              s"expected ${uniqueUpdateIdentifiers.size} entities to be updated, but found ${existingEntities.size}",
+              s"Expected ${uniqueUpdateIdentifiers.size} entities to be updated, but found ${existingEntities.size}",
               code = StatusCodes.BadRequest
             )
         }
@@ -192,11 +192,8 @@ trait BatchHandling extends LazyLogging with AttributeSupport {
       if (updates.isEmpty) {
         // end of updates.
         // now that everything has been applied, collect and handle any errors.
-        val failures = accum.collect { case Failure(ex) =>
-          ErrorReport(ex)
-        }
+        val failures = accum.collect { case Failure(ex) => ErrorReport(ex) }
         if (failures.nonEmpty) {
-          logger.warn(s"**************** ${failures.size} failures; throwing")
           throw new RawlsExceptionWithErrorReport(
             ErrorReport(StatusCodes.BadRequest, "Some entities could not be updated.", failures)
           )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -1145,7 +1145,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     assert(newId != id3)
   }
 
-  // Update quicksilver to have same behavior as legacy, then update test to use quicksilver
   it should "return 400 when batch upserting an entity with invalid update operations" in withTestDataApiServices {
     services =>
       val update1 =
@@ -1416,7 +1415,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
   }
 
-  // Update quicksilver to have same behavior as legacy, then update test to use quicksilver
   it should "return 400 when batch updating an entity with invalid update operations" in withTestDataApiServices {
     services =>
       val update1 =
@@ -2527,7 +2525,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  // TODO CORE-649 Switch to Quicksilver once the behavior is updated
   it should "return 409 for soft conflicts multiple levels down" in withTestDataApiServices { services =>
     val sourceWorkspace = WorkspaceName(testData.workspace.namespace, testData.workspace.name)
     val newWorkspace = WorkspaceName(testData.workspace.namespace, "my-brand-new-workspace")
@@ -2595,7 +2592,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  // TODO CORE-649 Switch to Quicksilver once the behavior is updated
   it should "return 409 for copying entities into a workspace with subtree conflicts, but successfully copy when asked to" in withTestDataApiServices {
     services =>
       val sourceWorkspace = WorkspaceName(testData.workspace.namespace, testData.workspace.name)
@@ -3045,7 +3041,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
   }
 
-  // TODO CORE-635 Update quicksilver to have same behavior as legacy, then update test to use quicksilver
   it should "return 200 OK on entity query for unknown sort field" in withPaginationTestDataApiServices { services =>
     Get(
       s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=asdfasdfasdf"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -1370,7 +1370,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
   }
 
-  // TODO CORE-633 Update quicksilver to have same behavior as legacy, then update test to use quicksilver
   it should "return 403 when batch upserting an entity with invalid-namespace attributes" in withTestDataApiServices {
     services =>
       val invalidAttrNamespace = "invalid"
@@ -1437,7 +1436,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
   }
 
-  // Update quicksilver to have same behavior as legacy, then update test to use quicksilver
   it should "return 400 when batch updating an entity that does not yet exist" in withTestDataApiServices { services =>
     val update1 = EntityUpdateDefinition(
       "superDuperNewSample",
@@ -1456,7 +1454,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  // Update quicksilver to have same behavior as legacy, then update test to use quicksilver
   it should "return 400 when batch updating an entity that was deleted" in withTestDataApiServices { services =>
     val e = Entity("foo", "bar", Map.empty)
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -1346,7 +1346,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  // TODO CORE-633 Update quicksilver to have same behavior as legacy, then update test to use quicksilver
   it should "return 400 when batch upserting an entity with references that don't exist" in withTestDataApiServices {
     services =>
       val update1 = EntityUpdateDefinition(
@@ -1365,8 +1364,8 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           assertResult(StatusCodes.BadRequest) {
             status
           }
-          assertResult(2) {
-            responseAs[ErrorReport].causes.length
+          assertResult("Some entity references do not exist") {
+            responseAs[ErrorReport].message
           }
         }
   }
@@ -1438,7 +1437,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
   }
 
-  // TODO CORE-633 Expected 400 Bad Request, but got 404 Not Found
   // Update quicksilver to have same behavior as legacy, then update test to use quicksilver
   it should "return 400 when batch updating an entity that does not yet exist" in withTestDataApiServices { services =>
     val update1 = EntityUpdateDefinition(
@@ -1452,13 +1450,12 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.BadRequest) {
           status
         }
-        assertResult(1) {
-          responseAs[ErrorReport].causes.length
+        assertResult("Expected 1 entities to be updated, but found 0") {
+          responseAs[ErrorReport].message
         }
       }
   }
 
-  // TODO CORE-633 org.scalatest.exceptions.TestFailedException: Expected 400 Bad Request, but got 404 Not Found
   // Update quicksilver to have same behavior as legacy, then update test to use quicksilver
   it should "return 400 when batch updating an entity that was deleted" in withTestDataApiServices { services =>
     val e = Entity("foo", "bar", Map.empty)
@@ -1495,8 +1492,8 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.BadRequest) {
           status
         }
-        assertResult(1) {
-          responseAs[ErrorReport].causes.length
+        assertResult("Expected 1 entities to be updated, but found 0") {
+          responseAs[ErrorReport].message
         }
       }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -1145,9 +1145,8 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     assert(newId != id3)
   }
 
-  // TODO CORE-633 org.scalatest.exceptions.TestFailedException: Expected 400 Bad Request, but got 500 Internal Server Error
   // Update quicksilver to have same behavior as legacy, then update test to use quicksilver
-  it should "return 400 when batch upserting an entity with invalid update operations" in withLegacyTestDataApiServices {
+  it should "return 400 when batch upserting an entity with invalid update operations" in withTestDataApiServices {
     services =>
       val update1 =
         EntityUpdateDefinition(testData.sample1.name,
@@ -1348,7 +1347,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   // TODO CORE-633 Update quicksilver to have same behavior as legacy, then update test to use quicksilver
-  it should "return 400 when batch upserting an entity with references that don't exist" in withLegacyTestDataApiServices {
+  it should "return 400 when batch upserting an entity with references that don't exist" in withTestDataApiServices {
     services =>
       val update1 = EntityUpdateDefinition(
         testData.sample1.name,
@@ -1373,7 +1372,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   // TODO CORE-633 Update quicksilver to have same behavior as legacy, then update test to use quicksilver
-  it should "return 403 when batch upserting an entity with invalid-namespace attributes" in withLegacyTestDataApiServices {
+  it should "return 403 when batch upserting an entity with invalid-namespace attributes" in withTestDataApiServices {
     services =>
       val invalidAttrNamespace = "invalid"
 
@@ -1419,9 +1418,8 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
   }
 
-  // TODO CORE-633 org.scalatest.exceptions.TestFailedException: Expected 400 Bad Request, but got 500 Internal Server Error
   // Update quicksilver to have same behavior as legacy, then update test to use quicksilver
-  it should "return 400 when batch updating an entity with invalid update operations" in withLegacyTestDataApiServices {
+  it should "return 400 when batch updating an entity with invalid update operations" in withTestDataApiServices {
     services =>
       val update1 =
         EntityUpdateDefinition(testData.sample1.name,
@@ -1442,28 +1440,27 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   // TODO CORE-633 Expected 400 Bad Request, but got 404 Not Found
   // Update quicksilver to have same behavior as legacy, then update test to use quicksilver
-  it should "return 400 when batch updating an entity that does not yet exist" in withLegacyTestDataApiServices {
-    services =>
-      val update1 = EntityUpdateDefinition(
-        "superDuperNewSample",
-        "Samples",
-        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo")))
-      )
-      Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
-        sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
-        check {
-          assertResult(StatusCodes.BadRequest) {
-            status
-          }
-          assertResult(1) {
-            responseAs[ErrorReport].causes.length
-          }
+  it should "return 400 when batch updating an entity that does not yet exist" in withTestDataApiServices { services =>
+    val update1 = EntityUpdateDefinition(
+      "superDuperNewSample",
+      "Samples",
+      Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo")))
+    )
+    Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
+      check {
+        assertResult(StatusCodes.BadRequest) {
+          status
         }
+        assertResult(1) {
+          responseAs[ErrorReport].causes.length
+        }
+      }
   }
 
   // TODO CORE-633 org.scalatest.exceptions.TestFailedException: Expected 400 Bad Request, but got 404 Not Found
   // Update quicksilver to have same behavior as legacy, then update test to use quicksilver
-  it should "return 400 when batch updating an entity that was deleted" in withLegacyTestDataApiServices { services =>
+  it should "return 400 when batch updating an entity that was deleted" in withTestDataApiServices { services =>
     val e = Entity("foo", "bar", Map.empty)
 
     Post(s"${testData.workspace.path}/entities", httpJson(e)) ~>


### PR DESCRIPTION
Ticket: CORE-633

Various Quicksilver changes to mimic legacy behavior and update unit tests:
* when updating a single entity, throw 404 if that entity does not exist.
* when batch-updating multiple entities, throw 400 if any entity does not exist.
* in batch-update/upsert, collect multiple failures (such as an invalid update operation) and report on them as a group instead of throwing on the first failure
* adjust a few unit tests to look for an expected failure message instead of asserting on the size of the underlying wrapped exceptions