### PR TITLE
CORE-665: Quicksilver migration is conditional on setting's value

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -638,7 +638,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
           traceFutureWithParent("setWorkspaceSettings", s) { _ =>
             settingsRepo.createWorkspaceSettingsRecords(
               workspaceContext.workspaceIdAsUUID,
-              List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true))),
+              List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true, performMigration = Option(false)))),
               ctx.userInfo.userSubjectId
             )
           }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -220,7 +220,7 @@ class WorkspaceService(
     def enableQuicksilver(workspaceId: UUID): Future[Int] = for {
       _ <- workspaceSettingsRepository.createWorkspaceSettingsRecords(
         workspaceId,
-        List(CompactDataTablesSetting(CompactDataTablesConfig(true))),
+        List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true, performMigration = Option(false)))),
         parentContext.userInfo.userSubjectId
       )
       numApplied <- workspaceSettingsRepository.markWorkspaceSettingApplied(workspaceId,
@@ -1219,7 +1219,7 @@ class WorkspaceService(
           logger.info("enabling compact data tables on new workspace")
           workspaceSettingServiceConstructor(ctx).setWorkspaceSettings(
             destWorkspaceContext.toWorkspaceName,
-            List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
+            List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true, performMigration = Option(false))))
           )
         } else {
           Future.successful()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -305,7 +305,7 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
         case _ =>
           Future.successful(())
       }
-    } else if (performMigration.contains(true)) {
+    } else if (performMigration.isEmpty || performMigration.contains(true)) { // default to true
       // If compact data tables setting is enabled and a migration is requested, we need to migrate the entity attributes.
       Future {
         entityService

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -143,7 +143,7 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
             }
           case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) => None
           case PubliclyReadableSetting(PubliclyReadableConfig(_))                             => None
-          case CompactDataTablesSetting(CompactDataTablesConfig(_))                           => None
+          case CompactDataTablesSetting(CompactDataTablesConfig(_, _))                        => None
         }
       }
 
@@ -221,8 +221,8 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
         // SeparateSubmissionFinalOutputsSetting and CompactDataTablesSetting
         // are not bucket settings, so we do not need to apply anything here
 
-        case CompactDataTablesSetting(CompactDataTablesConfig(enabled)) =>
-          applyCompactDataTablesSetting(WorkspaceName(workspace.namespace, workspace.name), enabled)
+        case CompactDataTablesSetting(CompactDataTablesConfig(enabled, performMigration)) =>
+          applyCompactDataTablesSetting(WorkspaceName(workspace.namespace, workspace.name), enabled, performMigration)
 
         case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) =>
           Future.successful(())
@@ -291,19 +291,22 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
   /**
    * Call to handle entity attributes migration when compact data tables setting enabled.
    */
-  private def applyCompactDataTablesSetting(workspaceName: WorkspaceName, enabled: Boolean): Future[Unit] =
+  private def applyCompactDataTablesSetting(workspaceName: WorkspaceName,
+                                            enabled: Boolean,
+                                            performMigration: Option[Boolean]
+  ): Future[Unit] =
     if (!enabled) {
       // Check if the setting is already enabled in the database
       getWorkspaceSettingOfType(workspaceName, CompactDataTables).flatMap {
-        case Some(CompactDataTablesSetting(CompactDataTablesConfig(true))) =>
+        case Some(CompactDataTablesSetting(CompactDataTablesConfig(true, _))) =>
           throw new RawlsExceptionWithErrorReport(
             ErrorReport(StatusCodes.BadRequest, "Cannot disable compact data tables setting once enabled.")
           )
         case _ =>
           Future.successful(())
       }
-    } else {
-      // If compact data tables setting is enabled, we need to migrate the entity attributes.
+    } else if (performMigration.contains(true)) {
+      // If compact data tables setting is enabled and a migration is requested, we need to migrate the entity attributes.
       Future {
         entityService
           .quicksilverMigration(workspaceName = workspaceName, updateWorkspaceSettings = false)
@@ -314,5 +317,8 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
             )
           }
       }.flatten
+    } else {
+      // no action necessary; no migration was requested
+      Future.successful(())
     }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -1849,7 +1849,9 @@ class WorkspaceServiceSpec
       )
     )
 
-    actual should contain(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
+    actual should contain(
+      CompactDataTablesSetting(CompactDataTablesConfig(enabled = true, performMigration = Option(false)))
+    )
   }
 
   // There is another test in WorkspaceComponentSpec that gets into more scenarios for selecting the right Workspaces
@@ -1957,7 +1959,7 @@ class WorkspaceServiceSpec
     val destWorkspaceName = WorkspaceName(testData.testProject1Name.value, newWorkspaceName)
     verify(mockWorkspaceSettingService).setWorkspaceSettings(
       destWorkspaceName,
-      List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true)))
+      List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true, performMigration = Option(false))))
     )
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -55,11 +55,12 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, anyBoolean, anyInt}
+import org.mockito.Mockito.times
 import org.mockito.Mockito.{verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.matchers.must.Matchers.{contain, include}
+import org.scalatest.matchers.must.Matchers.{contain, empty, include}
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import java.util.UUID
@@ -1188,4 +1189,141 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     error.statusCode shouldBe Some(StatusCodes.BadRequest)
     error.message should include("Cannot disable compact data tables setting once enabled.")
   }
+
+  List(Option(true), None) foreach { performMigrationArgument =>
+    it should s"trigger a migration when performMigration is $performMigrationArgument" in {
+      val workspaceId = workspace.workspaceIdAsUUID
+      val workspaceName = workspace.toWorkspaceName
+      val enableCompactDataTablesSetting =
+        CompactDataTablesSetting(CompactDataTablesConfig(enabled = true, performMigration = performMigrationArgument))
+
+      val workspaceRepository = mock[WorkspaceRepository]
+      when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
+
+      val workspaceSettingRepository = mock[WorkspaceSettingRepository]
+      when(workspaceSettingRepository.getWorkspaceSettings(workspaceId)).thenReturn(Future.successful(List.empty))
+      when(
+        workspaceSettingRepository.createWorkspaceSettingsRecords(workspaceId,
+                                                                  List(enableCompactDataTablesSetting),
+                                                                  defaultRequestContext.userInfo.userSubjectId
+        )
+      ).thenReturn(Future.successful(List(enableCompactDataTablesSetting)))
+      when(
+        workspaceSettingRepository.markWorkspaceSettingApplied(workspaceId, enableCompactDataTablesSetting.settingType)
+      )
+        .thenReturn(Future.successful(1))
+
+      val samDAO = mock[SamDAO]
+      when(samDAO.getUserStatus(any()))
+        .thenReturn(
+          Future.successful(Option(SamUserStatusResponse("fake_user_id", "user@example.com", enabled = true)))
+        )
+      when(
+        samDAO.userHasAction(
+          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+          ArgumentMatchers.eq(workspaceId.toString),
+          ArgumentMatchers.eq(SamWorkspaceActions.writeSettings),
+          any()
+        )
+      ).thenReturn(Future.successful(true))
+
+      val entityService = mock[EntityService]
+      when(
+        entityService.quicksilverMigration(
+          ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
+          any[Boolean],
+          any[Int],
+          any[Boolean]
+        )
+      ).thenReturn(Future.successful(QuicksilverMigrationResult(1, 2, 3)))
+
+      val service =
+        workspaceSettingServiceConstructor(
+          samDAO = samDAO,
+          workspaceRepository = workspaceRepository,
+          workspaceSettingRepository = workspaceSettingRepository,
+          entityService = entityService
+        )
+
+      val result =
+        Await.result(service.setWorkspaceSettings(workspaceName, List(enableCompactDataTablesSetting)), Duration.Inf)
+      result.successes shouldBe List(enableCompactDataTablesSetting)
+      result.failures shouldBe empty
+
+      verify(entityService).quicksilverMigration(
+        ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
+        anyBoolean(),
+        anyInt(),
+        ArgumentMatchers.eq(false)
+      )
+    }
+  }
+
+  it should s"not trigger a migration when performMigration is Some(false)" in {
+    val workspaceId = workspace.workspaceIdAsUUID
+    val workspaceName = workspace.toWorkspaceName
+    val enableCompactDataTablesSetting =
+      CompactDataTablesSetting(CompactDataTablesConfig(enabled = true, performMigration = Option(false)))
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
+
+    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
+    when(workspaceSettingRepository.getWorkspaceSettings(workspaceId)).thenReturn(Future.successful(List.empty))
+    when(
+      workspaceSettingRepository.createWorkspaceSettingsRecords(workspaceId,
+                                                                List(enableCompactDataTablesSetting),
+                                                                defaultRequestContext.userInfo.userSubjectId
+      )
+    ).thenReturn(Future.successful(List(enableCompactDataTablesSetting)))
+    when(
+      workspaceSettingRepository.markWorkspaceSettingApplied(workspaceId, enableCompactDataTablesSetting.settingType)
+    )
+      .thenReturn(Future.successful(1))
+
+    val samDAO = mock[SamDAO]
+    when(samDAO.getUserStatus(any()))
+      .thenReturn(
+        Future.successful(Option(SamUserStatusResponse("fake_user_id", "user@example.com", enabled = true)))
+      )
+    when(
+      samDAO.userHasAction(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceId.toString),
+        ArgumentMatchers.eq(SamWorkspaceActions.writeSettings),
+        any()
+      )
+    ).thenReturn(Future.successful(true))
+
+    val entityService = mock[EntityService]
+    when(
+      entityService.quicksilverMigration(
+        ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
+        any[Boolean],
+        any[Int],
+        any[Boolean]
+      )
+    ).thenReturn(Future.successful(QuicksilverMigrationResult(1, 2, 3)))
+
+    val service =
+      workspaceSettingServiceConstructor(
+        samDAO = samDAO,
+        workspaceRepository = workspaceRepository,
+        workspaceSettingRepository = workspaceSettingRepository,
+        entityService = entityService
+      )
+
+    val result =
+      Await.result(service.setWorkspaceSettings(workspaceName, List(enableCompactDataTablesSetting)), Duration.Inf)
+    result.successes shouldBe List(enableCompactDataTablesSetting)
+    result.failures shouldBe empty
+
+    verify(entityService, times(0)).quicksilverMigration(
+      any[WorkspaceName],
+      anyBoolean(),
+      anyInt(),
+      anyBoolean()
+    )
+  }
+
 }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -672,7 +672,8 @@ object WorkspaceSettingConfig {
 
   case class PubliclyReadableConfig(enabled: Boolean) extends WorkspaceSettingConfig
 
-  case class CompactDataTablesConfig(enabled: Boolean) extends WorkspaceSettingConfig
+  case class CompactDataTablesConfig(enabled: Boolean, performMigration: Option[Boolean] = Some(true))
+      extends WorkspaceSettingConfig
 }
 
 case class WorkspaceSettingResponse(successes: List[WorkspaceSetting], failures: Map[WorkspaceSettingType, ErrorReport])
@@ -1301,7 +1302,7 @@ class WorkspaceJsonSupport extends JsonSupport {
     PubliclyReadableConfig.apply
   )
 
-  implicit val CompactDataTablesConfigFormat: RootJsonFormat[CompactDataTablesConfig] = jsonFormat1(
+  implicit val CompactDataTablesConfigFormat: RootJsonFormat[CompactDataTablesConfig] = jsonFormat2(
     CompactDataTablesConfig.apply
   )
 


### PR DESCRIPTION
Ticket: CORE-665

Add logic to conditionally skip or execute a data table migration when the `CompactDataTablesSetting` workspace setting is saved. This PR adds a new `performMigration` argument to the setting's config, and skips migration if `performMigration` contains `false`.

This allows us to safely add the setting to a workspace at times we don't want to execute a migration:
* when creating a new workspace (no data tables exist yet; migration is extraneous)
* when cloning a workspace  (we've already cloned data tables; migration is extraneous at best and could risk overwriting data)
* from inside the migration code, if the setting doesn't already exist (prevents calling the migration recursively)

The new `performMigration` argument is an `Option` to handle deserialization from existing settings which don't have the argument.