### PR TITLE
CORE-677: SubmissionSupervisor is resilient to pet-retrieval errors

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
@@ -59,6 +59,8 @@ object SubmissionSupervisor {
   case class SaveGlobalJobExecCounts(submissionStatuses: Map[SubmissionStatus, Int],
                                      workflowStatuses: Map[WorkflowStatus, Int]
   )
+  // for unit testing
+  case object CountChildren
 
   def props(executionServiceCluster: ExecutionServiceCluster,
             datasource: DataSourceAccess,
@@ -178,6 +180,10 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
 
     case SaveGlobalJobExecCounts(submissionStatuses, workflowStatuses) =>
       saveGlobalJobExecCounts(submissionStatuses, workflowStatuses)
+
+    // for unit testing
+    case CountChildren =>
+      sender() ! context.children.size
   }
 
   private def scheduleInitialMonitorPass: Cancellable =
@@ -245,13 +251,18 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
         monitoredSubmissions.contains(subId.toString)
       }
 
-      unmonitoredSubmissionsWithPets <- Future.traverse(unmonitoredSubmissions) {
-        case (subId, wsName, perWorkflowCostCap, googleProjectId, submitter) =>
-          getPetServiceAccountUserInfo(googleProjectId, submitter).map(petUserInfo =>
-            (subId, wsName, perWorkflowCostCap, petUserInfo)
-          )
-      }
-      _ = unmonitoredSubmissionsWithPets.foreach { case (subId, wsName, perWorkflowCostCap, pet) =>
+      unmonitoredSubmissionsWithPets <- Future
+        .traverse(unmonitoredSubmissions) { case (subId, wsName, perWorkflowCostCap, googleProjectId, submitter) =>
+          getPetServiceAccountUserInfo(googleProjectId, submitter)
+            .map(petUserInfo => Option((subId, wsName, perWorkflowCostCap, petUserInfo)))
+            .recover { case t: Throwable =>
+              logger.error(s"Error starting submission monitor actors for new submissions: $subId -> ${t.getMessage}",
+                           t
+              )
+              None
+            }
+        }
+      _ = unmonitoredSubmissionsWithPets.flatten.foreach { case (subId, wsName, perWorkflowCostCap, pet) =>
         self ! SubmissionStarted(wsName, subId, perWorkflowCostCap, pet)
       }
     } yield SubmissionMonitorPassComplete).recover { case t: Throwable =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
@@ -382,7 +382,7 @@ class SubmissionSupervisorSpec
 
   it should "handle getPetServiceAccountUserInfo failures gracefully and still start monitors for successful submissions" in withDefaultTestDatabase {
 
-    // Mock the SamDAO to fail for one submission and succeed for the other
+    // Mock the SamDAO
     val mockSamDAOWithFailure = mock[HttpSamDAO]
 
     // Create a new supervisor with the mocked SamDAO
@@ -422,15 +422,17 @@ class SubmissionSupervisorSpec
         .thenReturn(successfulKey) // succeed for the third submission
         .thenReturn(failedKey, failedKey) // fail for any others
 
-      val probe = TestProbe()
-
       // Send StartMonitorPass to trigger startMonitoringNewSubmissions
       supervisorWithMockSam ! StartMonitorPass
 
       // Wait for processing to complete
       Thread.sleep(1000)
 
-      // ask the supervisor how many children it has (i.e. active submission monitors)
+      // Ask the supervisor how many children it has (i.e. active submission monitors).
+      // If the supervisor failed to monitor any submissions, this will be zero.
+      // If the supervisor correctly started monitors for all submissions in `testData`, this will be 11.
+      // We expect it to be 2 because the Sam mock above only succeeds twice.
+      val probe = TestProbe()
       probe.send(supervisorWithMockSam, CountChildren)
       val expectedChildCount = 2
       probe.expectMsgPF(Duration.apply("2 seconds"), s"Expected $expectedChildCount child actors") { case count: Int =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.jobexec
 
 import akka.actor.{ActorRef, ActorSystem, PoisonPill}
 import akka.stream.ActorMaterializer
-import akka.testkit.TestKit
+import akka.testkit.{TestKit, TestProbe}
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
 import org.broadinstitute.dsde.rawls.credentials.FakeRawlsCredentials
@@ -15,15 +15,19 @@ import org.broadinstitute.dsde.rawls.dataaccess.{
 }
 import org.broadinstitute.dsde.rawls.entities.EntityService
 import org.broadinstitute.dsde.rawls.jobexec.SubmissionSupervisor.{
+  CountChildren,
   RefreshGlobalJobExecGauges,
   SaveCurrentWorkflowStatusCounts,
+  StartMonitorPass,
   SubmissionStarted
 }
 import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
 import org.broadinstitute.dsde.rawls.mock.RemoteServicesMockServer
-import org.broadinstitute.dsde.rawls.model.{SubmissionStatuses, WorkflowStatuses}
+import org.broadinstitute.dsde.rawls.model.{GoogleProjectId, RawlsUserEmail, SubmissionStatuses, WorkflowStatuses}
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.when
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -31,6 +35,7 @@ import org.scalatest.matchers.should.Matchers
 
 import java.time.Instant
 import java.util.UUID
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
@@ -373,5 +378,66 @@ class SubmissionSupervisorSpec
         )
       )
     }
+  }
+
+  it should "handle getPetServiceAccountUserInfo failures gracefully and still start monitors for successful submissions" in withDefaultTestDatabase {
+
+    // Mock the SamDAO to fail for one submission and succeed for the other
+    val mockSamDAOWithFailure = mock[HttpSamDAO]
+
+    // Create a new supervisor with the mocked SamDAO
+    val execSvcDAO = new MockExecutionServiceDAO()
+    val execCluster = MockShardedExecutionServiceCluster.fromDAO(execSvcDAO, slickDataSource)
+    val config = SubmissionMonitorConfig(20 minutes, 30 days, true, 20000, true, true)
+
+    val supervisorWithMockSam = system.actorOf(
+      SubmissionSupervisor
+        .props(
+          execCluster,
+          new UncoordinatedDataSourceAccess(slickDataSource),
+          mockSamDAOWithFailure,
+          gcsDAO,
+          _ => mock[EntityService],
+          mockNotificationDAO,
+          config,
+          workbenchMetricBaseName
+        )
+        .withDispatcher("submission-monitor-dispatcher"),
+      "test-supervisor-with-mock-sam"
+    )
+
+    try {
+      // set up the Sam mock to only succeed on the 2nd and 4th calls; this should result in only two
+      // active submission monitors
+      val successfulKey = Future.successful("fake key")
+      val failedKey = Future.failed(new RuntimeException("Sam failure for unit test"))
+      when(
+        mockSamDAOWithFailure.getPetServiceAccountKeyForUser(
+          ArgumentMatchers.any[GoogleProjectId],
+          ArgumentMatchers.any[RawlsUserEmail]
+        )
+      )
+        .thenReturn(successfulKey) // succeed for the first submission
+        .thenReturn(failedKey) // fail for the second submission
+        .thenReturn(successfulKey) // succeed for the third submission
+        .thenReturn(failedKey, failedKey) // fail for any others
+
+      val probe = TestProbe()
+
+      // Send StartMonitorPass to trigger startMonitoringNewSubmissions
+      supervisorWithMockSam ! StartMonitorPass
+
+      // Wait for processing to complete
+      Thread.sleep(1000)
+
+      // ask the supervisor how many children it has (i.e. active submission monitors)
+      probe.send(supervisorWithMockSam, CountChildren)
+      val expectedChildCount = 2
+      probe.expectMsgPF(Duration.apply("2 seconds"), s"Expected $expectedChildCount child actors") { case count: Int =>
+        count shouldBe expectedChildCount
+      }
+
+    } finally
+      supervisorWithMockSam ! PoisonPill
   }
 }


### PR DESCRIPTION
Ticket: CORE-677

Make the `SubmissionSupervisor` resilient to errors retrieving pets for a given submission.

The `SubmissionSupervisor` is the Actor responsible for starting SubmissionMonitorActors for each new submission (and for already-running submissions upon Rawls restart). If it can't start a SubmissionMonitorActor for a given submission, that submission appears in Terra to be hung in "Submitted" status and will never write its outputs back to data tables.

Before this PR, if the `SubmissionSupervisor` hit a Sam error when preparing to start a monitor for ANY new submission, it would fail to start monitors for ALL new submissions. Thus, a single errant submission could make all submissions appear to hang.

In this PR:
* errors on any submission only affect that submission
* the log message for failure-starting-monitor now includes the submission id for the errant submission
