### PR TITLE
CORE-678: when creating a submission, use the submitter email address known by Sam

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -486,14 +486,14 @@ class SubmissionsService(
       }
     }
 
-  private def getUserEmail: Future[RawlsUserEmail] = {
+  private def getUserEmail: Future[RawlsUserEmail] =
     for {
       // ask Sam for the email address it knows for this user
-      submitterOption <- samDAO.getUserStatus(ctx) recover {
-        case e: Throwable =>
-          throw new RawlsExceptionWithErrorReport(
-            errorReport = ErrorReport(StatusCodes.InternalServerError, s"Failed to get user status from Sam: ${e.getMessage}")
-          )
+      submitterOption <- samDAO.getUserStatus(ctx) recover { case e: Throwable =>
+        throw new RawlsExceptionWithErrorReport(
+          errorReport =
+            ErrorReport(StatusCodes.InternalServerError, s"Failed to get user status from Sam: ${e.getMessage}")
+        )
       }
       submitter = submitterOption match {
         case Some(userStatus) => RawlsUserEmail(userStatus.userEmail)
@@ -509,7 +509,6 @@ class SubmissionsService(
         )
       }
     } yield submitter
-  }
 
   def createSubmission(workspaceName: WorkspaceName, submissionRequest: SubmissionRequest): Future[SubmissionReport] =
     for {
@@ -1023,4 +1022,3 @@ class SubmissionsService(
         }
     } yield s"gs://${workspace.bucketName}/submissions/$intermediates$id"
 }
-  }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -42,6 +42,7 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsBillingProject,
   RawlsBillingProjectName,
   RawlsRequestContext,
+  RawlsUserEmail,
   RetriedSubmissionReport,
   SamWorkspaceActions,
   SeparateSubmissionFinalOutputsSetting,
@@ -485,8 +486,36 @@ class SubmissionsService(
       }
     }
 
+  private def getUserEmail: Future[RawlsUserEmail] = {
+    for {
+      // ask Sam for the email address it knows for this user
+      submitterOption <- samDAO.getUserStatus(ctx) recover {
+        case e: Throwable =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.InternalServerError, s"Failed to get user status from Sam: ${e.getMessage}")
+          )
+      }
+      submitter = submitterOption match {
+        case Some(userStatus) => RawlsUserEmail(userStatus.userEmail)
+        case None =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.Unauthorized, "User not found in Sam")
+          )
+      }
+      // for debugging
+      _ = if (submitter != ctx.userInfo.userEmail) {
+        logger.warn(
+          s"User email in Sam is different than the one in the request context: $submitter vs ${ctx.userInfo.userEmail}"
+        )
+      }
+    } yield submitter
+  }
+
   def createSubmission(workspaceName: WorkspaceName, submissionRequest: SubmissionRequest): Future[SubmissionReport] =
     for {
+      // ask Sam for the email address it knows for this user
+      submitter <- getUserEmail
+
       ps <- prepareSubmission(workspaceName, submissionRequest)
       submission <- saveSubmission(
         ps.workspace,
@@ -495,7 +524,8 @@ class SubmissionsService(
         ps.submissionRoot,
         ps.inputs,
         ps.failureMode,
-        ps.header
+        ps.header,
+        submitter
       )
       _ <- getSetToDelete(submissionRequest)
         .map { setToDelete =>
@@ -760,7 +790,8 @@ class SubmissionsService(
                              submissionRoot: String,
                              submissionParameters: Seq[SubmissionValidationEntityInputs],
                              workflowFailureMode: Option[WorkflowFailureMode],
-                             header: SubmissionValidationHeader
+                             header: SubmissionValidationHeader,
+                             submitter: RawlsUserEmail
   ): Future[Submission] =
     dataSource.inTransaction { dataAccess =>
       val (successes, failures) = submissionParameters.partition { entityInputs =>
@@ -807,7 +838,7 @@ class SubmissionsService(
       val submission = Submission(
         submissionId = submissionId.toString,
         submissionDate = DateTime.now(),
-        submitter = WorkbenchEmail(ctx.userInfo.userEmail.value),
+        submitter = WorkbenchEmail(submitter.value),
         methodConfigurationNamespace = submissionRequest.methodConfigurationNamespace,
         methodConfigurationName = submissionRequest.methodConfigurationName,
         submissionEntity = submissionEntityOpt,
@@ -992,3 +1023,4 @@ class SubmissionsService(
         }
     } yield s"gs://${workspace.bucketName}/submissions/$intermediates$id"
 }
+  }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -35,6 +35,7 @@ import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNoti
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
@@ -460,7 +461,8 @@ class SubmissionSpec(_system: ActorSystem)
       new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName),
     bigQueryServiceFactory: GoogleBigQueryServiceFactoryImpl = MockBigQueryServiceFactory.ioFactory(),
     dataRepoDAO: DataRepoDAO = mock[DataRepoDAO](RETURNS_SMART_NULLS),
-    workspaceSettingRepository: WorkspaceSettingRepository = baseSpyWorkspaceSettingRepository
+    workspaceSettingRepository: WorkspaceSettingRepository = baseSpyWorkspaceSettingRepository,
+    maybeSamDAO: Option[SamDAO] = None
   ): T = {
 
     withDataOp { dataSource =>
@@ -471,7 +473,7 @@ class SubmissionSpec(_system: ActorSystem)
         SubmissionMonitorConfig(250.milliseconds, 30 days, trackDetailedSubmissionMetrics = true, 20000, false, true)
       val gcsDAO: MockGoogleServicesDAO = new MockGoogleServicesDAO("test")
       val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
-      val samDAO = new MockSamDAO(dataSource)
+      val samDAO = maybeSamDAO.getOrElse(new MockSamDAO(dataSource))
       val gpsDAO = new org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 
       val testConf = ConfigFactory.load()
@@ -593,6 +595,15 @@ class SubmissionSpec(_system: ActorSystem)
     val execSvcDAO = new MockExecutionServiceDAO()
     withDataAndService(service => testCode(execSvcDAO)(service), withDefaultTestDatabase[T], execSvcDAO)
   }
+
+  def withSubmissionsServiceMockSam[T](testCode: SamDAO => SubmissionsService => T): T = {
+    val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    withDataAndService(service => testCode(mockSamDAO)(service),
+                       withDefaultTestDatabase[T],
+                       maybeSamDAO = Option(mockSamDAO)
+    )
+  }
+
   def withSubmissionsServiceMockTimeoutExecution[T](testCode: MockExecutionServiceDAO => SubmissionsService => T): T = {
     val execSvcDAO = new MockExecutionServiceDAO(true)
     withDataAndService(service => testCode(execSvcDAO)(service), withDefaultTestDatabase[T], execSvcDAO)
@@ -1320,6 +1331,53 @@ class SubmissionSpec(_system: ActorSystem)
       assertResult(StatusCodes.BadRequest) {
         rqComplete.errorReport.statusCode.get
       }
+  }
+
+  it should "use Sam's knowledge of the submitter's email address" in withSubmissionsServiceMockSam {
+    mockSamDAO => submissionsService =>
+      val samEmail = "fixture@unit.test"
+
+      // mocks necessary for submission success
+      when(
+        mockSamDAO.userHasAction(any[SamResourceTypeName],
+                                 any[String],
+                                 any[SamResourceAction],
+                                 any[RawlsRequestContext]
+        )
+      )
+        .thenReturn(Future(true))
+      when(mockSamDAO.getPetServiceAccountKeyForUser(any[GoogleProjectId], any[RawlsUserEmail]))
+        // same value as in MockSamDAO
+        .thenReturn(
+          Future(
+            """{"client_email": "pet-110347448408766049948@broad-dsde-dev.iam.gserviceaccount.com", "client_id": "104493171545941951815"}"""
+          )
+        )
+
+      // this is the mock under test: Sam returns "fixture@unit.test" as the current user's email address
+      when(mockSamDAO.getUserStatus(any[RawlsRequestContext]))
+        .thenReturn(Future(Option(SamUserStatusResponse(userSubjectId = "123", userEmail = samEmail, enabled = true))))
+
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("Pair"),
+        entityName = Option("pair1"),
+        expression = Option("this.case"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val newSubmissionReport =
+        Await.result(submissionsService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+
+      val monitorActor = waitForSubmissionActor(newSubmissionReport.submissionId)
+      // not really necessary, failing to find the actor above will throw an exception and thus fail this test
+      assert(monitorActor != ActorRef.noSender)
+
+      assert(newSubmissionReport.workflows.size == 1)
+
+      val actualSubmission = checkSubmissionStatus(submissionsService, newSubmissionReport.submissionId)
+      actualSubmission.submitter shouldBe WorkbenchEmail(samEmail)
   }
 
   def workspaceSettingSubmissionTest[T](


### PR DESCRIPTION
Ticket: CORE-678

When creating a submission, query Sam for its knowledge about the user making the request. Use Sam's response to populate an email address into the `submitter` column for this submission instead of relying on the email address reported by Google's oauth.

Since we later use that email address to query Sam for pet tokens, we should be more likely to match email addresses between Rawls and Sam this way.