### PR TITLE
CORE-672: handle 'this' as a root expression for Quicksilver submissions

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -182,7 +182,8 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
 
       case (Some(entityType), Some(entityName), Some(rootEntityType)) =>
         if (
-          expressionEvaluationContext.expression.isEmpty &&
+          // if the expression is empty or exactly "this", we expect the entityType to match the rootEntityType
+          (expressionEvaluationContext.expression.isEmpty || expressionEvaluationContext.expression.contains("this")) &&
           entityType != rootEntityType
         ) {
           val whatYouGaveUs =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/parser/antlr/CompactEvaluateVisitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/parser/antlr/CompactEvaluateVisitor.scala
@@ -25,14 +25,19 @@ class CompactEvaluateVisitor extends TerraExpressionBaseVisitor[Seq[ExpressionLo
 
   override protected def defaultResult(): Seq[ExpressionLookup] = Seq.empty[ExpressionLookup]
 
-  override def visitEntityLookup(ctx: EntityLookupContext): Seq[ExpressionLookup] =
+  override def visitEntityLookup(ctx: EntityLookupContext): Seq[ExpressionLookup] = {
+    // handle nulls in ctx.attributeName()
+    val attributeNameOption = Option(ctx.attributeName()).map { attrName =>
+      toDelimitedName(AntlrTerraExpressionParser.toAttributeName(attrName))
+    }
     Seq(
       ExpressionLookup(
         expression = ctx.getText,
         relations = ctx.relation().asScala.toList,
-        attributeName = Some(toDelimitedName(AntlrTerraExpressionParser.toAttributeName(ctx.attributeName())))
+        attributeName = attributeNameOption
       )
     )
+  }
 
   override def visitWorkspaceAttributeLookup(
     ctx: TerraExpressionParser.WorkspaceAttributeLookupContext

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -1193,90 +1193,90 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
 
   behavior of "evaluateExpressions"
 
-  it should "allow `this` as a root expression" in withMinimalTestDatabase { _ =>
-    // save exemplar data
-    val typeUnderTest = "cat"
+  List(None, Some("this")) foreach { expressionUnderTest =>
+    val entityType = "cat"
     val fooAttribute: AttributeName = AttributeName.withDefaultNS("foo")
     val exemplarDataWithCommonNames: Seq[Entity] =
       Seq(
-        Entity(s"001", typeUnderTest, Map(fooAttribute -> AttributeString(s"$typeUnderTest-001"))),
-        Entity(s"002", typeUnderTest, Map(fooAttribute -> AttributeString(s"$typeUnderTest-002"))),
-        Entity(s"003", typeUnderTest, Map(fooAttribute -> AttributeString(s"$typeUnderTest-003")))
+        Entity(s"001", entityType, Map(fooAttribute -> AttributeString(s"$entityType-001"))),
+        Entity(s"002", entityType, Map(fooAttribute -> AttributeString(s"$entityType-002"))),
+        Entity(s"003", entityType, Map(fooAttribute -> AttributeString(s"$entityType-003")))
       )
-    runAndWait(
-      compactEntityQuery.batchWriteEntities(minimalTestData.workspace.workspaceIdAsUUID,
-                                            exemplarDataWithCommonNames,
-                                            insertOnly = false
+
+    it should s"allow $expressionUnderTest as a root expression" in withMinimalTestDatabase { _ =>
+      // save exemplar data
+      runAndWait(
+        compactEntityQuery.batchWriteEntities(minimalTestData.workspace.workspaceIdAsUUID,
+                                              exemplarDataWithCommonNames,
+                                              insertOnly = false
+        )
       )
-    )
 
-    // get provider
-    val provider = defaultProvider()
+      // get provider
+      val provider = defaultProvider()
 
-    // set up arguments for expression evaluation
-    val expression = Option("this") // <-- this is the root expression, important for this test
-    val expressionEvaluationContext =
-      ExpressionEvaluationContext(Option(typeUnderTest), Option("002"), expression, Option(typeUnderTest))
+      // set up arguments for expression evaluation
+      val expressionEvaluationContext =
+        ExpressionEvaluationContext(Option(entityType), Option("002"), expressionUnderTest, Option(entityType))
 
-    val toolInputParameter = new ToolInputParameter()
-      .name("my-input-name")
-      .valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
-    val processableInputs = Set(MethodInput(toolInputParameter, "this.foo"))
-    val gatherInputsResult = GatherInputsResult(processableInputs, Set(), Set(), Set())
+      val toolInputParameter = new ToolInputParameter()
+        .name("my-input-name")
+        .valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
+      val processableInputs = Set(MethodInput(toolInputParameter, "this.foo"))
+      val gatherInputsResult = GatherInputsResult(processableInputs, Set(), Set(), Set())
 
-    val submissionValidationEntityInputsList =
-      Await.result(provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()), atMost).toList
-    submissionValidationEntityInputsList.size shouldBe 1
-
-    val entityInputs = submissionValidationEntityInputsList.head
-    entityInputs.entityName shouldBe "002"
-    entityInputs.inputResolutions.size shouldBe 1
-    entityInputs.inputResolutions.head.error shouldBe empty
-    entityInputs.inputResolutions.head.inputName shouldBe "my-input-name"
-    entityInputs.inputResolutions.head.value should contain(AttributeString(s"$typeUnderTest-002"))
-  }
-
-  it should "validate entity type even with `this` as a root expression" in withMinimalTestDatabase { _ =>
-    // save exemplar data
-    val typeUnderTest = "cat"
-    val fooAttribute: AttributeName = AttributeName.withDefaultNS("foo")
-    val exemplarDataWithCommonNames: Seq[Entity] =
-      Seq(
-        Entity(s"001", typeUnderTest, Map(fooAttribute -> AttributeString(s"$typeUnderTest-001"))),
-        Entity(s"002", typeUnderTest, Map(fooAttribute -> AttributeString(s"$typeUnderTest-002"))),
-        Entity(s"003", typeUnderTest, Map(fooAttribute -> AttributeString(s"$typeUnderTest-003")))
-      )
-    runAndWait(
-      compactEntityQuery.batchWriteEntities(minimalTestData.workspace.workspaceIdAsUUID,
-                                            exemplarDataWithCommonNames,
-                                            insertOnly = false
-      )
-    )
-
-    // get provider
-    val provider = defaultProvider()
-
-    // set up arguments for expression evaluation
-    val expression = Option("this") // <-- this is the root expression, important for this test
-    val entityType = Option(s"$typeUnderTest-doesnotmatch") // <-- this is the entity type, important for this test
-    val expressionEvaluationContext =
-      ExpressionEvaluationContext(entityType, Option("002"), expression, Option(typeUnderTest))
-
-    val toolInputParameter = new ToolInputParameter()
-      .name("my-input-name")
-      .valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
-    val processableInputs = Set(MethodInput(toolInputParameter, "this.foo"))
-    val gatherInputsResult = GatherInputsResult(processableInputs, Set(), Set(), Set())
-
-    val actualException =
-      intercept[RawlsExceptionWithErrorReport] {
+      val submissionValidationEntityInputsList =
         Await
           .result(provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()), atMost)
           .toList
-      }
+      submissionValidationEntityInputsList.size shouldBe 1
 
-    actualException.errorReport.statusCode should contain(StatusCodes.BadRequest)
-    actualException.errorReport.message should include("expects an entity of type")
+      val entityInputs = submissionValidationEntityInputsList.head
+      entityInputs.entityName shouldBe "002"
+      entityInputs.inputResolutions.size shouldBe 1
+      entityInputs.inputResolutions.head.error shouldBe empty
+      entityInputs.inputResolutions.head.inputName shouldBe "my-input-name"
+      entityInputs.inputResolutions.head.value should contain(AttributeString(s"$entityType-002"))
+    }
+
+    it should s"validate entity type even with $expressionUnderTest as a root expression" in withMinimalTestDatabase {
+      _ =>
+        // save exemplar data
+        runAndWait(
+          compactEntityQuery.batchWriteEntities(minimalTestData.workspace.workspaceIdAsUUID,
+                                                exemplarDataWithCommonNames,
+                                                insertOnly = false
+          )
+        )
+
+        // get provider
+        val provider = defaultProvider()
+
+        // set up arguments for expression evaluation
+        // note that entityType and rootEntityType do not match
+        val expressionEvaluationContext =
+          ExpressionEvaluationContext(Option(s"$entityType-doesnotmatch"),
+                                      Option("002"),
+                                      expressionUnderTest,
+                                      Option(entityType)
+          )
+
+        val toolInputParameter = new ToolInputParameter()
+          .name("my-input-name")
+          .valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
+        val processableInputs = Set(MethodInput(toolInputParameter, "this.foo"))
+        val gatherInputsResult = GatherInputsResult(processableInputs, Set(), Set(), Set())
+
+        val actualException =
+          intercept[RawlsExceptionWithErrorReport] {
+            Await
+              .result(provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()), atMost)
+              .toList
+          }
+
+        actualException.errorReport.statusCode should contain(StatusCodes.BadRequest)
+        actualException.errorReport.message should include("expects an entity of type")
+    }
 
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -3,10 +3,13 @@ package org.broadinstitute.dsde.rawls.entities.compact
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.scaladsl.{Sink, Source}
+import cromwell.client.model.{ToolInputParameter, ValueType}
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponentWithFlatSpecAndMatchers
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
+import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationContext
 import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityNotFoundException}
+import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
   AddListMember,
@@ -1185,6 +1188,51 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
     copiedEntities.entitiesCopied shouldBe empty
     copiedEntities.hardConflicts shouldBe empty
     copiedEntities.softConflicts shouldBe empty
+  }
+
+  behavior of "evaluateExpressions"
+
+  it should "allow `this` as a root expression" in withMinimalTestDatabase { _ =>
+    // save exemplar data
+    val typeUnderTest = "cat"
+    val fooAttribute: AttributeName = AttributeName.withDefaultNS("foo")
+    val exemplarDataWithCommonNames: Seq[Entity] =
+      Seq(
+        Entity(s"001", typeUnderTest, Map(fooAttribute -> AttributeString(s"$typeUnderTest-001"))),
+        Entity(s"002", typeUnderTest, Map(fooAttribute -> AttributeString(s"$typeUnderTest-002"))),
+        Entity(s"003", typeUnderTest, Map(fooAttribute -> AttributeString(s"$typeUnderTest-003")))
+      )
+    runAndWait(
+      compactEntityQuery.batchWriteEntities(minimalTestData.workspace.workspaceIdAsUUID,
+                                            exemplarDataWithCommonNames,
+                                            insertOnly = false
+      )
+    )
+
+    // get provider
+    val provider = defaultProvider()
+
+    // set up arguments for expression evaluation
+    val expression = Option("this") // <-- this is the root expression, important for this test
+    val expressionEvaluationContext =
+      ExpressionEvaluationContext(Option(typeUnderTest), Option("002"), expression, Option(typeUnderTest))
+
+    val toolInputParameter = new ToolInputParameter()
+      .name("my-input-name")
+      .valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
+    val processableInputs = Set(MethodInput(toolInputParameter, "this.foo"))
+    val gatherInputsResult = GatherInputsResult(processableInputs, Set(), Set(), Set())
+
+    val submissionValidationEntityInputsList =
+      Await.result(provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()), atMost).toList
+    submissionValidationEntityInputsList.size shouldBe 1
+
+    val entityInputs = submissionValidationEntityInputsList.head
+    entityInputs.entityName shouldBe "002"
+    entityInputs.inputResolutions.size shouldBe 1
+    entityInputs.inputResolutions.head.error shouldBe empty
+    entityInputs.inputResolutions.head.inputName shouldBe "my-input-name"
+    entityInputs.inputResolutions.head.value should contain(AttributeString(s"$typeUnderTest-002"))
   }
 
   // ====================================================================================================

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.entities.compact
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.scaladsl.{Sink, Source}
 import cromwell.client.model.{ToolInputParameter, ValueType}
@@ -1233,6 +1234,50 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
     entityInputs.inputResolutions.head.error shouldBe empty
     entityInputs.inputResolutions.head.inputName shouldBe "my-input-name"
     entityInputs.inputResolutions.head.value should contain(AttributeString(s"$typeUnderTest-002"))
+  }
+
+  it should "validate entity type even with `this` as a root expression" in withMinimalTestDatabase { _ =>
+    // save exemplar data
+    val typeUnderTest = "cat"
+    val fooAttribute: AttributeName = AttributeName.withDefaultNS("foo")
+    val exemplarDataWithCommonNames: Seq[Entity] =
+      Seq(
+        Entity(s"001", typeUnderTest, Map(fooAttribute -> AttributeString(s"$typeUnderTest-001"))),
+        Entity(s"002", typeUnderTest, Map(fooAttribute -> AttributeString(s"$typeUnderTest-002"))),
+        Entity(s"003", typeUnderTest, Map(fooAttribute -> AttributeString(s"$typeUnderTest-003")))
+      )
+    runAndWait(
+      compactEntityQuery.batchWriteEntities(minimalTestData.workspace.workspaceIdAsUUID,
+                                            exemplarDataWithCommonNames,
+                                            insertOnly = false
+      )
+    )
+
+    // get provider
+    val provider = defaultProvider()
+
+    // set up arguments for expression evaluation
+    val expression = Option("this") // <-- this is the root expression, important for this test
+    val entityType = Option(s"$typeUnderTest-doesnotmatch") // <-- this is the entity type, important for this test
+    val expressionEvaluationContext =
+      ExpressionEvaluationContext(entityType, Option("002"), expression, Option(typeUnderTest))
+
+    val toolInputParameter = new ToolInputParameter()
+      .name("my-input-name")
+      .valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
+    val processableInputs = Set(MethodInput(toolInputParameter, "this.foo"))
+    val gatherInputsResult = GatherInputsResult(processableInputs, Set(), Set(), Set())
+
+    val actualException =
+      intercept[RawlsExceptionWithErrorReport] {
+        Await
+          .result(provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()), atMost)
+          .toList
+      }
+
+    actualException.errorReport.statusCode should contain(StatusCodes.BadRequest)
+    actualException.errorReport.message should include("expects an entity of type")
+
   }
 
   // ====================================================================================================

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -4,11 +4,14 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.scaladsl.Source
+import cromwell.client.model.{ToolInputParameter, ValueType}
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{RefMapping, _}
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
+import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationContext
 import org.broadinstitute.dsde.rawls.entities.compact.entityQuery.CountAndSource
 import org.broadinstitute.dsde.rawls.entities.exceptions._
+import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
   AddUpdateAttribute,
   AttributeUpdateOperation,
@@ -688,10 +691,6 @@ class CompactEntityProviderSpec
       "type3" -> EntityTypeMetadata(3, "type3" + Attributable.entityIdAttributeSuffix, Seq())
     )
   }
-
-  "evaluateExpression" should "have tests" is pending
-  "evaluateExpressions" should "have tests" is pending
-  "expressionValidator" should "have tests" is pending
 
   behavior of "getEntity"
 


### PR DESCRIPTION
Ticket: CORE-672

Fixes two issues when a submission uses a root expression of exactly `this`, such as seen [here](https://github.com/broadinstitute/rawls/blob/3e648b075482bac3b489b5eb1ba7de1cbd5a9268/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala#L83).

The fixes are:
1. Submissions did not validate the supplied entity type against the entity type expected by the method config.
2. Submissions hit a null-pointer error during expression parsing.


