### PR TITLE
CORE-665: quicksilver migration API is not recursive

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -365,7 +365,7 @@ object Boot extends IOApp with LazyLogging {
         workbenchMetricBaseName = metricsPrefix,
         entityManager,
         appConfigManager.conf.getInt("entities.pageSizeLimit"),
-        Some(workspaceSettingServiceConstructor)
+        Some(workspaceSettingRepository)
       )
 
       lazy val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -32,7 +32,11 @@ import org.broadinstitute.dsde.rawls.util.TracingUtils.{
   traceFutureWithParent
 }
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
-import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceSettingService}
+import org.broadinstitute.dsde.rawls.workspace.{
+  WorkspaceRepository,
+  WorkspaceSettingRepository,
+  WorkspaceSettingService
+}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValidationUtils}
 import slick.dbio.{DBIO, DBIOAction, Effect, NoStream}
 import spray.json.DefaultJsonProtocol.jsonFormat3
@@ -48,7 +52,7 @@ object EntityService {
                   workbenchMetricBaseName: String,
                   entityManager: EntityManager,
                   pageSizeLimit: Int,
-                  workspaceSettingServiceConstructor: Option[RawlsRequestContext => WorkspaceSettingService] =
+                  workspaceSettingsRepository: Option[WorkspaceSettingRepository] =
                     None // only used for Quicksilver migration
   )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext, system: ActorSystem): EntityService =
     new EntityService(ctx,
@@ -57,7 +61,7 @@ object EntityService {
                       entityManager,
                       workbenchMetricBaseName,
                       pageSizeLimit,
-                      workspaceSettingServiceConstructor
+                      workspaceSettingsRepository
     )
 }
 
@@ -67,7 +71,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                     entityManager: EntityManager,
                     override val workbenchMetricBaseName: String,
                     pageSizeLimit: Int,
-                    workspaceSettingServiceConstructor: Option[RawlsRequestContext => WorkspaceSettingService] =
+                    workspaceSettingsRepository: Option[WorkspaceSettingRepository] =
                       None // only used for Quicksilver migration
 )(implicit protected val executionContext: ExecutionContext, system: ActorSystem)
     extends WorkspaceSupport
@@ -389,8 +393,8 @@ class EntityService(protected val ctx: RawlsRequestContext,
         _ = authDomainCheck(sourceAD.toSet, destAD.toSet)
         entityProvider <- getProviderWithTracing(destWsCtx, localContext)
 
-        sourceCompactEnabled <- isCompactDataTableSettingEnabled(entityCopyDef.sourceWorkspace)
-        destCompactEnabled <- isCompactDataTableSettingEnabled(entityCopyDef.destinationWorkspace)
+        sourceCompactEnabled <- isCompactDataTableSettingEnabled(sourceWsCtx.workspaceIdAsUUID)
+        destCompactEnabled <- isCompactDataTableSettingEnabled(destWsCtx.workspaceIdAsUUID)
         _ = if (sourceCompactEnabled != destCompactEnabled) {
           throw new RawlsExceptionWithErrorReport(
             ErrorReport(
@@ -561,11 +565,10 @@ class EntityService(protected val ctx: RawlsRequestContext,
   /**
    * Determine if a workspace has the CompactDataTables setting enabled.
    */
-  def isCompactDataTableSettingEnabled(workspaceName: WorkspaceName): Future[Boolean] =
-    workspaceSettingServiceConstructor match {
-      case Some(serviceConstructor) =>
-        val workspaceSettingService = serviceConstructor(ctx)
-        workspaceSettingService.getWorkspaceSettingOfType(workspaceName, CompactDataTables) map {
+  def isCompactDataTableSettingEnabled(workspaceId: UUID): Future[Boolean] =
+    workspaceSettingsRepository match {
+      case Some(repository) =>
+        repository.getWorkspaceSettingOfType(workspaceId, CompactDataTables) map {
           case Some(qs: CompactDataTablesSetting) => qs.config.enabled
           case _                                  => false
         }
@@ -601,9 +604,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
         workspaceId = workspaceContext.workspaceIdAsUUID
 
         // confirm if this is already a quicksilver workspace by checking settings
-        workspaceSettingService = workspaceSettingServiceConstructor.get.apply(ctx)
+        settingsRepo = workspaceSettingsRepository.get
         settings <- traceFutureWithParent("getWorkspaceSettings", s) { _ =>
-          workspaceSettingService.getWorkspaceSettings(workspaceName)
+          settingsRepo.getWorkspaceSettings(workspaceContext.workspaceIdAsUUID)
         }
         _ = if (
           settings
@@ -618,7 +621,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         // If Migration is triggered from Settings, there will be "Pending" settings
         // If Migration is triggered from the Migration API, there will be no "Pending" settings unless already requested
         hasPendingSettings <- traceFutureWithParent("workspaceHasPendingSettings", s) { _ =>
-          workspaceSettingService.workspaceHasPendingSettings(workspaceName, CompactDataTables)
+          settingsRepo.hasPendingSettings(workspaceContext.workspaceIdAsUUID, CompactDataTables)
         }
 
         // If there are pending settings, it means migration has already been requested and is currently in progress.
@@ -633,9 +636,10 @@ class EntityService(protected val ctx: RawlsRequestContext,
         // This is done before the migration starts to ensure that the workspace setting marked as "Pending"
         _ = if (!hasPendingSettings && updateWorkspaceSettings) {
           traceFutureWithParent("setWorkspaceSettings", s) { _ =>
-            workspaceSettingService.setWorkspaceSettings(
-              workspaceName,
-              List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
+            settingsRepo.createWorkspaceSettingsRecords(
+              workspaceContext.workspaceIdAsUUID,
+              List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true))),
+              ctx.userInfo.userSubjectId
             )
           }
         }
@@ -688,6 +692,16 @@ class EntityService(protected val ctx: RawlsRequestContext,
             } yield QuicksilverMigrationResult(numEntitiesUpdated, numEntitiesDeleted, numAttributesDeleted)
           }
 
+        }
+
+        // Apply the workspace setting to mark the migration as finalized
+        _ = if (updateWorkspaceSettings) {
+          traceFutureWithParent("applyWorkspaceSettings", s) { _ =>
+            settingsRepo.markWorkspaceSettingApplied(
+              workspaceContext.workspaceIdAsUUID,
+              WorkspaceSettingTypes.CompactDataTables
+            )
+          }
         }
 
         // return a count of entities updated

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1147,7 +1147,7 @@ class WorkspaceService(
       }
 
       compactDataTablesEnabled <- entityServiceConstructor(ctx).isCompactDataTableSettingEnabled(
-        sourceWorkspace.toWorkspaceName
+        sourceWorkspace.workspaceIdAsUUID
       )
 
       (sourceWorkspaceContext, destWorkspaceContext) <- dataSource.inTransactionWithAttrTempTable(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -96,10 +96,12 @@ class EntityServiceCompactMigrationSpec
 
     val googleStorageService = mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS)
 
+    val workspaceSettingRepository = new WorkspaceSettingRepository(dataSource)
+
     val workspaceSettingServiceConstructor: Option[RawlsRequestContext => WorkspaceSettingService] = Some { ctx =>
       new WorkspaceSettingService(
         ctx,
-        new WorkspaceSettingRepository(dataSource),
+        workspaceSettingRepository,
         new WorkspaceRepository(dataSource),
         new MockGoogleServicesDAO("groupsPrefix"),
         samDAO,
@@ -114,13 +116,13 @@ class EntityServiceCompactMigrationSpec
       workbenchMetricBaseName,
       EntityManager.defaultEntityManager(
         dataSource,
-        new WorkspaceSettingRepository(dataSource),
+        workspaceSettingRepository,
         testConf.getBoolean("entityStatisticsCache.enabled"),
         testConf.getDuration("entities.queryTimeout"),
         workbenchMetricBaseName
       )(executionContext, system),
       7, // <-- specifically, chosen to be lower than the number of samples in "workspace" within testData
-      workspaceSettingServiceConstructor
+      Option(workspaceSettingRepository)
     ) _
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -280,14 +280,10 @@ class FastPassServiceSpec
       mock[WorkspaceSettingService](RETURNS_SMART_NULLS)
 
     val entityService = Mockito.spy(
-      new EntityService(ctx1,
-                        slickDataSource,
-                        samDAO,
-                        entityManager,
-                        workbenchMetricBaseName,
-                        10000,
-                        Some(workspaceSettingServiceConstructor)
-      )(executionContext, ActorSystem("mockEntityService"))
+      new EntityService(ctx1, slickDataSource, samDAO, entityManager, workbenchMetricBaseName, 10000, None)(
+        executionContext,
+        ActorSystem("mockEntityService")
+      )
     )
     val entityServiceConstructor: RawlsRequestContext => EntityService = _ => entityService
 
@@ -418,7 +414,7 @@ class FastPassServiceSpec
 
     doReturn(Future.successful(false))
       .when(services.entityService)
-      .isCompactDataTableSettingEnabled(parentWorkspace.toWorkspaceName)
+      .isCompactDataTableSettingEnabled(parentWorkspace.workspaceIdAsUUID)
 
     val mockedProvider = mock[LocalEntityProvider](RETURNS_SMART_NULLS)
     when(mockedProvider.clone(any(), any(), any())).thenReturn(DBIO.successful((1, 0)))
@@ -1102,7 +1098,7 @@ class FastPassServiceSpec
 
     doReturn(Future.successful(false))
       .when(services.entityService)
-      .isCompactDataTableSettingEnabled(parentWorkspace.toWorkspaceName)
+      .isCompactDataTableSettingEnabled(parentWorkspace.workspaceIdAsUUID)
 
     val mockedProvider = mock[LocalEntityProvider](RETURNS_SMART_NULLS)
     when(mockedProvider.clone(any(), any(), any())).thenReturn(DBIO.successful((1, 0)))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -294,7 +294,7 @@ trait ApiServiceSpec
                                 workbenchMetricBaseName = "test",
                                 entityManager,
                                 1000,
-                                Some(workspaceSettingServiceConstructor)
+                                Some(new WorkspaceSettingRepository(slickDataSource))
       ) _
 
     val resourceBufferDAO: ResourceBufferDAO = new MockResourceBufferDAO

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -80,7 +80,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
                                 workbenchMetricBaseName = "test",
                                 entityManager,
                                 1000,
-                                Some(settingService)
+                                Some(spyWorkspaceSettingRepository)
       )
 
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -119,7 +119,8 @@ class WorkspaceServiceSpec
 
   val leonardoDAO: MockLeonardoDAO = new MockLeonardoDAO()
 
-  val mockWorkspaceSettingService: WorkspaceSettingService = mock[WorkspaceSettingService](RETURNS_SMART_NULLS);
+  val mockWorkspaceSettingService: WorkspaceSettingService = mock[WorkspaceSettingService](RETURNS_SMART_NULLS)
+  val mockWorkspaceSettingRepository: WorkspaceSettingRepository = mock[WorkspaceSettingRepository](RETURNS_SMART_NULLS)
 
   val mockLocalProvider: LocalEntityProvider = mock[LocalEntityProvider](RETURNS_SMART_NULLS)
 
@@ -307,7 +308,13 @@ class WorkspaceServiceSpec
       .resolveProviderFuture(any[EntityRequestArguments])(any[ExecutionContext])
 
     val entityServiceConstructor =
-      EntityService.constructor(slickDataSource, samDAO, workbenchMetricBaseName = "test", entityManager, 1000, None) _
+      EntityService.constructor(slickDataSource,
+                                samDAO,
+                                workbenchMetricBaseName = "test",
+                                entityManager,
+                                1000,
+                                Option(mockWorkspaceSettingRepository)
+      ) _
 
     val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,
@@ -1914,9 +1921,10 @@ class WorkspaceServiceSpec
   "cloneWorkspace" should "create a V2 Workspace using compact data tables" in withTestDataServices { services =>
     val baseWorkspace = testData.workspace
     val newWorkspaceName = "cloned_space"
+
     when(
-      mockWorkspaceSettingService.getWorkspaceSettingOfType(
-        baseWorkspace.toWorkspaceName,
+      services.mockWorkspaceSettingRepository.getWorkspaceSettingOfType(
+        baseWorkspace.workspaceIdAsUUID,
         CompactDataTables
       )
     ).thenReturn(Future.successful(Option(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -140,12 +140,19 @@ class WorkspaceServiceSpec
 
   override def beforeEach(): Unit = {
     super.beforeEach()
+    clearInvocations(mockWorkspaceSettingService, mockWorkspaceSettingRepository)
     when(
       mockWorkspaceSettingService.getWorkspaceSettingOfType(
         any[WorkspaceName],
         any[WorkspaceSettingType]
       )
     ).thenReturn(Future.successful(None))
+    when(
+      mockWorkspaceSettingRepository.getWorkspaceSettingOfType(
+        any[UUID],
+        ArgumentMatchers.eq(CompactDataTables)
+      )
+    ).thenReturn(Future.successful(Option(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))))
   }
 
   // noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
@@ -1903,6 +1910,9 @@ class WorkspaceServiceSpec
     val newWorkspaceName = "cloned_space"
     val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)
 
+    when(mockWorkspaceSettingService.setWorkspaceSettings(any[WorkspaceName], any[List[WorkspaceSetting]]))
+      .thenReturn(Future.successful(mock[WorkspaceSettingResponse]))
+
     val workspace =
       Await.result(services.workspaceService.cloneWorkspace(
                      baseWorkspace.toWorkspaceName,
@@ -1921,13 +1931,6 @@ class WorkspaceServiceSpec
   "cloneWorkspace" should "create a V2 Workspace using compact data tables" in withTestDataServices { services =>
     val baseWorkspace = testData.workspace
     val newWorkspaceName = "cloned_space"
-
-    when(
-      services.mockWorkspaceSettingRepository.getWorkspaceSettingOfType(
-        baseWorkspace.workspaceIdAsUUID,
-        CompactDataTables
-      )
-    ).thenReturn(Future.successful(Option(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))))
 
     when(mockWorkspaceSettingService.setWorkspaceSettings(any[WorkspaceName], any[List[WorkspaceSetting]]))
       .thenReturn(Future.successful(mock[WorkspaceSettingResponse]))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -307,13 +307,7 @@ class WorkspaceServiceSpec
       .resolveProviderFuture(any[EntityRequestArguments])(any[ExecutionContext])
 
     val entityServiceConstructor =
-      EntityService.constructor(slickDataSource,
-                                samDAO,
-                                workbenchMetricBaseName = "test",
-                                entityManager,
-                                1000,
-                                Some(workspaceSettingServiceConstructor)
-      ) _
+      EntityService.constructor(slickDataSource, samDAO, workbenchMetricBaseName = "test", entityManager, 1000, None) _
 
     val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,


### PR DESCRIPTION
Ticket: CORE-665

Fixes an issue with the `quicksilver_migration` API which ran two migrations in parallel, with one of those typically failing with a lock-wait error. On trivially small workspaces, both parallel migrations might succeed.

When migrating a workspace to Quicksilver using workspace settings, the high-level flow is:
1. Toggle the `CompactDataTablesSetting` to true, which triggers:
2. `EntityService.quicksilverMigration()` to perform the data table migration
3. Mark the `CompactDataTablesSetting` as applied

However, prior to this PR, when migrating a workspace to Quicksilver using the `quicksilver_migration` API, the high-level flow was:
1. Call `EntityService.quicksilverMigration()` to start the data table migration, which internally:
2. Toggles the `CompactDataTablesSetting` to true, which triggers:
3. A parallel execution of `EntityService.quicksilverMigration()`

We had logic in `EntityService.quicksilverMigration()` to prevent double-writing the workspace setting value. But we did not have logic in workspace settings to prevent double-execution of the migration.

In this PR, I change the `EntityService.quicksilverMigration()` to bypass WorkspaceSettingService and instead write settings directly via WorkspaceSettingRepository. Only WorkspaceSettingService will trigger a migration when the setting changes, so this prevents the parallel execution.

_All of this logic should be removed once all workspaces are migrated to Quicksilver._
