### PR TITLE
[AN-742] Remove UseCromwellGcpBatchBackend setting again

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -145,4 +145,5 @@
     <include file="changesets/20250604_entity_refs_view.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250616_remove_all_gcpbatch_workspace_settings.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250724_entity_keys_cache.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20250821_remove_all_gcpbatch_workspace_settings_again.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250821_remove_all_gcpbatch_workspace_settings_again.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250821_remove_all_gcpbatch_workspace_settings_again.xml
@@ -2,7 +2,7 @@
 <databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
-    <changeSet logicalFilePath="dummy" author="lmcnatt" id="remove_all_gcpbatch_workspace_settings">
+    <changeSet logicalFilePath="dummy" author="lmcnatt" id="remove_all_gcpbatch_workspace_settings_again">
         <sql>
             UPDATE WORKSPACE_SETTINGS
                 SET STATUS = 'Deleted',

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250821_remove_all_gcpbatch_workspace_settings_again.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250821_remove_all_gcpbatch_workspace_settings_again.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
+    <changeSet logicalFilePath="dummy" author="lmcnatt" id="remove_all_gcpbatch_workspace_settings">
+        <sql>
+            UPDATE WORKSPACE_SETTINGS
+                SET STATUS = 'Deleted',
+                    LAST_UPDATED = NOW(6)
+                WHERE SETTING_TYPE = 'UseCromwellGcpBatchBackend'
+                  AND STATUS = 'Applied'
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250821_remove_all_gcpbatch_workspace_settings_again.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250821_remove_all_gcpbatch_workspace_settings_again.xml
@@ -4,6 +4,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
     <changeSet logicalFilePath="dummy" author="lmcnatt" id="remove_all_gcpbatch_workspace_settings_again">
         <sql>
+        <!-- Deleting again for select users who opted back into Batch after GA -->
             UPDATE WORKSPACE_SETTINGS
                 SET STATUS = 'Deleted',
                     LAST_UPDATED = NOW(6)


### PR DESCRIPTION
Ticket: [AN-742](https://broadworkbench.atlassian.net/browse/AN-742)

Certain workspaces got exceptions to continue using Batch, so when we removed the `UseCromwellGcpBatchBackend` workspace setting infrastructure, they still had the setting and it could no longer be parsed by the system.

Need to re-add this changeset: [Liquibase migration to turn GCP Batch on for all workspaces (#3350) · broadinstitute/rawls@a167a70](https://github.com/broadinstitute/rawls/commit/a167a7015e315ee9918dffd242057fe1cd9a467a)

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[AN-742]: https://broadworkbench.atlassian.net/browse/AN-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ