### PR TITLE
CORE-651: Quicksilver attribute-rename exceptions match legacy

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -602,15 +602,15 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         newNameExists <- repository.queries.attributeExists(workspaceId, entityType, newName)
         _ = if (newNameExists)
           throw new AttributeException(
-            message = s"${AttributeName.toDelimitedName(newName)} already exists.",
-            code = StatusCodes.BadRequest
+            message = s"${AttributeName.toDelimitedName(newName)} already exists as an attribute name",
+            code = StatusCodes.Conflict
           )
         // does old name already exist? fail if it does not.
         oldNameExists <- repository.queries.attributeExists(workspaceId, entityType, oldName)
         _ = if (!oldNameExists)
           throw new AttributeException(
-            message = s"${AttributeName.toDelimitedName(oldName)} does not exist.",
-            code = StatusCodes.BadRequest
+            message = s"Can't find attribute name ${AttributeName.toDelimitedName(oldName)}",
+            code = StatusCodes.NotFound
           )
         // perform the rename
         numEntitiesAffected <- repository.queries.renameAttribute(workspaceId,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/AttributeException.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/AttributeException.scala
@@ -2,5 +2,5 @@ package org.broadinstitute.dsde.rawls.entities.exceptions
 
 import akka.http.scaladsl.model.StatusCode
 
-class AttributeException(message: String, cause: Throwable = null, override val code: StatusCode)
+class AttributeException(val message: String, cause: Throwable = null, override val code: StatusCode)
     extends DataEntityException(message, cause, code)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -429,21 +429,20 @@ class EntityServiceSpec
     }
   }
 
-  // TODO CORE-651 Update messaging behavior to be more specific, then change these tests to quicksilver
-  it should "fail to rename an attribute name to a name already in use" in withLegacyTestDataServices { services =>
+  it should "fail to rename an attribute name to a name already in use" in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
-    val ex = intercept[RawlsExceptionWithErrorReport] {
+    val ex = intercept[AttributeException] {
       Await.result(
-        services.entityService.renameAttribute(legacyTestData.wsName,
-                                               legacyTestData.pair1.entityType,
+        services.entityService.renameAttribute(testData.wsName,
+                                               testData.pair1.entityType,
                                                AttributeName.withDefaultNS("case"),
                                                AttributeRename(AttributeName.withDefaultNS("control"))
         ),
         waitDuration
       )
     }
-    ex.errorReport.message shouldBe "control already exists as an attribute name"
-    ex.errorReport.statusCode shouldBe Some(StatusCodes.Conflict)
+    ex.message shouldBe "control already exists as an attribute name"
+    ex.code shouldBe StatusCodes.Conflict
   }
 
   it should "rename an attribute name as long as the selected name is not in use" in withTestDataServices { services =>
@@ -467,23 +466,22 @@ class EntityServiceSpec
     }
   }
 
-  // TODO CORE-651 Update messaging behavior to be more specific, then change these tests to quicksilver
-  it should "throw an error when trying to rename an attribute that does not exist" in withLegacyTestDataServices {
+  it should "throw an error when trying to rename an attribute that does not exist" in withTestDataServices {
     services =>
       val waitDuration = Duration(10, SECONDS)
-      val ex = intercept[RawlsExceptionWithErrorReport] {
+      val ex = intercept[AttributeException] {
         Await.result(
           services.entityService.renameAttribute(
-            legacyTestData.wsName,
-            legacyTestData.pair1.entityType,
+            testData.wsName,
+            testData.pair1.entityType,
             AttributeName.withDefaultNS("non-existent-attribute"),
             AttributeRename(AttributeName.withDefaultNS("any"))
           ),
           waitDuration
         )
       }
-      ex.errorReport.message shouldBe "Can't find attribute name non-existent-attribute"
-      ex.errorReport.statusCode shouldBe Some(StatusCodes.NotFound)
+      ex.message shouldBe "Can't find attribute name non-existent-attribute"
+      ex.code shouldBe StatusCodes.NotFound
   }
 
   it should "do nothing when asked to delete zero entities" in withTestDataServices { services =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -121,7 +121,7 @@ class EntityServiceSpec
   }
 
   // noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
-  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser, useLegacy: Boolean = false)(implicit
+  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit
     val executionContext: ExecutionContext
   ) extends EntityApiService
       with MockUserInfoDirectivesWithUser {
@@ -153,7 +153,7 @@ class EntityServiceSpec
       workbenchMetricBaseName,
       EntityManager.defaultEntityManager(
         dataSource,
-        if (useLegacy) workspaceSettingRepository else spyWorkspaceSettingRepository,
+        spyWorkspaceSettingRepository,
         testConf.getBoolean("entityStatisticsCache.enabled"),
         testConf.getDuration("entities.queryTimeout"),
         workbenchMetricBaseName
@@ -167,15 +167,10 @@ class EntityServiceSpec
       withServices(dataSource, testData.userOwner)(testCode)
     }
 
-  def withLegacyTestDataServices[T](testCode: TestApiService => T): T =
-    withLegacyDefaultTestDatabase { dataSource: SlickDataSource =>
-      withServices(dataSource, legacyTestData.userOwner, true)(testCode)
-    }
-
-  private def withServices[T](dataSource: SlickDataSource, user: RawlsUser, useLegacy: Boolean = false)(
+  private def withServices[T](dataSource: SlickDataSource, user: RawlsUser)(
     testCode: (TestApiService) => T
   ) = {
-    val apiService = new TestApiService(dataSource, user, useLegacy)
+    val apiService = new TestApiService(dataSource, user)
     testCode(apiService)
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -904,7 +904,7 @@ class CompactEntityProviderSpec
       Await.result(provider.renameAttribute(entityType, oldName, AttributeRename(newName), testContext), atMost)
     }
 
-    exception.code shouldBe StatusCodes.BadRequest
+    exception.code shouldBe StatusCodes.Conflict
 
     // execution should short-circuit before executing a rename
     verify(mockQueries, never()).renameAttribute(any(), any(), any(), any())
@@ -930,7 +930,7 @@ class CompactEntityProviderSpec
       Await.result(provider.renameAttribute(entityType, oldName, AttributeRename(newName), testContext), atMost)
     }
 
-    exception.code shouldBe StatusCodes.BadRequest
+    exception.code shouldBe StatusCodes.NotFound
 
     // execution should short-circuit before executing a rename
     verify(mockQueries, never()).renameAttribute(any(), any(), any(), any())


### PR DESCRIPTION
Ticket: CORE-651

When renaming an attribute using Quicksilver, error messages and status codes now match legacy behavior.