### PR TITLE
CORE-681: use rawls admin permissions to delete pets from a v1 billing project

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
@@ -743,6 +743,18 @@ class HttpSamDAO(baseSamServiceURL: String,
         callback.future.map(_ => ())
       }
 
+    override def deletePetPerProject(userId: String,
+                                     googleProject: GoogleProjectId,
+                                     ctx: RawlsRequestContext
+    ): Future[Unit] =
+      retry(when401or5xx) { () =>
+        val callback = new SamApiCallback[Void]("deletePetPerProject")
+
+        adminApi(ctx).deletePetPerProjectAsync(userId, googleProject.value, callback)
+
+        callback.future.map(_ => ())
+      }
+
     override def userHasResourceTypeAdminPermission(resourceTypeName: SamResourceTypeName,
                                                     action: SamResourceAction,
                                                     ctx: RawlsRequestContext
@@ -753,6 +765,7 @@ class HttpSamDAO(baseSamServiceURL: String,
 
       callback.future.map(_.booleanValue())
     }
+
   }
 
   override def getStatus(): Future[SubsystemStatus] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
@@ -207,6 +207,8 @@ trait SamAdminDAO {
                            ctx: RawlsRequestContext
   ): Future[Unit]
 
+  def deletePetPerProject(userId: String, googleProject: GoogleProjectId, ctx: RawlsRequestContext): Future[Unit]
+
   def userHasResourceTypeAdminPermission(resourceTypeName: SamResourceTypeName,
                                          action: SamResourceAction,
                                          ctx: RawlsRequestContext

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -139,19 +139,19 @@ object UserService {
   )(implicit ex: ExecutionContext): Future[Unit] =
     for {
       projectUsers <- samDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject, projectName.value, ctx)
-      _ <- projectUsers.toList.traverse(destroyPet(_, projectName, gcsDAO, samDAO, ctx))
+      _ <- projectUsers.toList.traverse(destroyPet(_, projectName, samDAO, ctx))
     } yield ()
 
   private def destroyPet(userIdInfo: UserIdInfo,
                          projectName: GoogleProjectId,
-                         gcsDAO: GoogleServicesDAO,
                          samDAO: SamDAO,
                          ctx: RawlsRequestContext
   )(implicit ex: ExecutionContext): Future[Unit] =
     for {
-      petSAJson <- samDAO.getPetServiceAccountKeyForUser(projectName, RawlsUserEmail(userIdInfo.userEmail))
-      petUserInfo <- gcsDAO.getUserInfoUsingJson(petSAJson)
-      _ <- samDAO.deleteUserPetServiceAccount(projectName, ctx.copy(userInfo = petUserInfo))
+      _ <- samDAO.admin.deletePetPerProject(userIdInfo.userSubjectId,
+                                            projectName,
+                                            samDAO.rawlsSAContext.copy(otelContext = ctx.otelContext)
+      )
     } yield ()
 }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
@@ -286,10 +286,17 @@ class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: Executi
     ): Future[Unit] =
       MockSamDAO.this.removeUserFromPolicy(resourceTypeName, resourceId, policyName, memberEmail, ctx)
 
+    override def deletePetPerProject(userId: String,
+                                     googleProject: GoogleProjectId,
+                                     ctx: RawlsRequestContext
+    ): Future[Unit] =
+      ???
+
     override def userHasResourceTypeAdminPermission(resourceTypeName: SamResourceTypeName,
                                                     action: SamResourceAction,
                                                     ctx: RawlsRequestContext
     ): Future[Boolean] = ???
+
   }
 
   override def setPolicyPublic(resourceTypeName: SamResourceTypeName,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.user
 
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.google.api.client.http.{HttpHeaders, HttpResponseException}
 import com.google.api.services.cloudresourcemanager.model.Project
 import com.typesafe.config.{Config, ConfigFactory}
@@ -13,7 +14,7 @@ import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterServiceImp
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.model.google.{BigQueryDatasetName, BigQueryTableName, GoogleProject}
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
+import org.mockito.ArgumentMatchers.{any, anyString, eq => mockitoEq}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
@@ -286,7 +287,18 @@ class UserServiceSpec
       val petSAJson = "petJson"
       runAndWait(rawlsBillingProjectQuery.create(project))
 
+      val adminRequestContext: RawlsRequestContext =
+        RawlsRequestContext(
+          UserInfo(RawlsUserEmail("admin"),
+                   OAuth2BearerToken("Bearer admin token"),
+                   999,
+                   RawlsUserSubjectId("adminSubjectId")
+          )
+        )
+
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+      val mockSamAdminDAO = mock[SamAdminDAO](RETURNS_SMART_NULLS)
+      when(mockSamDAO.admin).thenReturn(mockSamAdminDAO)
       when(
         mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
                                  project.projectName.value,
@@ -305,7 +317,15 @@ class UserServiceSpec
             Seq(SamFullyQualifiedResourceId(project.googleProjectId.value, SamResourceTypeNames.googleProject.value))
           )
         )
-      when(mockSamDAO.deleteUserPetServiceAccount(project.googleProjectId, testContext)).thenReturn(Future.successful())
+      when(mockSamDAO.rawlsSAContext).thenReturn(adminRequestContext)
+      when(
+        mockSamAdminDAO.deletePetPerProject(
+          testContext.userInfo.userSubjectId.value,
+          project.googleProjectId,
+          adminRequestContext.copy(otelContext = testContext.otelContext)
+        )
+      ).thenReturn(Future.successful())
+
       when(mockSamDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, testContext))
         .thenReturn(Future.successful())
       when(mockSamDAO.deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, testContext))
@@ -319,7 +339,10 @@ class UserServiceSpec
       val userService = getUserService(dataSource, mockSamDAO, gcsDAO = mockGcsDAO)
       val actual: Unit = userService.deleteBillingProject(defaultBillingProjectName).futureValue
 
-      verify(mockSamDAO).deleteUserPetServiceAccount(project.googleProjectId, testContext)
+      verify(mockSamAdminDAO).deletePetPerProject(testContext.userInfo.userSubjectId.value,
+                                                  project.googleProjectId,
+                                                  adminRequestContext.copy(otelContext = testContext.otelContext)
+      )
       verify(mockSamDAO).deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, testContext)
       verify(mockSamDAO).deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, testContext)
       verify(mockGcsDAO).deleteV1Project(project.googleProjectId)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.webservice
 
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.rawls.billing.{
   BillingProjectDeletion,
@@ -1046,7 +1047,17 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
   "DELETE /billing/v2/{projectName}" should "return 204 - deleting google project" in withEmptyDatabaseAndApiServices {
     services =>
       val project = createProject("project")
+      val adminRequestContext: RawlsRequestContext =
+        RawlsRequestContext(
+          UserInfo(RawlsUserEmail("admin"),
+                   OAuth2BearerToken("Bearer admin token"),
+                   999,
+                   RawlsUserSubjectId("adminSubjectId")
+          )
+        )
       // wow there are a lot of sam calls in delete billing project
+      val mockSamAdminDAO = mock[SamAdminDAO]
+      when(services.samDAO.admin).thenReturn(mockSamAdminDAO)
       when(
         services.samDAO.userHasAction(
           ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
@@ -1075,9 +1086,11 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
           Seq(SamFullyQualifiedResourceId(project.googleProjectId.value, SamResourceTypeNames.googleProject.value))
         )
       )
+      when(services.samDAO.rawlsSAContext).thenReturn(adminRequestContext)
       when(
-        services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(project.googleProjectId),
-                                                    any[RawlsRequestContext]
+        services.samDAO.admin.deletePetPerProject(anyString(),
+                                                  ArgumentMatchers.eq(project.googleProjectId),
+                                                  any[RawlsRequestContext]
         )
       )
         .thenReturn(Future.successful())
@@ -1106,8 +1119,9 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
           }
         }
 
-      verify(services.samDAO).deleteUserPetServiceAccount(ArgumentMatchers.eq(project.googleProjectId),
-                                                          any[RawlsRequestContext]
+      verify(mockSamAdminDAO).deletePetPerProject(ArgumentMatchers.eq(testContext.userInfo.userSubjectId.value),
+                                                  ArgumentMatchers.eq(project.googleProjectId),
+                                                  any[RawlsRequestContext]
       )
       verify(services.samDAO).deleteResource(
         ArgumentMatchers.eq(SamResourceTypeNames.googleProject),


### PR DESCRIPTION
Ticket: CORE-681

When deleting a v1 billing project, use the Rawls SA to delete pets from the billing project's underlying Google project.

Before this PR, Rawls would generate a token for each pet it wanted to delete, then delete the pet using that pet's token. This would prevent deletion of the billing project if any pet failed to generate a token.