### PR TITLE
[AN-523] Remove UseCromwellGcpBatchBackend workspace setting

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5358,7 +5358,6 @@ components:
             - GcpBucketRequesterPays
             - GcpLogBucketRetention
             - SeparateSubmissionFinalOutputs
-            - UseCromwellGcpBatchBackend
             - PubliclyReadable
         config:
           description: The configuration of the workspace setting
@@ -5368,7 +5367,6 @@ components:
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketRequesterPaysConfig'
             - $ref: '#/components/schemas/WorkspaceSettingGcpLogBucketRetentionConfig'
             - $ref: '#/components/schemas/WorkspaceSettingSeparateSubmissionFinalOutputsConfig'
-            - $ref: '#/components/schemas/WorkspaceSettingUseCromwellGcpBatchBackendConfig'
             - $ref: '#/components/schemas/WorkspaceSettingPubliclyReadableConfig'
             - $ref: '#/components/schemas/WorkspaceSettingCompactDataTablesConfig'
     WorkspaceSettingGcpBucketLifecycleConfig:
@@ -5445,14 +5443,6 @@ components:
         enabled:
           type: boolean
           description: Whether submission final outputs should be separated from intermediate outputs
-    WorkspaceSettingUseCromwellGcpBatchBackendConfig:
-      required:
-        - enabled
-      type: object
-      properties:
-        enabled:
-          type: boolean
-          description: Whether workflows submitted to Cromwell should be run using Cromwell's GCP Batch backend
     WorkspaceSettingPubliclyReadableConfig:
       required:
         - enabled

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
@@ -7,8 +7,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{
   GcpBucketSoftDeleteConfigFormat,
   GcpLogBucketRetentionConfigFormat,
   PubliclyReadableConfigFormat,
-  SeparateSubmissionFinalOutputsConfigFormat,
-  UseCromwellGcpBatchBackendConfigFormat
+  SeparateSubmissionFinalOutputsConfigFormat
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   CompactDataTablesConfig,
@@ -17,8 +16,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketSoftDeleteConfig,
   GcpLogBucketRetentionConfig,
   PubliclyReadableConfig,
-  SeparateSubmissionFinalOutputsConfig,
-  UseCromwellGcpBatchBackendConfig
+  SeparateSubmissionFinalOutputsConfig
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.WorkspaceSettingType
 import org.broadinstitute.dsde.rawls.model._
@@ -80,10 +78,6 @@ object WorkspaceSettingRecord {
       case WorkspaceSettingTypes.SeparateSubmissionFinalOutputs =>
         SeparateSubmissionFinalOutputsSetting(
           workspaceSettingRecord.config.parseJson.convertTo[SeparateSubmissionFinalOutputsConfig]
-        )
-      case WorkspaceSettingTypes.UseCromwellGcpBatchBackend =>
-        UseCromwellGcpBatchBackendSetting(
-          workspaceSettingRecord.config.parseJson.convertTo[UseCromwellGcpBatchBackendConfig]
         )
       case WorkspaceSettingTypes.PubliclyReadable =>
         PubliclyReadableSetting(workspaceSettingRecord.config.parseJson.convertTo[PubliclyReadableConfig])

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -310,15 +310,6 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
       // - final_workflow_outputs_dir = submissions/final-outputs
       // - final_workflow_outputs_mode = "copy".
 
-      // Note: Usage of 'useBatchAsDefaultBackend' and 'highSecurityNetworkCromwellBackend' will be removed as part of
-      // https://broadworkbench.atlassian.net/browse/AN-518 when GCP Batch becomes the default backend.
-      useCromwellGcpBatchBackend: Boolean = currentSettings
-        .collectFirst { case backendSetting: UseCromwellGcpBatchBackendSetting => backendSetting.config.enabled }
-        .getOrElse(useBatchAsDefaultBackend)
-
-      cromwellSubmissionBackend =
-        if (useCromwellGcpBatchBackend) gcpBatchBackend else highSecurityNetworkCromwellBackend
-
       executionServiceWorkflowOptions = ExecutionServiceWorkflowOptions(
         // We pass the submission root as the value for two options,
         // one for the PAPI Cromwell backend and one for the GCP Batch backend.
@@ -336,7 +327,7 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
         deleteIntermediateOutputFiles,
         useReferenceDisks,
         memoryRetryMultiplier,
-        cromwellSubmissionBackend,
+        gcpBatchBackend,
         workflowFailureMode,
         google_labels = Map("terra-submission-id" -> s"terra-${submission.id.toString}"),
         ignoreEmptyOutputs,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -27,7 +27,6 @@ import org.broadinstitute.dsde.rawls.model.{
   SamWorkspaceActions,
   SamWorkspacePolicyNames,
   SeparateSubmissionFinalOutputsSetting,
-  UseCromwellGcpBatchBackendSetting,
   Workspace,
   WorkspaceName,
   WorkspaceSetting,
@@ -143,7 +142,6 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
               case _ => None
             }
           case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) => None
-          case UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(_))         => None
           case PubliclyReadableSetting(PubliclyReadableConfig(_))                             => None
           case CompactDataTablesSetting(CompactDataTablesConfig(_))                           => None
         }
@@ -220,16 +218,13 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
         case PubliclyReadableSetting(PubliclyReadableConfig(enabled)) =>
           applyPublicReadableSetting(workspace, enabled)
 
-        // SeparateSubmissionFinalOutputsSetting, UseCromwellGcpBatchBackendSetting, and CompactDataTablesSetting
+        // SeparateSubmissionFinalOutputsSetting and CompactDataTablesSetting
         // are not bucket settings, so we do not need to apply anything here
 
         case CompactDataTablesSetting(CompactDataTablesConfig(enabled)) =>
           applyCompactDataTablesSetting(WorkspaceName(workspace.namespace, workspace.name), enabled)
 
         case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) =>
-          Future.successful(())
-
-        case UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(_)) =>
           Future.successful(())
       }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -21,7 +21,6 @@ import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.ExecutionService
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketSoftDeleteConfig,
   SeparateSubmissionFinalOutputsConfig,
-  UseCromwellGcpBatchBackendConfig
 }
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
@@ -978,71 +977,7 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
     }
   }
 
-  it should "submit workflows to Cromwell's GCP Batch backend when UseCromwellGcpBatchBackendSetting is true" in withDefaultTestDatabase {
-    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
-    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
-    when(workspaceSettingRepository.getWorkspaceSettings(UUID.fromString(testData.workspace.workspaceId))).thenReturn(
-      Future.successful(
-        List(GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(604800)),
-             UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(true))
-        )
-      )
-    )
-
-    val workflowSubmission =
-      new TestWorkflowSubmission(slickDataSource, workspaceSettingRepository = workspaceSettingRepository) {
-        override val executionServiceCluster = mockExecCluster
-      }
-
-    val (workflowRecs, submissionRec, workspaceRec) =
-      getWorkflowSubmissionWorkspaceRecords(testData.regionalSubmission, testData.workspace)
-
-    Await.result(
-      workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
-      Duration.Inf
-    )
-
-    val workflowOptions = mockExecCluster.getDefaultSubmitMember
-      .asInstanceOf[MockExecutionServiceDAO]
-      .submitOptions
-      .map(_.parseJson.convertTo[ExecutionServiceWorkflowOptions])
-
-    workflowOptions.get.backend should be(CromwellBackend("GCPBatch"))
-  }
-
-  it should "submit workflows to Cromwell's high security network backend when UseCromwellGcpBatchBackendSetting is false" in withDefaultTestDatabase {
-    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
-    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
-    when(workspaceSettingRepository.getWorkspaceSettings(UUID.fromString(testData.workspace.workspaceId))).thenReturn(
-      Future.successful(
-        List(GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(604800)),
-             UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(false))
-        )
-      )
-    )
-
-    val workflowSubmission =
-      new TestWorkflowSubmission(slickDataSource, workspaceSettingRepository = workspaceSettingRepository) {
-        override val executionServiceCluster = mockExecCluster
-      }
-
-    val (workflowRecs, submissionRec, workspaceRec) =
-      getWorkflowSubmissionWorkspaceRecords(testData.regionalSubmission, testData.workspace)
-
-    Await.result(
-      workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
-      Duration.Inf
-    )
-
-    val workflowOptions = mockExecCluster.getDefaultSubmitMember
-      .asInstanceOf[MockExecutionServiceDAO]
-      .submitOptions
-      .map(_.parseJson.convertTo[ExecutionServiceWorkflowOptions])
-
-    workflowOptions.get.backend should be(CromwellBackend("PAPIv2-CloudNAT"))
-  }
-
-  it should "submit workflows to Cromwell's high security network backend when UseCromwellGcpBatchBackendSetting is not set and Batch is not default" in withDefaultTestDatabase {
+  it should "submit workflows to Cromwell's GCP Batch backend as that is the default" in withDefaultTestDatabase {
     val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
     val workspaceSettingRepository = mock[WorkspaceSettingRepository]
     when(workspaceSettingRepository.getWorkspaceSettings(UUID.fromString(testData.workspace.workspaceId))).thenReturn(
@@ -1051,37 +986,8 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
 
     val workflowSubmission =
       new TestWorkflowSubmission(slickDataSource,
-                                 workspaceSettingRepository = workspaceSettingRepository,
-                                 useBatchAsDefaultBackend = false
+                                 workspaceSettingRepository = workspaceSettingRepository
       ) {
-        override val executionServiceCluster = mockExecCluster
-      }
-
-    val (workflowRecs, submissionRec, workspaceRec) =
-      getWorkflowSubmissionWorkspaceRecords(testData.regionalSubmission, testData.workspace)
-
-    Await.result(
-      workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
-      Duration.Inf
-    )
-
-    val workflowOptions = mockExecCluster.getDefaultSubmitMember
-      .asInstanceOf[MockExecutionServiceDAO]
-      .submitOptions
-      .map(_.parseJson.convertTo[ExecutionServiceWorkflowOptions])
-
-    workflowOptions.get.backend should be(CromwellBackend("PAPIv2-CloudNAT"))
-  }
-
-  it should "submit workflows to Cromwell's Batch backend when UseCromwellGcpBatchBackendSetting is not set but Batch is default" in withDefaultTestDatabase {
-    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
-    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
-    when(workspaceSettingRepository.getWorkspaceSettings(UUID.fromString(testData.workspace.workspaceId))).thenReturn(
-      Future.successful(List())
-    )
-
-    val workflowSubmission =
-      new TestWorkflowSubmission(slickDataSource, workspaceSettingRepository = workspaceSettingRepository) {
         override val executionServiceCluster = mockExecCluster
       }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
@@ -11,8 +11,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
   GcpLogBucketRetentionConfig,
-  SeparateSubmissionFinalOutputsConfig,
-  UseCromwellGcpBatchBackendConfig
+  SeparateSubmissionFinalOutputsConfig
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.{CompactDataTables, GcpBucketSoftDelete}
 import org.broadinstitute.dsde.rawls.model.{
@@ -21,7 +20,6 @@ import org.broadinstitute.dsde.rawls.model.{
   GcpBucketSoftDeleteSetting,
   GcpLogBucketRetentionSetting,
   SeparateSubmissionFinalOutputsSetting,
-  UseCromwellGcpBatchBackendSetting,
   Workspace,
   WorkspaceSettingTypes
 }
@@ -112,8 +110,7 @@ class WorkspaceSettingRepositorySpec
       GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(0)),
       GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)),
       GcpLogBucketRetentionSetting(GcpLogBucketRetentionConfig(60)),
-      SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(true)),
-      UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(true))
+      SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(true))
     )
   }
     it should s"be able to get a ${workspaceSetting.getClass.getSimpleName}" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -26,8 +26,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketSoftDeleteConfig,
   GcpLogBucketRetentionConfig,
   PubliclyReadableConfig,
-  SeparateSubmissionFinalOutputsConfig,
-  UseCromwellGcpBatchBackendConfig
+  SeparateSubmissionFinalOutputsConfig
 }
 import org.broadinstitute.dsde.rawls.model.{
   CompactDataTablesSetting,
@@ -45,7 +44,6 @@ import org.broadinstitute.dsde.rawls.model.{
   SamWorkspaceActions,
   SamWorkspacePolicyNames,
   SeparateSubmissionFinalOutputsSetting,
-  UseCromwellGcpBatchBackendSetting,
   UserInfo,
   Workspace,
   WorkspaceName,
@@ -265,8 +263,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
       GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(7.days.toSeconds)),
       GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)),
       GcpLogBucketRetentionSetting(GcpLogBucketRetentionConfig(60)),
-      SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(true)),
-      UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(true))
+      SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(true))
     )
 
     val workspaceRepository = mock[WorkspaceRepository]

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -20,8 +20,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketSoftDeleteConfig,
   GcpLogBucketRetentionConfig,
   PubliclyReadableConfig,
-  SeparateSubmissionFinalOutputsConfig,
-  UseCromwellGcpBatchBackendConfig
+  SeparateSubmissionFinalOutputsConfig
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.{
   CompactDataTables,
@@ -31,7 +30,6 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.{
   GcpLogBucketRetention,
   PubliclyReadable,
   SeparateSubmissionFinalOutputs,
-  UseCromwellGcpBatchBackend,
   WorkspaceSettingType
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceState.WorkspaceState
@@ -616,9 +614,6 @@ case class GcpLogBucketRetentionSetting(override val config: GcpLogBucketRetenti
 case class SeparateSubmissionFinalOutputsSetting(override val config: SeparateSubmissionFinalOutputsConfig)
     extends WorkspaceSetting(settingType = WorkspaceSettingTypes.SeparateSubmissionFinalOutputs, config)
 
-case class UseCromwellGcpBatchBackendSetting(override val config: UseCromwellGcpBatchBackendConfig)
-    extends WorkspaceSetting(settingType = WorkspaceSettingTypes.UseCromwellGcpBatchBackend, config)
-
 case class PubliclyReadableSetting(override val config: PubliclyReadableConfig)
     extends WorkspaceSetting(settingType = WorkspaceSettingTypes.PubliclyReadable, config)
 
@@ -637,7 +632,6 @@ object WorkspaceSettingTypes {
     case "gcpbucketrequesterpays"         => GcpBucketRequesterPays
     case "gcplogbucketretention"          => GcpLogBucketRetention
     case "separatesubmissionfinaloutputs" => SeparateSubmissionFinalOutputs
-    case "usecromwellgcpbatchbackend"     => UseCromwellGcpBatchBackend
     case "publiclyreadable"               => PubliclyReadable
     case "compactdatatables"              => CompactDataTables
     case _                                => throw new RawlsException(s"invalid WorkspaceSetting [$name]")
@@ -652,8 +646,6 @@ object WorkspaceSettingTypes {
   case object GcpLogBucketRetention extends WorkspaceSettingType
 
   case object SeparateSubmissionFinalOutputs extends WorkspaceSettingType
-
-  case object UseCromwellGcpBatchBackend extends WorkspaceSettingType
 
   case object PubliclyReadable extends WorkspaceSettingType
 
@@ -677,8 +669,6 @@ object WorkspaceSettingConfig {
   case class GcpLogBucketRetentionConfig(retentionDurationInDays: Days) extends WorkspaceSettingConfig
 
   case class SeparateSubmissionFinalOutputsConfig(enabled: Boolean) extends WorkspaceSettingConfig
-
-  case class UseCromwellGcpBatchBackendConfig(enabled: Boolean) extends WorkspaceSettingConfig
 
   case class PubliclyReadableConfig(enabled: Boolean) extends WorkspaceSettingConfig
 
@@ -1304,9 +1294,6 @@ class WorkspaceJsonSupport extends JsonSupport {
     jsonFormat1(
       SeparateSubmissionFinalOutputsConfig.apply
     )
-  implicit val UseCromwellGcpBatchBackendConfigFormat: RootJsonFormat[UseCromwellGcpBatchBackendConfig] = jsonFormat1(
-    UseCromwellGcpBatchBackendConfig.apply
-  )
 
   implicit val PubliclyReadableConfigFormat: RootJsonFormat[PubliclyReadableConfig] = jsonFormat1(
     PubliclyReadableConfig.apply
@@ -1332,7 +1319,6 @@ class WorkspaceJsonSupport extends JsonSupport {
       case config: GcpBucketRequesterPaysConfig         => config.toJson
       case config: GcpLogBucketRetentionConfig          => config.toJson
       case config: SeparateSubmissionFinalOutputsConfig => config.toJson
-      case config: UseCromwellGcpBatchBackendConfig     => config.toJson
       case config: PubliclyReadableConfig               => config.toJson
       case config: CompactDataTablesConfig              => config.toJson
     }
@@ -1362,8 +1348,6 @@ class WorkspaceJsonSupport extends JsonSupport {
           GcpLogBucketRetentionSetting(fields("config").convertTo[GcpLogBucketRetentionConfig])
         case SeparateSubmissionFinalOutputs =>
           SeparateSubmissionFinalOutputsSetting(fields("config").convertTo[SeparateSubmissionFinalOutputsConfig])
-        case UseCromwellGcpBatchBackend =>
-          UseCromwellGcpBatchBackendSetting(fields("config").convertTo[UseCromwellGcpBatchBackendConfig])
         case PubliclyReadable =>
           PubliclyReadableSetting(fields("config").convertTo[PubliclyReadableConfig])
         case CompactDataTables =>

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -12,8 +12,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
   GcpLogBucketRetentionConfig,
-  SeparateSubmissionFinalOutputsConfig,
-  UseCromwellGcpBatchBackendConfig
+  SeparateSubmissionFinalOutputsConfig
 }
 import org.joda.time.DateTime
 import org.scalatest.freespec.AnyFreeSpec
@@ -686,12 +685,10 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
         WorkspaceSettingTypes.withName("gcpbucketlifecycle") shouldBe WorkspaceSettingTypes.GcpBucketLifecycle
         WorkspaceSettingTypes.withName("gcpbucketsoftdelete") shouldBe WorkspaceSettingTypes.GcpBucketSoftDelete
         WorkspaceSettingTypes.withName("gcpbucketrequesterpays") shouldBe WorkspaceSettingTypes.GcpBucketRequesterPays
+        WorkspaceSettingTypes.withName("ccplogbucketretention") shouldBe WorkspaceSettingTypes.GcpLogBucketRetention
         WorkspaceSettingTypes.withName(
           "separatesubmissionfinaloutputs"
         ) shouldBe WorkspaceSettingTypes.SeparateSubmissionFinalOutputs
-        WorkspaceSettingTypes.withName(
-          "usecromwellgcpbatchbackend"
-        ) shouldBe WorkspaceSettingTypes.UseCromwellGcpBatchBackend
       }
 
       "should fail trying to parse an invalid workspace setting type" in {
@@ -706,8 +703,8 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
         WorkspaceSettingTypes.GcpBucketLifecycle.toString shouldBe "GcpBucketLifecycle"
         WorkspaceSettingTypes.GcpBucketSoftDelete.toString shouldBe "GcpBucketSoftDelete"
         WorkspaceSettingTypes.GcpBucketRequesterPays.toString shouldBe "GcpBucketRequesterPays"
+        WorkspaceSettingTypes.GcpLogBucketRetention.toString shouldBe "GcpLogBucketRetention"
         WorkspaceSettingTypes.SeparateSubmissionFinalOutputs.toString shouldBe "SeparateSubmissionFinalOutputs"
-        WorkspaceSettingTypes.UseCromwellGcpBatchBackend.toString shouldBe "UseCromwellGcpBatchBackend"
       }
     }
 
@@ -1227,76 +1224,6 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
         val settingBadConfig =
           """{
             |    "settingType": "SeparateSubmissionFinalOutputs",
-            |    "config": {
-            |      "enabled": 0
-            |    }
-            |  }""".stripMargin.parseJson
-        intercept[DeserializationException] {
-          WorkspaceSettingFormat.read(settingBadConfig)
-        }
-      }
-    }
-
-    "UseCromwellGcpBatchBackendSetting" - {
-      "serializes properly" in {
-        val settingJson =
-          """{
-            |    "settingType": "UseCromwellGcpBatchBackend",
-            |    "config": {
-            |      "enabled": true
-            |    }
-            |  }""".stripMargin.parseJson
-        assertResult(settingJson) {
-          WorkspaceSettingFormat.write(
-            UseCromwellGcpBatchBackendSetting(
-              UseCromwellGcpBatchBackendConfig(true)
-            )
-          )
-        }
-      }
-
-      "parses setting with enabled" in {
-        val setting =
-          """{
-            |    "settingType": "UseCromwellGcpBatchBackend",
-            |    "config": {
-            |      "enabled": true
-            |    }
-            |  }""".stripMargin.parseJson
-        assertResult {
-          UseCromwellGcpBatchBackendSetting(
-            UseCromwellGcpBatchBackendConfig(true)
-          )
-        } {
-          WorkspaceSettingFormat.read(setting)
-        }
-      }
-
-      "throws an exception for missing enabled" in {
-        val settingNoEnabled =
-          """{
-            |    "settingType": "UseCromwellGcpBatchBackend",
-            |    "config": {}
-            |  }""".stripMargin.parseJson
-        intercept[DeserializationException] {
-          WorkspaceSettingFormat.read(settingNoEnabled)
-        }
-      }
-
-      "throws an exception for missing config" in {
-        val settingNoConfig =
-          """{
-            |    "settingType": "UseCromwellGcpBatchBackend"
-            |  }""".stripMargin.parseJson
-        intercept[NoSuchElementException] {
-          WorkspaceSettingFormat.read(settingNoConfig)
-        }
-      }
-
-      "throws an exception for incorrect format" in {
-        val settingBadConfig =
-          """{
-            |    "settingType": "UseCromwellGcpBatchBackend",
             |    "config": {
             |      "enabled": 0
             |    }

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -685,7 +685,7 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
         WorkspaceSettingTypes.withName("gcpbucketlifecycle") shouldBe WorkspaceSettingTypes.GcpBucketLifecycle
         WorkspaceSettingTypes.withName("gcpbucketsoftdelete") shouldBe WorkspaceSettingTypes.GcpBucketSoftDelete
         WorkspaceSettingTypes.withName("gcpbucketrequesterpays") shouldBe WorkspaceSettingTypes.GcpBucketRequesterPays
-        WorkspaceSettingTypes.withName("ccplogbucketretention") shouldBe WorkspaceSettingTypes.GcpLogBucketRetention
+        WorkspaceSettingTypes.withName("gcplogbucketretention") shouldBe WorkspaceSettingTypes.GcpLogBucketRetention
         WorkspaceSettingTypes.withName(
           "separatesubmissionfinaloutputs"
         ) shouldBe WorkspaceSettingTypes.SeparateSubmissionFinalOutputs


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AN-523

This PR removes the UseCromwellGcpBatchBackend workspace setting. GCP Batch migration is complete and this setting is no longer needed and used. Other LifeSciences related code will be removed in follow up PR.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
