### PR TITLE
CORE-681: use new forget-project Sam API when deleting a v1 billing project

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
@@ -20,6 +20,7 @@ import org.broadinstitute.dsde.workbench.client.sam.model.{
   FilteredHierarchicalResource,
   FilteredHierarchicalResourcePolicy,
   FilteredResourcesHierarchicalResponse,
+  ForgetGoogleProject200Response,
   ListResourcesV2200Response
 }
 import org.broadinstitute.dsde.workbench.client.sam.{ApiCallback, ApiClient, ApiException}
@@ -797,6 +798,15 @@ class HttpSamDAO(baseSamServiceURL: String,
 
     callback.future.map(WorkbenchEmail)
   }
+
+  override def forgetProject(project: GoogleProjectId, ctx: RawlsRequestContext): Future[Unit] =
+    retry(when401or5xx) { () =>
+      val callback = new SamApiCallback[ForgetGoogleProject200Response]("forgetGoogleProject")
+
+      googleApi(ctx).forgetGoogleProjectAsync(project.value, callback)
+
+      callback.future.map(_ => ())
+    }
 }
 
 class OtelContextSettingInterceptor(otelContext: Context) extends Interceptor {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
@@ -187,6 +187,8 @@ trait SamDAO {
   )
 
   def getAllUsersGroup(ctx: RawlsRequestContext): Future[WorkbenchEmail]
+
+  def forgetProject(project: GoogleProjectId, ctx: RawlsRequestContext): Future[Unit]
 }
 
 trait SamAdminDAO {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -93,6 +93,8 @@ object UserService {
                                  ctx: RawlsRequestContext,
                                  deleteGoogleProjectWithGoogle: Boolean = true
   )(implicit ex: ExecutionContext): Future[Unit] = {
+
+    /** helper: does the project exist in Google, as far as Rawls can see? */
     def rawlsCreatedGoogleProjectExists(projectId: GoogleProjectId) =
       gcsDAO.getGoogleProject(projectId) transform {
         case Success(_) => Success(true)
@@ -105,13 +107,9 @@ object UserService {
 
     def F = Applicative[Future]
 
-    def deleteResourcesInGoogle(projectId: GoogleProjectId) =
-      for {
-        _ <- deletePetsInProject(projectId, gcsDAO, samDAO, ctx)
-        _ <- F.whenA(deleteGoogleProjectWithGoogle)(gcsDAO.deleteV1Project(projectId))
-      } yield ()
-
     val projectId = GoogleProjectId(projectName.value)
+
+    // does this `billing-project` Sam resource have a child `google-project` of the same name?
     samDAO.listResourceChildren(SamResourceTypeNames.billingProject,
                                 projectName.value,
                                 ctx.copy(userInfo = userInfoForSam)
@@ -122,37 +120,16 @@ object UserService {
         )
       )(
         for {
-          _ <- rawlsCreatedGoogleProjectExists(projectId).ifM(deleteResourcesInGoogle(projectId), F.unit)
-          _ <- samDAO.deleteResource(SamResourceTypeNames.googleProject,
-                                     projectName.value,
-                                     ctx.copy(userInfo = userInfoForSam)
-          )
+          // if the project exists in the cloud, delete the project from the cloud
+          _ <- rawlsCreatedGoogleProjectExists(projectId)
+            .ifM(F.whenA(deleteGoogleProjectWithGoogle)(gcsDAO.deleteV1Project(projectId)), F.unit)
+          // delete the project from Sam
+          _ <- samDAO.forgetProject(projectId, ctx)
         } yield ()
       )
     }
   }
 
-  private def deletePetsInProject(projectName: GoogleProjectId,
-                                  gcsDAO: GoogleServicesDAO,
-                                  samDAO: SamDAO,
-                                  ctx: RawlsRequestContext
-  )(implicit ex: ExecutionContext): Future[Unit] =
-    for {
-      projectUsers <- samDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject, projectName.value, ctx)
-      _ <- projectUsers.toList.traverse(destroyPet(_, projectName, gcsDAO, samDAO, ctx))
-    } yield ()
-
-  private def destroyPet(userIdInfo: UserIdInfo,
-                         projectName: GoogleProjectId,
-                         gcsDAO: GoogleServicesDAO,
-                         samDAO: SamDAO,
-                         ctx: RawlsRequestContext
-  )(implicit ex: ExecutionContext): Future[Unit] =
-    for {
-      petSAJson <- samDAO.getPetServiceAccountKeyForUser(projectName, RawlsUserEmail(userIdInfo.userEmail))
-      petUserInfo <- gcsDAO.getUserInfoUsingJson(petSAJson)
-      _ <- samDAO.deleteUserPetServiceAccount(projectName, ctx.copy(userInfo = petUserInfo))
-    } yield ()
 }
 
 class UserService(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
@@ -301,6 +301,8 @@ class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: Executi
 
   override def getAllUsersGroup(ctx: RawlsRequestContext): Future[WorkbenchEmail] = ???
 
+  override def forgetProject(project: GoogleProjectId, ctx: RawlsRequestContext): Future[Unit] = Future.successful(())
+
   override def addResourceAuthDomain(resourceTypeName: SamResourceTypeName,
                                      resourceId: String,
                                      authDomain: Set[String],

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -294,34 +294,32 @@ class UserServiceSpec
                                  testContext
         )
       ).thenReturn(Future.successful(true))
-      when(
-        mockSamDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject, project.projectName.value, testContext)
-      ).thenReturn(Future.successful(Set(userIdInfo)))
-      when(mockSamDAO.getPetServiceAccountKeyForUser(project.googleProjectId, userInfo.userEmail))
-        .thenReturn(Future.successful(petSAJson))
       when(mockSamDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, testContext))
         .thenReturn(
           Future.successful(
             Seq(SamFullyQualifiedResourceId(project.googleProjectId.value, SamResourceTypeNames.googleProject.value))
           )
         )
-      when(mockSamDAO.deleteUserPetServiceAccount(project.googleProjectId, testContext)).thenReturn(Future.successful())
+      when(mockSamDAO.forgetProject(project.googleProjectId, testContext)).thenReturn(Future.successful(()))
       when(mockSamDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, testContext))
-        .thenReturn(Future.successful())
-      when(mockSamDAO.deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, testContext))
         .thenReturn(Future.successful())
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-      when(mockGcsDAO.getUserInfoUsingJson(petSAJson)).thenReturn(Future.successful(userInfo))
       when(mockGcsDAO.deleteV1Project(project.googleProjectId)).thenReturn(Future.successful())
       when(mockGcsDAO.getGoogleProject(project.googleProjectId)).thenReturn(Future.successful(new Project()))
 
       val userService = getUserService(dataSource, mockSamDAO, gcsDAO = mockGcsDAO)
       val actual: Unit = userService.deleteBillingProject(defaultBillingProjectName).futureValue
 
-      verify(mockSamDAO).deleteUserPetServiceAccount(project.googleProjectId, testContext)
+      verify(mockGcsDAO, never()).getUserInfoUsingJson(petSAJson)
+      verify(mockSamDAO, never()).listAllResourceMemberIds(SamResourceTypeNames.billingProject,
+                                                           project.projectName.value,
+                                                           testContext
+      )
+      verify(mockSamDAO, never()).getPetServiceAccountKeyForUser(any[GoogleProjectId], any[RawlsUserEmail])
+      verify(mockSamDAO, never()).deleteUserPetServiceAccount(project.googleProjectId, testContext)
+      verify(mockSamDAO).forgetProject(project.googleProjectId, testContext)
       verify(mockSamDAO).deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, testContext)
-      verify(mockSamDAO).deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, testContext)
       verify(mockGcsDAO).deleteV1Project(project.googleProjectId)
 
       runAndWait(rawlsBillingProjectQuery.load(defaultBillingProjectName)) shouldBe empty
@@ -343,9 +341,6 @@ class UserServiceSpec
                                  testContext
         )
       ).thenReturn(Future.successful(true))
-      when(
-        mockSamDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject, project.projectName.value, testContext)
-      ).thenReturn(Future.successful(Set(userIdInfo)))
       when(mockSamDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, testContext))
         .thenReturn(
           Future.successful(
@@ -354,8 +349,7 @@ class UserServiceSpec
         )
       when(mockSamDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, testContext))
         .thenReturn(Future.successful())
-      when(mockSamDAO.deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, testContext))
-        .thenReturn(Future.successful())
+      when(mockSamDAO.forgetProject(project.googleProjectId, testContext)).thenReturn(Future.successful(()))
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       when(mockGcsDAO.getGoogleProject(project.googleProjectId)).thenReturn(
@@ -368,9 +362,15 @@ class UserServiceSpec
       val userService = getUserService(dataSource, mockSamDAO, gcsDAO = mockGcsDAO)
       val actual: Unit = userService.deleteBillingProject(defaultBillingProjectName).futureValue
 
+      verify(mockGcsDAO, never()).getUserInfoUsingJson(petSAJson)
+      verify(mockSamDAO, never()).listAllResourceMemberIds(SamResourceTypeNames.billingProject,
+                                                           project.projectName.value,
+                                                           testContext
+      )
+      verify(mockSamDAO, never()).getPetServiceAccountKeyForUser(any[GoogleProjectId], any[RawlsUserEmail])
       verify(mockSamDAO, never()).deleteUserPetServiceAccount(project.googleProjectId, testContext)
+      verify(mockSamDAO).forgetProject(project.googleProjectId, testContext)
       verify(mockSamDAO).deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, testContext)
-      verify(mockSamDAO).deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, testContext)
       verify(mockGcsDAO, never()).deleteV1Project(project.googleProjectId)
 
       runAndWait(rawlsBillingProjectQuery.load(defaultBillingProjectName)) shouldBe empty

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -1056,14 +1056,11 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
         )
       ).thenReturn(Future.successful(true))
       when(
-        services.samDAO.listAllResourceMemberIds(
-          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-          ArgumentMatchers.eq(project.projectName.value),
-          ArgumentMatchers.argThat(userInfoEq(testContext))
+        services.samDAO.forgetProject(ArgumentMatchers.eq(project.googleProjectId),
+                                      ArgumentMatchers.argThat(userInfoEq(testContext))
         )
-      ).thenReturn(Future.successful(Set(UserIdInfo(userInfo.userSubjectId.value, userInfo.userEmail.value, None))))
-      when(services.samDAO.getPetServiceAccountKeyForUser(project.googleProjectId, userInfo.userEmail))
-        .thenReturn(Future.successful("petSAJson"))
+      )
+        .thenReturn(Future.successful())
       when(
         services.samDAO.listResourceChildren(
           ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
@@ -1076,23 +1073,9 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
         )
       )
       when(
-        services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(project.googleProjectId),
-                                                    any[RawlsRequestContext]
-        )
-      )
-        .thenReturn(Future.successful())
-      when(
         services.samDAO.deleteResource(
           ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
           ArgumentMatchers.eq(project.projectName.value),
-          ArgumentMatchers.argThat(userInfoEq(testContext))
-        )
-      )
-        .thenReturn(Future.successful())
-      when(
-        services.samDAO.deleteResource(
-          ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
-          ArgumentMatchers.eq(project.googleProjectId.value),
           ArgumentMatchers.argThat(userInfoEq(testContext))
         )
       )
@@ -1106,13 +1089,8 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
           }
         }
 
-      verify(services.samDAO).deleteUserPetServiceAccount(ArgumentMatchers.eq(project.googleProjectId),
-                                                          any[RawlsRequestContext]
-      )
-      verify(services.samDAO).deleteResource(
-        ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
-        ArgumentMatchers.eq(project.googleProjectId.value),
-        ArgumentMatchers.argThat(userInfoEq(testContext))
+      verify(services.samDAO).forgetProject(ArgumentMatchers.eq(project.googleProjectId),
+                                            ArgumentMatchers.argThat(userInfoEq(testContext))
       )
   }
   it should "return 204 - without google project" in withEmptyDatabaseAndApiServices { services =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -132,7 +132,7 @@ object Dependencies {
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.593.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.153-SNAPSHOT")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "1.1.42-SNAPSHOT" classifier "plain"))
-  val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.415")
+  val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.423")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-2e87300"
   val policyService = clientLibExclusions("bio.terra" % "terra-policy-client" % "1.0.28-SNAPSHOT")
 


### PR DESCRIPTION
Ticket: CORE-681

Use the new "forget project" API in Sam (see https://github.com/broadinstitute/sam/pull/1716) from Rawls when deleting a v1 billing project.

This nontrivially simplifies Rawls' code and reduces back-and-forth between Rawls and Sam.