### PR TITLE
CORE-678: ignore case when deciding to log discrepancies in submitter email

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.submissions
 import akka.http.scaladsl.model.StatusCodes
 import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.commons.lang3.StringUtils
 import org.broadinstitute.dsde.rawls.config.WorkspaceServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction, WorkflowRecord}
 import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, StringValidationUtils}
@@ -503,7 +504,7 @@ class SubmissionsService(
           )
       }
       // for debugging
-      _ = if (submitter != ctx.userInfo.userEmail) {
+      _ = if (!StringUtils.equalsIgnoreCase(submitter.value, ctx.userInfo.userEmail.value)) {
         logger.warn(
           s"User email in Sam is different than the one in the request context: $submitter vs ${ctx.userInfo.userEmail}"
         )


### PR DESCRIPTION
Ticket: CORE-678

Followup to #3470. That other PR adds a log statement whenever a user creates a submission and we detect that the submitter's email address reported by Google is different than the email address known to Sam.

In this PR, ignore case when comparing those two email addresses to eliminate spurious logs.