### PR TITLE
CORE-624: cache BigQuery's workflow actual costs

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -146,4 +146,5 @@
     <include file="changesets/20250616_remove_all_gcpbatch_workspace_settings.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250724_entity_keys_cache.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250821_remove_all_gcpbatch_workspace_settings_again.xml" relativeToChangelogFile="true"/>
+<!--    <include file="changesets/20250912_workflow_actual_cost.xml" relativeToChangelogFile="true"/>-->
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -146,5 +146,5 @@
     <include file="changesets/20250616_remove_all_gcpbatch_workspace_settings.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250724_entity_keys_cache.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250821_remove_all_gcpbatch_workspace_settings_again.xml" relativeToChangelogFile="true"/>
-<!--    <include file="changesets/20250912_workflow_actual_cost.xml" relativeToChangelogFile="true"/>-->
+    <include file="changesets/20250912_workflow_actual_cost.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250912_workflow_actual_cost.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250912_workflow_actual_cost.xml
@@ -5,8 +5,16 @@
     <changeSet logicalFilePath="dummy" author="davidan" id="workflow_actual_cost">
         <!-- create WORKFLOW_COST table -->
         <createTable tableName="WORKFLOW_ACTUAL_COST">
+            <column name="WORKFLOW_ID" type="bigint(19)">
+                <constraints nullable="false"
+                             unique="true"
+                             referencedTableName="WORKFLOW"
+                             referencedColumnNames="ID"
+                             foreignKeyName="FK_WORKFLOW_ACTUAL_COST_WORKFLOW"
+                             deleteCascade="true"/>
+            </column>
             <column name="EXTERNAL_ID" type="char(36)">
-                <constraints primaryKey="true"/>
+                <constraints unique="true"/>
             </column>
             <column name="COST" type="NUMBER(10,2)">
                 <constraints nullable="true"/>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250912_workflow_actual_cost.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250912_workflow_actual_cost.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
+    <changeSet logicalFilePath="dummy" author="davidan" id="workflow_actual_cost">
+        <!-- create WORKFLOW_COST table -->
+        <createTable tableName="WORKFLOW_ACTUAL_COST">
+            <column name="EXTERNAL_ID" type="char(36)">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="COST" type="NUMBER(10,2)">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -244,7 +244,7 @@ object Boot extends IOApp with LazyLogging {
       val policyService = new PolicyService(tpsDAO)
 
       val submissionCostService =
-        SubmissionCostServiceFactory.createSubmissionCostService(appConfigManager, bigQueryDAO)
+        SubmissionCostServiceFactory.createSubmissionCostService(appConfigManager, slickDataSource, bigQueryDAO)
 
       val methodRepoDAO =
         MethodRepoDAOFactory.createMethodRepoDAO(appConfigManager, metricsPrefix)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
@@ -11,14 +11,16 @@ trait SubmissionCostService {
 
   val stringParamType: QueryParameterType
 
-  def getSubmissionCosts(workflowIds: Seq[String],
+  def getSubmissionCosts(submissionId: String,
+                         workflowIds: Seq[String],
                          googleProjectId: GoogleProjectId,
                          submissionDate: DateTime,
                          terminalStatusDate: Option[DateTime],
                          tableNameOpt: Option[String]
   ): Future[Map[String, Float]]
 
-  def getWorkflowCost(workflowId: String,
+  def getWorkflowCost(submissionId: String,
+                      workflowId: String,
                       googleProjectId: GoogleProjectId,
                       submissionDate: DateTime,
                       terminalStatusDate: Option[DateTime],

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
@@ -11,8 +11,7 @@ trait SubmissionCostService {
 
   val stringParamType: QueryParameterType
 
-  def getSubmissionCosts(submissionId: String,
-                         workflowIds: Seq[String],
+  def getSubmissionCosts(workflowIds: Seq[String],
                          googleProjectId: GoogleProjectId,
                          submissionDate: DateTime,
                          terminalStatusDate: Option[DateTime],

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceImpl.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceImpl.scala
@@ -74,7 +74,11 @@ class SubmissionCostServiceImpl(defaultTableName: String,
         // determine which of the uncachedWorkflows did not have a hit in BigQuery
         notFoundWorkflows = uncachedWorkflows diff liveResults.keySet
         // persist BigQuery results back to WORKFLOW_ACTUAL_COST
-        writeBack <- writeCostsToLocalDb(liveResults, notFoundWorkflows)
+        _ <-
+          if (liveResults.nonEmpty || notFoundWorkflows.nonEmpty)
+            writeCostsToLocalDb(liveResults, notFoundWorkflows)
+          else
+            Future.successful(())
       } yield {
         // extract from the cached results only those workflows which actually have a cost
         val cachedResultsWithCost = cachedResults.collect {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceImpl.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceImpl.scala
@@ -1,17 +1,21 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
+import akka.http.scaladsl.model.StatusCodes
 import com.google.api.services.bigquery.model._
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkflowActualCostRecord
-import org.broadinstitute.dsde.rawls.model.GoogleProjectId
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, GoogleProjectId}
 import org.broadinstitute.dsde.workbench.google.GoogleBigQueryDAO
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 
 import java.util
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 object SubmissionCostServiceImpl {
   def constructor(defaultTableName: String,
@@ -45,7 +49,8 @@ class SubmissionCostServiceImpl(defaultTableName: String,
   /**
    * Retrieve actual costs for multiple workflows.
    */
-  def getSubmissionCosts(workflowIds: Seq[String],
+  def getSubmissionCosts(submissionIdStr: String,
+                         workflowIds: Seq[String],
                          googleProjectId: GoogleProjectId,
                          submissionDate: DateTime,
                          terminalStatusDate: Option[DateTime],
@@ -54,11 +59,16 @@ class SubmissionCostServiceImpl(defaultTableName: String,
     if (workflowIds.isEmpty) {
       Future.successful(Map.empty[String, Float])
     } else {
+      val submissionId = Try(UUID.fromString(submissionIdStr)).getOrElse(
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, "invalid submission id; must be a UUID.")
+        )
+      )
       for {
         // ask WORKFLOW_ACTUAL_COST table for any cached costs
-        cachedResults: Map[String, Option[Float]] <- retrieveCostsFromLocalDb(workflowIds)
+        cachedResults: Seq[WorkflowActualCostRecord] <- retrieveCostsFromLocalDb(workflowIds)
         // determine which of the requested workflows were not found in WORKFLOW_ACTUAL_COST
-        uncachedWorkflows = workflowIds.toSet diff cachedResults.keySet
+        uncachedWorkflows = workflowIds.toSet diff cachedResults.map(_.externalId).toSet
         // ask BigQuery for any workflows which weren't found in WORKFLOW_ACTUAL_COST
         liveResults <-
           if (uncachedWorkflows.nonEmpty) {
@@ -78,14 +88,15 @@ class SubmissionCostServiceImpl(defaultTableName: String,
         // persist BigQuery results back to WORKFLOW_ACTUAL_COST
         _ <-
           if (liveResults.nonEmpty || notFoundWorkflows.nonEmpty)
-            writeCostsToLocalDb(liveResults, notFoundWorkflows)
+            writeCostsToLocalDb(submissionId, liveResults, notFoundWorkflows)
           else
-            Future.successful(())
+            Future.successful(-1)
       } yield {
         // extract from the cached results only those workflows which actually have a cost
         val cachedResultsWithCost = cachedResults.collect {
-          case (externalId: String, maybeCost: Option[Float]) if maybeCost.isDefined => (externalId, maybeCost.get)
-        }
+          case r: WorkflowActualCostRecord if r.cost.isDefined =>
+            (r.externalId, r.cost.get)
+        }.toMap
         // return the union of WORKFLOW_ACTUAL_COST and BigQuery results
         cachedResultsWithCost ++ liveResults
       }
@@ -94,27 +105,23 @@ class SubmissionCostServiceImpl(defaultTableName: String,
   /**
    * Retrieve the actual cost for a single workflow.
    */
-  def getWorkflowCost(workflowId: String,
+  def getWorkflowCost(submissionId: String,
+                      workflowId: String,
                       googleProjectId: GoogleProjectId,
                       submissionDate: DateTime,
                       terminalStatusDate: Option[DateTime],
                       tableNameOpt: Option[String] = Option(defaultTableName)
   ): Future[Map[String, Float]] =
-    getSubmissionCosts(Seq(workflowId), googleProjectId, submissionDate, terminalStatusDate, tableNameOpt)
+    getSubmissionCosts(submissionId, Seq(workflowId), googleProjectId, submissionDate, terminalStatusDate, tableNameOpt)
 
   // ask WORKFLOW_ACTUAL_COST table for specific workflows
   private def retrieveCostsFromLocalDb(
     workflowIds: Seq[String]
-  ): Future[Map[String, Option[Float]]] = {
+  ): Future[Seq[WorkflowActualCostRecord]] = {
     import dataSource.dataAccess.driver.api._
     dataSource
       .inTransaction { dataAccess =>
         dataAccess.workflowActualCostQuery.filter(row => row.externalId.inSetBind(workflowIds)).result
-      }
-      .map { costs =>
-        costs.map { cost =>
-          cost.externalId -> cost.cost.map(_.floatValue)
-        }.toMap
       }
   }
 
@@ -141,18 +148,35 @@ class SubmissionCostServiceImpl(defaultTableName: String,
   }
 
   // modular method to save rows to WORKFLOW_ACTUAL_COST
-  private def writeCostsToLocalDb(costs: Map[String, Float], notFoundWorkflows: Set[String]): Future[Int] = {
-    // generate records for the found costs
-    val foundCosts: Seq[WorkflowActualCostRecord] = costs.map { case (externalId: String, cost: Float) =>
-      WorkflowActualCostRecord(externalId, Option(cost))
-    }.toSeq
-    // generate records for the not-found costs
-    val notFoundCosts: Seq[WorkflowActualCostRecord] = notFoundWorkflows.toSeq.map { externalId =>
-      WorkflowActualCostRecord(externalId, None)
-    }
-
+  protected[dataaccess] def writeCostsToLocalDb(submissionId: UUID,
+                                                costs: Map[String, Float],
+                                                notFoundWorkflows: Set[String]
+  ): Future[Int] = {
+    val allExternalIds = costs.keySet ++ notFoundWorkflows
     dataSource.inTransaction { dataAccess =>
-      dataAccess.workflowActualCostRawSqlQuery.safeInsert(foundCosts ++ notFoundCosts)
+      import dataAccess.driver.api._
+      for {
+        // look up the internal workflow ids (Longs) for these external ids (Strings)
+        workflowRecords <- dataAccess.workflowQuery
+          .findWorkflowByExternalIdsAndSubmissionId(allExternalIds, submissionId)
+          .result
+        // map this submission's external ids to internal ids
+        internalIdMap: Map[String, Long] = workflowRecords
+          .filter(_.externalId.isDefined)
+          .map(r => r.externalId.get -> r.id)
+          .toMap
+        // generate records for the found costs
+        foundCosts: Seq[WorkflowActualCostRecord] = costs.map {
+          case (externalId: String, cost: Float) if internalIdMap.contains(externalId) =>
+            WorkflowActualCostRecord(internalIdMap(externalId), externalId, Option(cost))
+        }.toSeq
+        // generate records for the not-found costs
+        notFoundCosts: Seq[WorkflowActualCostRecord] = notFoundWorkflows.toSeq.map {
+          case externalId if internalIdMap.contains(externalId) =>
+            WorkflowActualCostRecord(internalIdMap(externalId), externalId, None)
+        }
+        numRowsWritten <- dataAccess.workflowActualCostRawSqlQuery.safeInsert(foundCosts ++ notFoundCosts)
+      } yield numRowsWritten
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceImpl.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceImpl.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 
 import com.google.api.services.bigquery.model._
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkflowActualCostRecord
 import org.broadinstitute.dsde.rawls.model.GoogleProjectId
 import org.broadinstitute.dsde.workbench.google.GoogleBigQueryDAO
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -17,12 +18,14 @@ object SubmissionCostServiceImpl {
                   defaultDatePartitionColumn: String,
                   serviceProject: String,
                   billingSearchWindowDays: Int,
+                  dataSource: SlickDataSource,
                   bigQueryDAO: GoogleBigQueryDAO
   )(implicit executionContext: ExecutionContext) =
     new SubmissionCostServiceImpl(defaultTableName,
                                   defaultDatePartitionColumn,
                                   serviceProject,
                                   billingSearchWindowDays,
+                                  dataSource,
                                   bigQueryDAO
     )
 }
@@ -31,6 +34,7 @@ class SubmissionCostServiceImpl(defaultTableName: String,
                                 defaultDatePartitionColumn: String,
                                 serviceProject: String,
                                 billingSearchWindowDays: Int,
+                                dataSource: SlickDataSource,
                                 bigQueryDAO: GoogleBigQueryDAO
 )(implicit val executionContext: ExecutionContext)
     extends LazyLogging
@@ -38,50 +42,114 @@ class SubmissionCostServiceImpl(defaultTableName: String,
 
   val stringParamType = new QueryParameterType().setType("STRING")
 
-  def getSubmissionCosts(submissionId: String,
-                         workflowIds: Seq[String],
+  /**
+   * Retrieve actual costs for multiple workflows.
+   */
+  def getSubmissionCosts(workflowIds: Seq[String],
                          googleProjectId: GoogleProjectId,
                          submissionDate: DateTime,
                          terminalStatusDate: Option[DateTime],
                          tableNameOpt: Option[String] = Option(defaultTableName)
-  ): Future[Map[String, Float]] = {
-    val tableName = tableNameOpt.getOrElse(defaultTableName)
-    val datePartitionColumn = if (tableName == defaultTableName) Some(defaultDatePartitionColumn) else None
-
+  ): Future[Map[String, Float]] =
     if (workflowIds.isEmpty) {
       Future.successful(Map.empty[String, Float])
     } else {
       for {
-        // Lookup-only costs for the requested workflow IDs
-        workflowCosts <- executeWorkflowCostsQuery(
-          workflowIds,
-          googleProjectId,
-          submissionDate,
-          terminalStatusDate,
-          tableName,
-          datePartitionColumn
-        )
-      } yield extractCostResults(workflowCosts)
+        // ask WORKFLOW_ACTUAL_COST table for any cached costs
+        cachedResults: Map[String, Option[Float]] <- retrieveCostsFromLocalDb(workflowIds)
+        // determine which of the requested workflows were not found in WORKFLOW_ACTUAL_COST
+        uncachedWorkflows = workflowIds.toSet diff cachedResults.keySet
+        // ask BigQuery for any workflows which weren't found in WORKFLOW_ACTUAL_COST
+        liveResults <-
+          if (uncachedWorkflows.nonEmpty) {
+            retrieveCostsFromBigQuery(uncachedWorkflows.toSeq,
+                                      googleProjectId,
+                                      submissionDate,
+                                      terminalStatusDate,
+                                      tableNameOpt
+            )
+          } else {
+            Future.successful(Map.empty[String, Float])
+          }
+        // determine which of the uncachedWorkflows did not have a hit in BigQuery
+        notFoundWorkflows = uncachedWorkflows diff liveResults.keySet
+        // persist BigQuery results back to WORKFLOW_ACTUAL_COST
+        writeBack <- writeCostsToLocalDb(liveResults, notFoundWorkflows)
+      } yield {
+        // extract from the cached results only those workflows which actually have a cost
+        val cachedResultsWithCost = cachedResults.collect {
+          case (externalId: String, maybeCost: Option[Float]) if maybeCost.isDefined => (externalId, maybeCost.get)
+        }
+        // return the union of WORKFLOW_ACTUAL_COST and BigQuery results
+        cachedResultsWithCost ++ liveResults
+      }
     }
-  }
 
+  /**
+   * Retrieve the actual cost for a single workflow.
+   */
   def getWorkflowCost(workflowId: String,
                       googleProjectId: GoogleProjectId,
                       submissionDate: DateTime,
                       terminalStatusDate: Option[DateTime],
                       tableNameOpt: Option[String] = Option(defaultTableName)
+  ): Future[Map[String, Float]] =
+    getSubmissionCosts(Seq(workflowId), googleProjectId, submissionDate, terminalStatusDate, tableNameOpt)
+
+  // ask WORKFLOW_ACTUAL_COST table for specific workflows
+  protected[dataaccess] def retrieveCostsFromLocalDb(
+    workflowIds: Seq[String]
+  ): Future[Map[String, Option[Float]]] = {
+    import dataSource.dataAccess.driver.api._
+    dataSource
+      .inTransaction { dataAccess =>
+        dataAccess.workflowActualCostQuery.filter(row => row.externalId.inSetBind(workflowIds)).result
+      }
+      .map { costs =>
+        costs.map { cost =>
+          cost.externalId -> cost.cost.map(_.floatValue)
+        }.toMap
+      }
+  }
+
+  // modular method ask BigQuery for specific workflows
+  protected[dataaccess] def retrieveCostsFromBigQuery(workflowIds: Seq[String],
+                                                      googleProjectId: GoogleProjectId,
+                                                      submissionDate: DateTime,
+                                                      terminalStatusDate: Option[DateTime],
+                                                      tableNameOpt: Option[String] = Option(defaultTableName)
   ): Future[Map[String, Float]] = {
     val tableName = tableNameOpt.getOrElse(defaultTableName)
     val datePartitionColumn = if (tableName == defaultTableName) Some(defaultDatePartitionColumn) else None
+    for {
+      // Lookup-only costs for the requested workflow IDs
+      workflowCosts <- executeWorkflowCostsQuery(
+        workflowIds,
+        googleProjectId,
+        submissionDate,
+        terminalStatusDate,
+        tableName,
+        datePartitionColumn
+      )
+    } yield extractCostResults(workflowCosts)
+  }
 
-    executeWorkflowCostsQuery(
-      Seq(workflowId),
-      googleProjectId,
-      submissionDate,
-      terminalStatusDate,
-      tableName,
-      datePartitionColumn
-    ) map extractCostResults
+  // modular method to save rows to WORKFLOW_ACTUAL_COST
+  protected[dataaccess] def writeCostsToLocalDb(costs: Map[String, Float],
+                                                notFoundWorkflows: Set[String]
+  ): Future[Int] = {
+    // generate records for the found costs
+    val foundCosts: Seq[WorkflowActualCostRecord] = costs.map { case (externalId: String, cost: Float) =>
+      WorkflowActualCostRecord(externalId, Option(cost))
+    }.toSeq
+    // generate records for the not-found costs
+    val notFoundCosts: Seq[WorkflowActualCostRecord] = notFoundWorkflows.toSeq.map { externalId =>
+      WorkflowActualCostRecord(externalId, None)
+    }
+
+    dataSource.inTransaction { dataAccess =>
+      dataAccess.workflowActualCostRawSqlQuery.safeInsert(foundCosts ++ notFoundCosts)
+    }
   }
 
   /*

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceImpl.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceImpl.scala
@@ -62,6 +62,7 @@ class SubmissionCostServiceImpl(defaultTableName: String,
         // ask BigQuery for any workflows which weren't found in WORKFLOW_ACTUAL_COST
         liveResults <-
           if (uncachedWorkflows.nonEmpty) {
+            logger.info(s"getSubmissionCosts: ${uncachedWorkflows.size} workflows not found in cache; asking BigQuery")
             retrieveCostsFromBigQuery(uncachedWorkflows.toSeq,
                                       googleProjectId,
                                       submissionDate,
@@ -69,6 +70,7 @@ class SubmissionCostServiceImpl(defaultTableName: String,
                                       tableNameOpt
             )
           } else {
+            logger.info(s"getSubmissionCosts: all workflows found in cache; bypassing BigQuery")
             Future.successful(Map.empty[String, Float])
           }
         // determine which of the uncachedWorkflows did not have a hit in BigQuery

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceImpl.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceImpl.scala
@@ -40,7 +40,7 @@ class SubmissionCostServiceImpl(defaultTableName: String,
     extends LazyLogging
     with SubmissionCostService {
 
-  val stringParamType = new QueryParameterType().setType("STRING")
+  val stringParamType: QueryParameterType = new QueryParameterType().setType("STRING")
 
   /**
    * Retrieve actual costs for multiple workflows.
@@ -103,7 +103,7 @@ class SubmissionCostServiceImpl(defaultTableName: String,
     getSubmissionCosts(Seq(workflowId), googleProjectId, submissionDate, terminalStatusDate, tableNameOpt)
 
   // ask WORKFLOW_ACTUAL_COST table for specific workflows
-  protected[dataaccess] def retrieveCostsFromLocalDb(
+  private def retrieveCostsFromLocalDb(
     workflowIds: Seq[String]
   ): Future[Map[String, Option[Float]]] = {
     import dataSource.dataAccess.driver.api._
@@ -119,11 +119,11 @@ class SubmissionCostServiceImpl(defaultTableName: String,
   }
 
   // modular method ask BigQuery for specific workflows
-  protected[dataaccess] def retrieveCostsFromBigQuery(workflowIds: Seq[String],
-                                                      googleProjectId: GoogleProjectId,
-                                                      submissionDate: DateTime,
-                                                      terminalStatusDate: Option[DateTime],
-                                                      tableNameOpt: Option[String] = Option(defaultTableName)
+  private def retrieveCostsFromBigQuery(workflowIds: Seq[String],
+                                        googleProjectId: GoogleProjectId,
+                                        submissionDate: DateTime,
+                                        terminalStatusDate: Option[DateTime],
+                                        tableNameOpt: Option[String] = Option(defaultTableName)
   ): Future[Map[String, Float]] = {
     val tableName = tableNameOpt.getOrElse(defaultTableName)
     val datePartitionColumn = if (tableName == defaultTableName) Some(defaultDatePartitionColumn) else None
@@ -141,9 +141,7 @@ class SubmissionCostServiceImpl(defaultTableName: String,
   }
 
   // modular method to save rows to WORKFLOW_ACTUAL_COST
-  protected[dataaccess] def writeCostsToLocalDb(costs: Map[String, Float],
-                                                notFoundWorkflows: Set[String]
-  ): Future[Int] = {
+  private def writeCostsToLocalDb(costs: Map[String, Float], notFoundWorkflows: Set[String]): Future[Int] = {
     // generate records for the found costs
     val foundCosts: Seq[WorkflowActualCostRecord] = costs.map { case (externalId: String, cost: Float) =>
       WorkflowActualCostRecord(externalId, Option(cost))
@@ -188,34 +186,6 @@ class SubmissionCostServiceImpl(defaultTableName: String,
       .toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
 
     s"""AND $datePartitionColumn BETWEEN "$windowStartDate" AND "$windowEndDate""""
-  }
-
-  private def executeSubmissionCostsQuery(submissionId: String,
-                                          googleProjectId: GoogleProjectId,
-                                          submissionDate: DateTime,
-                                          terminalStatusDate: Option[DateTime],
-                                          tableName: String,
-                                          datePartitionColumn: Option[String]
-  ): Future[util.List[TableRow]] = {
-
-    val querySql: String =
-      generateSubmissionCostsQuery(submissionId, submissionDate, terminalStatusDate, tableName, datePartitionColumn)
-
-    val namespaceParam =
-      new QueryParameter()
-        .setParameterType(stringParamType)
-        .setParameterValue(new QueryParameterValue().setValue(googleProjectId.value))
-
-    val queryParameters: List[QueryParameter] = List(namespaceParam)
-
-    executeBigQuery(querySql, queryParameters) map { result =>
-      val rowsReturned = Option(result.getTotalRows).getOrElse(0)
-      val bytesProcessed = Option(result.getTotalBytesProcessed).getOrElse(0)
-      logger.debug(
-        s"Queried for costs of submission $submissionId: $rowsReturned Rows Returned and $bytesProcessed Bytes Processed."
-      )
-      Option(result.getRows).getOrElse(List.empty[TableRow].asJava)
-    }
   }
 
   /*

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
@@ -18,6 +18,7 @@ trait DataAccess
     with MethodConfigurationComponent
     with SubmissionComponent
     with WorkflowComponent
+    with WorkflowActualCostComponent
     with ExprEvalComponent
     with WorkspaceRequesterPaysComponent
     with EntityTypeStatisticsComponent
@@ -70,6 +71,7 @@ trait DataAccess
       TableQuery[MethodConfigurationOutputTable].delete andThen // FK to MC
       TableQuery[SubmissionValidationTable].delete andThen // FK to workflow, workflowfailure
       TableQuery[WorkflowMessageTable].delete andThen // FK to workflow
+      TableQuery[WorkflowActualCostTable].delete andThen
       TableQuery[WorkflowTable].delete andThen // FK to submission, entity
       TableQuery[SubmissionTable].delete andThen // FK to workspace, user, MC, entity
       TableQuery[MethodConfigurationTable].delete andThen // FK to workspace

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowActualCostComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowActualCostComponent.scala
@@ -1,0 +1,63 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+import cats.instances.int._
+import cats.instances.list._
+import cats.instances.map._
+import cats.syntax.foldable._
+import nl.grons.metrics4.scala.Counter
+import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.dataaccess.ExecutionServiceId
+import org.broadinstitute.dsde.rawls.model.SubmissionStatuses.SubmissionStatus
+import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
+import org.broadinstitute.dsde.rawls.model._
+import org.joda.time.DateTime
+import slick.dbio.Effect.Write
+import slick.jdbc.{GetResult, JdbcProfile, SQLActionBuilder}
+
+import java.sql.Timestamp
+import java.util.UUID
+
+case class WorkflowActualCostRecord(externalId: String, cost: Option[Float])
+
+trait WorkflowActualCostComponent {
+  this: DriverComponent =>
+
+  import driver.api._
+
+  class WorkflowActualCostTable(tag: Tag) extends Table[WorkflowActualCostRecord](tag, "WORKFLOW_ACTUAL_COST") {
+    def externalId = column[String]("EXTERNAL_ID", O.SqlType("CHAR(36)"))
+    def cost = column[Option[Float]]("COST")
+
+    def * = (
+      externalId,
+      cost
+    ) <> (WorkflowActualCostRecord.tupled, WorkflowActualCostRecord.unapply)
+  }
+
+  object workflowActualCostQuery extends TableQuery(new WorkflowActualCostTable(_)) {
+    type WorkflowActualCostQueryType = Query[WorkflowActualCostTable, WorkflowRecord, Seq]
+  }
+
+  object workflowActualCostRawSqlQuery extends RawSqlQuery {
+    val driver: JdbcProfile = WorkflowActualCostComponent.this.driver
+
+    def safeInsert(rows: Seq[WorkflowActualCostRecord]): ReadWriteAction[Int] = {
+
+      // generate parameters for each row
+      val rowParams: Seq[SQLActionBuilder] = rows.map { row =>
+        sql"""(${row.externalId}, ${row.cost})"""
+      }
+
+      val paramSql = reduceSqlActionsWithDelim(rowParams, sql",")
+
+      val startSql = sql"""
+            insert into WORKFLOW_ACTUAL_COSTS(EXTERNAL_ID, COST)
+            values("""
+      val endSql = sql""") on conflict do nothing;"""
+
+      concatSqlActions(startSql, paramSql, endSql).asUpdate
+    }
+
+  }
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowActualCostComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowActualCostComponent.scala
@@ -41,6 +41,16 @@ trait WorkflowActualCostComponent {
   object workflowActualCostRawSqlQuery extends RawSqlQuery {
     val driver: JdbcProfile = WorkflowActualCostComponent.this.driver
 
+    /**
+     * Insert rows into WORKFLOW_ACTUAL_COST, ignoring any conflicts on duplicate EXTERNAL_ID values.
+     * Because this method may be called concurrently by multiple users for the same workflows,
+     * it can try to insert the same rows multiple times. These rows are a cache of the value
+     * already in BigQuery, which should not change - therefore, we can ignore any duplicates here
+     * on the assumption they will have the same values.
+     *
+     * @param rows the rows to insert
+     * @return count of rows affected
+     */
     def safeInsert(rows: Seq[WorkflowActualCostRecord]): ReadWriteAction[Int] = {
 
       // generate parameters for each row
@@ -51,9 +61,9 @@ trait WorkflowActualCostComponent {
       val paramSql = reduceSqlActionsWithDelim(rowParams, sql",")
 
       val startSql = sql"""
-            insert into WORKFLOW_ACTUAL_COSTS(EXTERNAL_ID, COST)
-            values("""
-      val endSql = sql""") on conflict do nothing;"""
+            insert into WORKFLOW_ACTUAL_COST(EXTERNAL_ID, COST)
+            values """
+      val endSql = sql""" on duplicate key update COST=COST;"""
 
       concatSqlActions(startSql, paramSql, endSql).asUpdate
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowActualCostComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowActualCostComponent.scala
@@ -51,22 +51,25 @@ trait WorkflowActualCostComponent {
      * @param rows the rows to insert
      * @return count of rows affected
      */
-    def safeInsert(rows: Seq[WorkflowActualCostRecord]): ReadWriteAction[Int] = {
+    def safeInsert(rows: Seq[WorkflowActualCostRecord]): ReadWriteAction[Int] =
+      // prevent syntax errors if no rows
+      if (rows.isEmpty)
+        DBIO.successful(0)
+      else {
+        // generate parameters for each row
+        val rowParams: Seq[SQLActionBuilder] = rows.map { row =>
+          sql"""(${row.externalId}, ${row.cost})"""
+        }
 
-      // generate parameters for each row
-      val rowParams: Seq[SQLActionBuilder] = rows.map { row =>
-        sql"""(${row.externalId}, ${row.cost})"""
-      }
+        val paramSql = reduceSqlActionsWithDelim(rowParams, sql",")
 
-      val paramSql = reduceSqlActionsWithDelim(rowParams, sql",")
-
-      val startSql = sql"""
+        val startSql = sql"""
             insert into WORKFLOW_ACTUAL_COST(EXTERNAL_ID, COST)
             values """
-      val endSql = sql""" on duplicate key update COST=COST;"""
+        val endSql = sql""" on duplicate key update COST=COST;"""
 
-      concatSqlActions(startSql, paramSql, endSql).asUpdate
-    }
+        concatSqlActions(startSql, paramSql, endSql).asUpdate
+      }
 
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowActualCostComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowActualCostComponent.scala
@@ -17,7 +17,7 @@ import slick.jdbc.{GetResult, JdbcProfile, SQLActionBuilder}
 import java.sql.Timestamp
 import java.util.UUID
 
-case class WorkflowActualCostRecord(externalId: String, cost: Option[Float])
+case class WorkflowActualCostRecord(id: Long, externalId: String, cost: Option[Float])
 
 trait WorkflowActualCostComponent {
   this: DriverComponent =>
@@ -25,10 +25,12 @@ trait WorkflowActualCostComponent {
   import driver.api._
 
   class WorkflowActualCostTable(tag: Tag) extends Table[WorkflowActualCostRecord](tag, "WORKFLOW_ACTUAL_COST") {
+    def id = column[Long]("WORKFLOW_ID", O.PrimaryKey)
     def externalId = column[String]("EXTERNAL_ID", O.SqlType("CHAR(36)"))
     def cost = column[Option[Float]]("COST")
 
     def * = (
+      id,
       externalId,
       cost
     ) <> (WorkflowActualCostRecord.tupled, WorkflowActualCostRecord.unapply)
@@ -58,13 +60,13 @@ trait WorkflowActualCostComponent {
       else {
         // generate parameters for each row
         val rowParams: Seq[SQLActionBuilder] = rows.map { row =>
-          sql"""(${row.externalId}, ${row.cost})"""
+          sql"""(${row.id}, ${row.externalId}, ${row.cost})"""
         }
 
         val paramSql = reduceSqlActionsWithDelim(rowParams, sql",")
 
         val startSql = sql"""
-            insert into WORKFLOW_ACTUAL_COST(EXTERNAL_ID, COST)
+            insert into WORKFLOW_ACTUAL_COST(WORKFLOW_ID, EXTERNAL_ID, COST)
             values """
         val endSql = sql""" on duplicate key update COST=COST;"""
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
@@ -531,6 +531,9 @@ trait WorkflowComponent {
     def findWorkflowByExternalIdAndSubmissionId(externalId: String, submissionId: UUID): WorkflowQueryType =
       filter(wf => wf.externalId === externalId && wf.submissionId === submissionId)
 
+    def findWorkflowByExternalIdsAndSubmissionId(externalIds: Set[String], submissionId: UUID): WorkflowQueryType =
+      filter(wf => wf.externalId.inSetBind(externalIds) && wf.submissionId === submissionId)
+
     def findWorkflowsForAbort(submissionId: UUID): WorkflowQueryType = {
       val statuses: Traversable[String] = WorkflowStatuses.abortableStatuses map (_.toString)
       filter(wf => wf.submissionId === submissionId && wf.externalId.isDefined && wf.status.inSetBind(statuses))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/SubmissionCostServiceFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/SubmissionCostServiceFactory.scala
@@ -1,14 +1,14 @@
 package org.broadinstitute.dsde.rawls.serviceFactory
 
 import org.broadinstitute.dsde.rawls.config.RawlsConfigManager
-import org.broadinstitute.dsde.rawls.dataaccess.{SubmissionCostService, SubmissionCostServiceImpl}
+import org.broadinstitute.dsde.rawls.dataaccess.{SlickDataSource, SubmissionCostService, SubmissionCostServiceImpl}
 import org.broadinstitute.dsde.rawls.serviceFactory.DisabledServiceFactory.newDisabledService
 import org.broadinstitute.dsde.workbench.google.GoogleBigQueryDAO
 
 import scala.concurrent.ExecutionContext
 
 object SubmissionCostServiceFactory {
-  def createSubmissionCostService(appConfigManager: RawlsConfigManager, bigQueryDAO: GoogleBigQueryDAO)(implicit
+  def createSubmissionCostService(appConfigManager: RawlsConfigManager, dataSource: SlickDataSource, bigQueryDAO: GoogleBigQueryDAO)(implicit
     executionContext: ExecutionContext
   ): SubmissionCostService =
     appConfigManager.gcsConfig match {
@@ -18,6 +18,7 @@ object SubmissionCostServiceFactory {
           gcsConfig.getString("billingExportDatePartitionColumn"),
           gcsConfig.getString("serviceProject"),
           gcsConfig.getInt("billingSearchWindowDays"),
+          dataSource,
           bigQueryDAO
         )
       case None =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/SubmissionCostServiceFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/SubmissionCostServiceFactory.scala
@@ -8,7 +8,10 @@ import org.broadinstitute.dsde.workbench.google.GoogleBigQueryDAO
 import scala.concurrent.ExecutionContext
 
 object SubmissionCostServiceFactory {
-  def createSubmissionCostService(appConfigManager: RawlsConfigManager, dataSource: SlickDataSource, bigQueryDAO: GoogleBigQueryDAO)(implicit
+  def createSubmissionCostService(appConfigManager: RawlsConfigManager,
+                                  dataSource: SlickDataSource,
+                                  bigQueryDAO: GoogleBigQueryDAO
+  )(implicit
     executionContext: ExecutionContext
   ): SubmissionCostService =
     appConfigManager.gcsConfig match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -312,7 +312,8 @@ class SubmissionsService(
       // if we weren't able to do so above
       _ <- executionServiceCluster.findExecService(submissionId, workflowId, ctx.userInfo, optExecId)
       submissionDoneDate = getTerminalStatusDate(submission, Option(workflowId))
-      costs <- submissionCostService.getWorkflowCost(workflowId,
+      costs <- submissionCostService.getWorkflowCost(submissionId,
+                                                     workflowId,
                                                      workspace.googleProjectId,
                                                      submission.submissionDate,
                                                      submissionDoneDate,
@@ -392,7 +393,8 @@ class SubmissionsService(
           val submissionDoneDate: Option[DateTime] = getTerminalStatusDate(submission, None)
           getSpendReportTableName(RawlsBillingProjectName(workspaceName.namespace)) flatMap { tableName =>
             toFutureTry(
-              submissionCostService.getSubmissionCosts(workflowIdsForCostQuery,
+              submissionCostService.getSubmissionCosts(submissionId,
+                                                       workflowIdsForCostQuery,
                                                        workspace.googleProjectId,
                                                        submission.submissionDate,
                                                        submissionDoneDate,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -379,7 +379,7 @@ class SubmissionsService(
         }
       }
 
-    traceFutureWithParent("submissionWithoutCostsAndWorkspace", parentContext) { span =>
+    traceFutureWithParent("submissionWithoutCostsAndWorkspace", parentContext) { _ =>
       submissionWithoutCostsAndWorkspace flatMap { case (submission, workspace) =>
         // determine which workflows are eligible for actual-cost lookup
         val workflowIdsForCostQuery: Seq[String] = filterActualCostWorkflowCandidates(submission.workflows)
@@ -391,8 +391,7 @@ class SubmissionsService(
           val submissionDoneDate: Option[DateTime] = getTerminalStatusDate(submission, None)
           getSpendReportTableName(RawlsBillingProjectName(workspaceName.namespace)) flatMap { tableName =>
             toFutureTry(
-              submissionCostService.getSubmissionCosts(submissionId,
-                                                       workflowIdsForCostQuery,
+              submissionCostService.getSubmissionCosts(workflowIdsForCostQuery,
                                                        workspace.googleProjectId,
                                                        submission.submissionDate,
                                                        submissionDoneDate,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockSubmissionCostService.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockSubmissionCostService.scala
@@ -23,7 +23,8 @@ class MockSubmissionCostService(defaultTableName: String,
 
   val fixedCost = 1.23f
 
-  override def getSubmissionCosts(workflowIds: Seq[String],
+  override def getSubmissionCosts(submissionId: String,
+                                  workflowIds: Seq[String],
                                   googleProjectId: GoogleProjectId,
                                   submissionDate: DateTime,
                                   submissionDoneDate: Option[DateTime],
@@ -31,7 +32,8 @@ class MockSubmissionCostService(defaultTableName: String,
   ): Future[Map[String, Float]] =
     Future(workflowIds.map(_ -> fixedCost).toMap)
 
-  override def getWorkflowCost(workflowId: String,
+  override def getWorkflowCost(submissionId: String,
+                               workflowId: String,
                                googleProjectId: GoogleProjectId,
                                submissionDate: DateTime,
                                submissionDoneDate: Option[DateTime],

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockSubmissionCostService.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockSubmissionCostService.scala
@@ -10,19 +10,20 @@ class MockSubmissionCostService(defaultTableName: String,
                                 defaultDatePartitionColumn: String,
                                 serviceProject: String,
                                 billingSearchWindowDays: Int,
+                                dataSource: SlickDataSource,
                                 bigQueryDAO: GoogleBigQueryDAO
 )(implicit executionContext: ExecutionContext)
     extends SubmissionCostServiceImpl(defaultTableName,
                                       defaultDatePartitionColumn,
                                       serviceProject,
                                       billingSearchWindowDays,
+                                      dataSource,
                                       bigQueryDAO
     ) {
 
   val fixedCost = 1.23f
 
-  override def getSubmissionCosts(submissionId: String,
-                                  workflowIds: Seq[String],
+  override def getSubmissionCosts(workflowIds: Seq[String],
                                   googleProjectId: GoogleProjectId,
                                   submissionDate: DateTime,
                                   submissionDoneDate: Option[DateTime],

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
@@ -22,7 +22,7 @@ import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.ArgumentCaptor
 import org.scalatest.flatspec.AnyFlatSpec
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{spy, times, verify, when}
+import org.mockito.Mockito.{never, spy, times, verify, when}
 
 import java.util.UUID
 import scala.concurrent.{Await, Future}
@@ -324,9 +324,152 @@ class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils with Moc
       assertWorkflowParams(paramsCaptor, uncachedCosts.keySet)
   }
 
-  it should "bypass BigQuery if all workflows are cached" is pending
+  it should "bypass BigQuery if all workflows are cached" in withEmptyTestDatabase { dataSource: SlickDataSource =>
+    // 10 workflows, all are cached
+    val costs = generateWorkflowCosts(10)
+    logger.info(s"***** costs is: $costs")
+    val cachedCosts = costs
+    logger.info(s"***** cachedCosts is: $cachedCosts")
+    val uncachedCosts = Map.empty[String, Float]
+    // persist cachedCosts
+    val rows = cachedCosts.map { case (externalId, cost) =>
+      WorkflowActualCostRecord(externalId, Option(cost))
+    }
+    runAndWait(dataSource.dataAccess.workflowActualCostRawSqlQuery.safeInsert(rows.toSeq))
+    // get the mocked service
+    val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
+    // execute getSubmissionCosts
+    val actual = Await.result(
+      costService.getSubmissionCosts(
+        costs.keySet.toSeq,
+        defaultGoogleProjectId,
+        DateTime.now().minusDays(7),
+        Option(DateTime.now().minusDays(5))
+      ),
+      Duration.Inf
+    )
+    // verify correct results
+    actual shouldBe costs
+    // verify we didn't call BigQuery
+    verify(bigQuery, never).startParameterizedQuery(any[GoogleProject],
+                                                    any[String],
+                                                    any[List[QueryParameter]],
+                                                    any[String]
+    )
+  }
 
-  it should "write BigQuery results back to cache" is pending
+  it should "write BigQuery results back to cache" in withEmptyTestDatabase { dataSource: SlickDataSource =>
+    import dataSource.dataAccess.driver.api._
 
-  it should "write nulls to cache when BigQuery has no results" is pending
+    // 10 workflows, with 4 being cached
+    val costs = generateWorkflowCosts(10)
+    val cachedCosts = costs.take(4)
+    val uncachedCosts = costs -- cachedCosts.keySet
+    // persist cachedCosts
+    val rows = cachedCosts.map { case (externalId, cost) =>
+      WorkflowActualCostRecord(externalId, Option(cost))
+    }
+    runAndWait(dataSource.dataAccess.workflowActualCostRawSqlQuery.safeInsert(rows.toSeq))
+
+    // validate what's in the cache before running getSubmissionCosts
+    val actualCacheBefore = runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
+    actualCacheBefore should contain theSameElementsAs rows
+
+    // get the mocked service
+    val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
+    // execute getSubmissionCosts
+    val actual = Await.result(
+      costService.getSubmissionCosts(
+        costs.keySet.toSeq,
+        defaultGoogleProjectId,
+        DateTime.now().minusDays(7),
+        Option(DateTime.now().minusDays(5))
+      ),
+      Duration.Inf
+    )
+
+    // validate what's in the cache after running getSubmissionCosts
+    val actualCacheAfter = runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
+    val expectedCacheAfter = costs.map { case (externalId, cost) =>
+      WorkflowActualCostRecord(externalId, Option(cost))
+    }
+    actualCacheAfter should contain theSameElementsAs expectedCacheAfter
+  }
+
+  it should "write nulls to cache when nothing cached and BigQuery has no results" in withEmptyTestDatabase {
+    dataSource: SlickDataSource =>
+      import dataSource.dataAccess.driver.api._
+
+      // 3 workflows; none cached, and none found in BigQuery
+      val costs = generateWorkflowCosts(3)
+      val uncachedCosts = Map.empty[String, Float]
+
+      // validate what's in the cache before running getSubmissionCosts
+      val cacheBefore = runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
+      cacheBefore shouldBe empty
+
+      // get the mocked service
+      val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
+      // execute getSubmissionCosts
+      Await.result(
+        costService.getSubmissionCosts(
+          costs.keySet.toSeq,
+          defaultGoogleProjectId,
+          DateTime.now().minusDays(7),
+          Option(DateTime.now().minusDays(5))
+        ),
+        Duration.Inf
+      )
+
+      // validate what's in the cache after running getSubmissionCosts
+      val actualCacheAfter = runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
+      val expectedCacheAfter = costs.map { case (externalId, cost) =>
+        WorkflowActualCostRecord(externalId, None)
+      }
+      actualCacheAfter should contain theSameElementsAs expectedCacheAfter
+  }
+
+  it should "write nulls to cache when some cached and BigQuery has no results" in withEmptyTestDatabase {
+    dataSource: SlickDataSource =>
+      import dataSource.dataAccess.driver.api._
+
+      // 5 workflows; 2 cached, and none found in BigQuery
+      val costs = generateWorkflowCosts(5)
+      val cachedCosts = costs.take(2)
+      val uncachedCosts = Map.empty[String, Float]
+
+      // persist cachedCosts
+      val rows = cachedCosts.map { case (externalId, cost) =>
+        WorkflowActualCostRecord(externalId, Option(cost))
+      }
+      runAndWait(dataSource.dataAccess.workflowActualCostRawSqlQuery.safeInsert(rows.toSeq))
+
+      // validate what's in the cache before running getSubmissionCosts
+      val actualCacheBefore = runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
+      actualCacheBefore should contain theSameElementsAs rows
+
+      // get the mocked service
+      val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
+      // execute getSubmissionCosts
+      Await.result(
+        costService.getSubmissionCosts(
+          costs.keySet.toSeq,
+          defaultGoogleProjectId,
+          DateTime.now().minusDays(7),
+          Option(DateTime.now().minusDays(5))
+        ),
+        Duration.Inf
+      )
+
+      // validate what's in the cache after running getSubmissionCosts
+      val actualCacheAfter = runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
+      val nullRows = costs -- cachedCosts.keySet
+      val expectedCacheAfter = cachedCosts.map { case (externalId, cost) =>
+        WorkflowActualCostRecord(externalId, Option(cost))
+      } ++ nullRows.map { case (externalId, cost) =>
+        WorkflowActualCostRecord(externalId, None)
+      }
+      actualCacheAfter should contain theSameElementsAs expectedCacheAfter
+  }
+
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
@@ -1,19 +1,38 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
 import akka.actor.ActorSystem
-import com.google.api.services.bigquery.model.{TableCell, TableRow}
+import com.google.api.services.bigquery.model.{
+  GetQueryResultsResponse,
+  Job,
+  JobReference,
+  QueryParameter,
+  QueryParameterType,
+  QueryParameterValue,
+  TableCell,
+  TableRow
+}
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkflowActualCostRecord
 import org.broadinstitute.dsde.rawls.model.GoogleProjectId
+import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
+import org.broadinstitute.dsde.workbench.google.GoogleBigQueryDAO
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleBigQueryDAO
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.{DateTime, DateTimeZone}
+import org.mockito.ArgumentCaptor
 import org.scalatest.flatspec.AnyFlatSpec
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{spy, times, verify, when}
 
-import scala.concurrent.Await
+import java.util.UUID
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
+import scala.math.BigDecimal.RoundingMode
+import scala.util.Random
 
-class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils {
+class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils with MockitoTestUtils {
   implicit val actorSystem: ActorSystem = ActorSystem("SubmissionCostServiceSpec")
   val mockBigQueryDAO = new MockGoogleBigQueryDAO
   val submissionCostService = SubmissionCostServiceImpl.constructor(
@@ -179,4 +198,135 @@ class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils {
         1 minute
       )
     }
+
+  behavior of "actual-cost caching"
+
+  // helper: the Google project id used for all tests
+  val defaultGoogleProjectId = GoogleProjectId("doesnotmatter")
+  // helper: create a SubmissionCostServiceImpl using a mockito mock for BigQuery
+  def getMockitoSubmissionCostService(bqCosts: Map[String, Float]) = {
+    val mockitoGoogleBigQueryDAO = mock[GoogleBigQueryDAO]
+    val testJobReference: JobReference = new JobReference().setJobId("test job id")
+    val testJob: Job = new Job().setJobReference(testJobReference)
+    when(
+      mockitoGoogleBigQueryDAO.startParameterizedQuery(any[GoogleProject],
+                                                       any[String],
+                                                       any[List[QueryParameter]],
+                                                       any[String]
+      )
+    )
+      .thenReturn(Future.successful(testJobReference))
+    when(mockitoGoogleBigQueryDAO.getQueryStatus(any[JobReference]))
+      .thenReturn(Future.successful(testJob))
+    returnCostsFrom(mockitoGoogleBigQueryDAO, bqCosts)
+    val costService = SubmissionCostServiceImpl.constructor(
+      "fakeTableName",
+      "fakeDatePartitionColumn",
+      "fakeServiceProject",
+      31,
+      slickDataSource,
+      mockitoGoogleBigQueryDAO
+    )
+    (costService, mockitoGoogleBigQueryDAO)
+  }
+  // helper: generate some randomized workflow ids and costs
+  def generateWorkflowCosts(quantity: Int): Map[String, Float] = Range(0, quantity).map { _ =>
+    // ensure floats have precision 2
+    UUID.randomUUID().toString -> BigDecimal(Random.nextFloat() * 10)
+      .setScale(2, RoundingMode.HALF_UP)
+      .toFloat
+  }.toMap
+  // helper: return the supplied costs for the supplied workflows from mock BigQuery
+  def returnCostsFrom(bigQuery: GoogleBigQueryDAO, costs: Map[String, Float]) = {
+    val rows = costs
+      .map { case (wfid, cost) =>
+        new TableRow().setF(
+          List(new TableCell().setV("wfKey"), new TableCell().setV(wfid), new TableCell().setV(cost)).asJava
+        )
+      }
+      .toList
+      .asJava
+
+    val bqResponse = new GetQueryResultsResponse
+    bqResponse.setRows(rows)
+
+    when(bigQuery.getQueryResult(any[Job]))
+      .thenReturn(Future.successful(bqResponse))
+  }
+  // helper:
+  def assertWorkflowParams(params: ArgumentCaptor[List[QueryParameter]], workflowIds: Iterable[String]) = {
+    val stringParamType = new QueryParameterType().setType("STRING")
+    // expected params are the google project id + all workflows
+    val googleProjectIdParam = new QueryParameter()
+      .setParameterType(stringParamType)
+      .setParameterValue(new QueryParameterValue().setValue(defaultGoogleProjectId.value))
+    val workflowParams = workflowIds.toList map { workflowId =>
+      new QueryParameter()
+        .setParameterType(stringParamType)
+        .setParameterValue(new QueryParameterValue().setValue(s"%$workflowId%"))
+    }
+    params.getValue should contain theSameElementsAs (workflowParams ++ Seq(googleProjectIdParam))
+  }
+
+  it should "ask BigQuery for all workflows if nothing is cached" in withEmptyTestDatabase {
+    dataSource: SlickDataSource =>
+      // 10 workflows, none cached
+      val costs = generateWorkflowCosts(10)
+      val uncachedCosts = costs
+      // get the mocked service
+      val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
+      // execute getSubmissionCosts
+      val actual = Await.result(
+        costService.getSubmissionCosts(
+          costs.keySet.toSeq,
+          defaultGoogleProjectId,
+          DateTime.now().minusDays(7),
+          Option(DateTime.now().minusDays(5))
+        ),
+        Duration.Inf
+      )
+      // verify correct results
+      actual shouldBe costs
+      // verify call to BigQuery
+      val paramsCaptor = captor[List[QueryParameter]]
+      verify(bigQuery).startParameterizedQuery(any[GoogleProject], any[String], paramsCaptor.capture(), any[String])
+      assertWorkflowParams(paramsCaptor, uncachedCosts.keySet)
+  }
+
+  it should "ask BigQuery for uncached workflows if some are cached" in withEmptyTestDatabase {
+    dataSource: SlickDataSource =>
+      // 10 workflows, with 4 being cached
+      val costs = generateWorkflowCosts(10)
+      val cachedCosts = costs.take(4)
+      val uncachedCosts = costs -- cachedCosts.keySet
+      // persist cachedCosts
+      val rows = cachedCosts.map { case (externalId, cost) =>
+        WorkflowActualCostRecord(externalId, Option(cost))
+      }
+      runAndWait(dataSource.dataAccess.workflowActualCostRawSqlQuery.safeInsert(rows.toSeq))
+      // get the mocked service
+      val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
+      // execute getSubmissionCosts
+      val actual = Await.result(
+        costService.getSubmissionCosts(
+          costs.keySet.toSeq,
+          defaultGoogleProjectId,
+          DateTime.now().minusDays(7),
+          Option(DateTime.now().minusDays(5))
+        ),
+        Duration.Inf
+      )
+      // verify correct results
+      actual shouldBe costs
+      // verify call to BigQuery
+      val paramsCaptor = captor[List[QueryParameter]]
+      verify(bigQuery).startParameterizedQuery(any[GoogleProject], any[String], paramsCaptor.capture(), any[String])
+      assertWorkflowParams(paramsCaptor, uncachedCosts.keySet)
+  }
+
+  it should "bypass BigQuery if all workflows are cached" is pending
+
+  it should "write BigQuery results back to cache" is pending
+
+  it should "write nulls to cache when BigQuery has no results" is pending
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
@@ -190,7 +190,8 @@ class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils with Moc
   it should "bypass BigQuery with no workflow IDs" in
     assertResult(Map.empty) {
       Await.result(
-        submissionCostService.getSubmissionCosts(Seq.empty,
+        submissionCostService.getSubmissionCosts("submission-id",
+                                                 Seq.empty,
                                                  GoogleProjectId("test"),
                                                  new DateTime(DateTimeZone.UTC),
                                                  Option(new DateTime(DateTimeZone.UTC))
@@ -229,6 +230,11 @@ class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils with Moc
     )
     (costService, mockitoGoogleBigQueryDAO)
   }
+  // helper: generate a random cost with precision 2
+  def randomCost: Float = BigDecimal(Random.nextFloat() * 100)
+    .setScale(2, RoundingMode.HALF_UP)
+    .toFloat
+
   // helper: generate some randomized workflow ids and costs
   def generateWorkflowCosts(quantity: Int): Map[String, Float] = Range(0, quantity).map { _ =>
     // ensure floats have precision 2
@@ -268,79 +274,77 @@ class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils with Moc
     params.getValue should contain theSameElementsAs (workflowParams ++ Seq(googleProjectIdParam))
   }
 
-  it should "ask BigQuery for all workflows if nothing is cached" in withEmptyTestDatabase {
-    dataSource: SlickDataSource =>
-      // 10 workflows, none cached
-      val costs = generateWorkflowCosts(10)
-      val uncachedCosts = costs
-      // get the mocked service
-      val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
-      // execute getSubmissionCosts
-      val actual = Await.result(
-        costService.getSubmissionCosts(
-          costs.keySet.toSeq,
-          defaultGoogleProjectId,
-          DateTime.now().minusDays(7),
-          Option(DateTime.now().minusDays(5))
-        ),
-        Duration.Inf
-      )
-      // verify correct results
-      actual shouldBe costs
-      // verify call to BigQuery
-      val paramsCaptor = captor[List[QueryParameter]]
-      verify(bigQuery).startParameterizedQuery(any[GoogleProject], any[String], paramsCaptor.capture(), any[String])
-      assertWorkflowParams(paramsCaptor, uncachedCosts.keySet)
-  }
-
-  it should "ask BigQuery for uncached workflows if some are cached" in withEmptyTestDatabase {
-    dataSource: SlickDataSource =>
-      // 10 workflows, with 4 being cached
-      val costs = generateWorkflowCosts(10)
-      val cachedCosts = costs.take(4)
-      val uncachedCosts = costs -- cachedCosts.keySet
-      // persist cachedCosts
-      val rows = cachedCosts.map { case (externalId, cost) =>
-        WorkflowActualCostRecord(externalId, Option(cost))
-      }
-      runAndWait(dataSource.dataAccess.workflowActualCostRawSqlQuery.safeInsert(rows.toSeq))
-      // get the mocked service
-      val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
-      // execute getSubmissionCosts
-      val actual = Await.result(
-        costService.getSubmissionCosts(
-          costs.keySet.toSeq,
-          defaultGoogleProjectId,
-          DateTime.now().minusDays(7),
-          Option(DateTime.now().minusDays(5))
-        ),
-        Duration.Inf
-      )
-      // verify correct results
-      actual shouldBe costs
-      // verify call to BigQuery
-      val paramsCaptor = captor[List[QueryParameter]]
-      verify(bigQuery).startParameterizedQuery(any[GoogleProject], any[String], paramsCaptor.capture(), any[String])
-      assertWorkflowParams(paramsCaptor, uncachedCosts.keySet)
-  }
-
-  it should "bypass BigQuery if all workflows are cached" in withEmptyTestDatabase { dataSource: SlickDataSource =>
-    // 10 workflows, all are cached
-    val costs = generateWorkflowCosts(10)
-    logger.info(s"***** costs is: $costs")
-    val cachedCosts = costs
-    logger.info(s"***** cachedCosts is: $cachedCosts")
-    val uncachedCosts = Map.empty[String, Float]
-    // persist cachedCosts
-    val rows = cachedCosts.map { case (externalId, cost) =>
-      WorkflowActualCostRecord(externalId, Option(cost))
-    }
-    runAndWait(dataSource.dataAccess.workflowActualCostRawSqlQuery.safeInsert(rows.toSeq))
+  it should "ask BigQuery for all workflows if nothing is cached" in withDefaultTestDatabase { _: SlickDataSource =>
+    val submission = testData.costedSubmission1
+    // 3 workflows, none cached
+    val costs = submission.workflows.map(wf => wf.workflowId.get -> randomCost).toMap
+    val uncachedCosts = costs
     // get the mocked service
     val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
     // execute getSubmissionCosts
     val actual = Await.result(
       costService.getSubmissionCosts(
+        submission.submissionId,
+        costs.keySet.toSeq,
+        defaultGoogleProjectId,
+        DateTime.now().minusDays(7),
+        Option(DateTime.now().minusDays(5))
+      ),
+      Duration.Inf
+    )
+    // verify correct results
+    actual shouldBe costs
+    // verify call to BigQuery
+    val paramsCaptor = captor[List[QueryParameter]]
+    verify(bigQuery).startParameterizedQuery(any[GoogleProject], any[String], paramsCaptor.capture(), any[String])
+    assertWorkflowParams(paramsCaptor, uncachedCosts.keySet)
+  }
+
+  it should "ask BigQuery for uncached workflows if some are cached" in withDefaultTestDatabase { _: SlickDataSource =>
+    val submission = testData.costedSubmission1
+    val submissionUuid = UUID.fromString(submission.submissionId)
+    // 3 workflows, with 1 being cached
+    val costs = submission.workflows.map(wf => wf.workflowId.get -> randomCost).toMap
+    val cachedCosts = costs.take(1)
+    val uncachedCosts = costs -- cachedCosts.keySet
+    // get the mocked service
+    val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
+    // persist cachedCosts
+    Await.result(costService.writeCostsToLocalDb(submissionUuid, cachedCosts, Set()), Duration.Inf)
+    // execute getSubmissionCosts
+    val actual = Await.result(
+      costService.getSubmissionCosts(
+        testData.costedSubmission1.submissionId,
+        costs.keySet.toSeq,
+        defaultGoogleProjectId,
+        DateTime.now().minusDays(7),
+        Option(DateTime.now().minusDays(5))
+      ),
+      Duration.Inf
+    )
+    // verify correct results
+    actual shouldBe costs
+    // verify call to BigQuery
+    val paramsCaptor = captor[List[QueryParameter]]
+    verify(bigQuery).startParameterizedQuery(any[GoogleProject], any[String], paramsCaptor.capture(), any[String])
+    assertWorkflowParams(paramsCaptor, uncachedCosts.keySet)
+  }
+
+  it should "bypass BigQuery if all workflows are cached" in withDefaultTestDatabase { dataSource: SlickDataSource =>
+    val submission = testData.costedSubmission1
+    val submissionUuid = UUID.fromString(submission.submissionId)
+    // 3 workflows, all are cached
+    val costs = submission.workflows.map(wf => wf.workflowId.get -> randomCost).toMap
+    val cachedCosts = costs
+    val uncachedCosts = Map.empty[String, Float]
+    // get the mocked service
+    val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
+    // persist cachedCosts
+    Await.result(costService.writeCostsToLocalDb(submissionUuid, cachedCosts, Set()), Duration.Inf)
+    // execute getSubmissionCosts
+    val actual = Await.result(
+      costService.getSubmissionCosts(
+        testData.costedSubmission1.submissionId,
         costs.keySet.toSeq,
         defaultGoogleProjectId,
         DateTime.now().minusDays(7),
@@ -358,28 +362,28 @@ class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils with Moc
     )
   }
 
-  it should "write BigQuery results back to cache" in withEmptyTestDatabase { dataSource: SlickDataSource =>
+  it should "write BigQuery results back to cache" in withDefaultTestDatabase { dataSource: SlickDataSource =>
     import dataSource.dataAccess.driver.api._
 
-    // 10 workflows, with 4 being cached
-    val costs = generateWorkflowCosts(10)
-    val cachedCosts = costs.take(4)
+    val submission = testData.costedSubmission1
+    val submissionUuid = UUID.fromString(submission.submissionId)
+    // 3 workflows, with 1 being cached
+    val costs = submission.workflows.map(wf => wf.workflowId.get -> randomCost).toMap
+    val cachedCosts = costs.take(1)
     val uncachedCosts = costs -- cachedCosts.keySet
+    // get the mocked service
+    val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
     // persist cachedCosts
-    val rows = cachedCosts.map { case (externalId, cost) =>
-      WorkflowActualCostRecord(externalId, Option(cost))
-    }
-    runAndWait(dataSource.dataAccess.workflowActualCostRawSqlQuery.safeInsert(rows.toSeq))
+    Await.result(costService.writeCostsToLocalDb(submissionUuid, cachedCosts, Set()), Duration.Inf)
 
     // validate what's in the cache before running getSubmissionCosts
     val actualCacheBefore = runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
-    actualCacheBefore should contain theSameElementsAs rows
+    actualCacheBefore.map(_.externalId) should contain theSameElementsAs cachedCosts.keySet
 
-    // get the mocked service
-    val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
     // execute getSubmissionCosts
-    val actual = Await.result(
+    Await.result(
       costService.getSubmissionCosts(
+        testData.costedSubmission1.submissionId,
         costs.keySet.toSeq,
         defaultGoogleProjectId,
         DateTime.now().minusDays(7),
@@ -388,31 +392,35 @@ class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils with Moc
       Duration.Inf
     )
 
-    // validate what's in the cache after running getSubmissionCosts
+    // validate what's in the cache after running getSubmissionCosts; ignore the WORKFLOW_ID column
+    // because that is non-deterministic (it's an auto-increment column and is tested elsewhere)
     val actualCacheAfter = runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
+      .map(rec => rec.externalId -> rec.cost)
     val expectedCacheAfter = costs.map { case (externalId, cost) =>
-      WorkflowActualCostRecord(externalId, Option(cost))
+      externalId -> Option(cost)
     }
     actualCacheAfter should contain theSameElementsAs expectedCacheAfter
   }
 
-  it should "write nulls to cache when nothing cached and BigQuery has no results" in withEmptyTestDatabase {
+  it should "write nulls to cache when nothing cached and BigQuery has no results" in withDefaultTestDatabase {
     dataSource: SlickDataSource =>
       import dataSource.dataAccess.driver.api._
 
+      val submission = testData.costedSubmission1
       // 3 workflows; none cached, and none found in BigQuery
-      val costs = generateWorkflowCosts(3)
+      val costs = submission.workflows.map(wf => wf.workflowId.get -> randomCost).toMap
       val uncachedCosts = Map.empty[String, Float]
+      // get the mocked service
+      val (costService, _) = getMockitoSubmissionCostService(uncachedCosts)
 
       // validate what's in the cache before running getSubmissionCosts
       val cacheBefore = runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
       cacheBefore shouldBe empty
 
-      // get the mocked service
-      val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
       // execute getSubmissionCosts
       Await.result(
         costService.getSubmissionCosts(
+          testData.costedSubmission1.submissionId,
           costs.keySet.toSeq,
           defaultGoogleProjectId,
           DateTime.now().minusDays(7),
@@ -421,38 +429,40 @@ class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils with Moc
         Duration.Inf
       )
 
-      // validate what's in the cache after running getSubmissionCosts
+      // validate what's in the cache after running getSubmissionCosts; ignore the WORKFLOW_ID column
+      // because that is non-deterministic (it's an auto-increment column and is tested elsewhere)
       val actualCacheAfter = runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
+        .map(rec => rec.externalId -> rec.cost)
       val expectedCacheAfter = costs.map { case (externalId, cost) =>
-        WorkflowActualCostRecord(externalId, None)
+        externalId -> None
       }
       actualCacheAfter should contain theSameElementsAs expectedCacheAfter
   }
 
-  it should "write nulls to cache when some cached and BigQuery has no results" in withEmptyTestDatabase {
+  it should "write nulls to cache when some cached and BigQuery has no results" in withDefaultTestDatabase {
     dataSource: SlickDataSource =>
       import dataSource.dataAccess.driver.api._
 
-      // 5 workflows; 2 cached, and none found in BigQuery
-      val costs = generateWorkflowCosts(5)
-      val cachedCosts = costs.take(2)
+      val submission = testData.costedSubmission1
+      val submissionUuid = UUID.fromString(submission.submissionId)
+      // 3 workflows, with 1 being cached, and none found in BigQuery
+      val costs = submission.workflows.map(wf => wf.workflowId.get -> randomCost).toMap
+      val cachedCosts = costs.take(1)
       val uncachedCosts = Map.empty[String, Float]
-
+      // get the mocked service
+      val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
       // persist cachedCosts
-      val rows = cachedCosts.map { case (externalId, cost) =>
-        WorkflowActualCostRecord(externalId, Option(cost))
-      }
-      runAndWait(dataSource.dataAccess.workflowActualCostRawSqlQuery.safeInsert(rows.toSeq))
+      Await.result(costService.writeCostsToLocalDb(submissionUuid, cachedCosts, Set()), Duration.Inf)
 
       // validate what's in the cache before running getSubmissionCosts
       val actualCacheBefore = runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
-      actualCacheBefore should contain theSameElementsAs rows
+        .map(_.externalId)
+      actualCacheBefore should contain theSameElementsAs cachedCosts.keySet
 
-      // get the mocked service
-      val (costService, bigQuery) = getMockitoSubmissionCostService(uncachedCosts)
       // execute getSubmissionCosts
       Await.result(
         costService.getSubmissionCosts(
+          testData.costedSubmission1.submissionId,
           costs.keySet.toSeq,
           defaultGoogleProjectId,
           DateTime.now().minusDays(7),
@@ -461,15 +471,62 @@ class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils with Moc
         Duration.Inf
       )
 
-      // validate what's in the cache after running getSubmissionCosts
+      // validate what's in the cache after running getSubmissionCosts; ignore the WORKFLOW_ID column
+      // because that is non-deterministic (it's an auto-increment column and is tested elsewhere)
       val actualCacheAfter = runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
+        .map(rec => rec.externalId -> rec.cost)
       val nullRows = costs -- cachedCosts.keySet
       val expectedCacheAfter = cachedCosts.map { case (externalId, cost) =>
-        WorkflowActualCostRecord(externalId, Option(cost))
+        externalId -> Option(cost)
       } ++ nullRows.map { case (externalId, cost) =>
-        WorkflowActualCostRecord(externalId, None)
+        externalId -> None
       }
       actualCacheAfter should contain theSameElementsAs expectedCacheAfter
   }
 
+  behavior of "writeCostsToLocalDb"
+
+  it should "persist rows, including the foreign key to WORKFLOW" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      import dataSource.dataAccess.driver.api._
+
+      val submission = testData.costedSubmission1
+      val submissionUuid = UUID.fromString(submission.submissionId)
+      // find existing workflows; assert all workflows have an external id
+      submission.workflows.foreach { workflow =>
+        workflow.workflowId should not be empty
+      }
+      // generate some random costs for these workflows
+      val costs = submission.workflows.map { workflow =>
+        workflow.workflowId.get -> // ensure floats have precision 2
+          BigDecimal(Random.nextFloat() * 10)
+            .setScale(2, RoundingMode.HALF_UP)
+            .toFloat
+      }.toMap
+      // get the mocked service
+      val (costService, _) = getMockitoSubmissionCostService(Map())
+      // execute the writeCostsToLocalDb method
+      val actualWrite = Await.result(
+        costService.writeCostsToLocalDb(submissionUuid, costs, Set()),
+        Duration.Inf
+      )
+      actualWrite shouldBe costs.size
+      // retrieve the workflows, then retrieve the cached costs, and compare them
+      val actualWorkflows =
+        runAndWait(dataSource.dataAccess.workflowQuery.findWorkflowsBySubmissionId(submissionUuid).result)
+          .map(rec => rec.id -> rec.externalId)
+          .toMap
+      val actualCostRecords =
+        runAndWait(dataSource.dataAccess.workflowActualCostQuery.result)
+
+      actualCostRecords.foreach { costRecord =>
+        // the cost record's id should exist in the workflow table
+        actualWorkflows.get(costRecord.id) should not be empty
+        // the cost record's id->externalId pair should be the same as in the workflow table
+        actualWorkflows(costRecord.id) shouldBe Option(costRecord.externalId)
+        // the cost record's cost should be what we asked to insert
+        costRecord.cost shouldBe Option(costs(costRecord.externalId))
+      }
+
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
@@ -21,6 +21,7 @@ class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils {
     "fakeDatePartitionColumn",
     "fakeServiceProject",
     31,
+    slickDataSource,
     mockBigQueryDAO
   )
 
@@ -170,8 +171,7 @@ class SubmissionCostServiceSpec extends AnyFlatSpec with RawlsTestUtils {
   it should "bypass BigQuery with no workflow IDs" in
     assertResult(Map.empty) {
       Await.result(
-        submissionCostService.getSubmissionCosts("submission-id",
-                                                 Seq.empty,
+        submissionCostService.getSubmissionCosts(Seq.empty,
                                                  GoogleProjectId("test"),
                                                  new DateTime(DateTimeZone.UTC),
                                                  Option(new DateTime(DateTimeZone.UTC))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
@@ -181,6 +181,7 @@ class FastPassMonitorSpec
       "fakeDatePartitionColumn",
       "fakeServiceProject",
       31,
+      slickDataSource,
       bigQueryDAO
     )
     val execServiceBatchSize = 3

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -213,6 +213,7 @@ class FastPassServiceSpec
       "fakeDatePartitionColumn",
       "fakeServiceProject",
       31,
+      slickDataSource,
       bigQueryDAO
     )
     val execServiceBatchSize = 3

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -83,6 +83,7 @@ class SubmissionSpec(_system: ActorSystem)
     "fakeDatePartitionColumn",
     "fakeServiceProject",
     31,
+    slickDataSource,
     bigQueryDAO
   )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
@@ -183,6 +183,7 @@ class SubmissionsServiceSpec
       "fakeDatePartitionColumn",
       "fakeServiceProject",
       31,
+      slickDataSource,
       bigQueryDAO
     )
     val execServiceBatchSize = 3

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -248,7 +248,13 @@ trait ApiServiceSpec
     override val statusServiceConstructor = StatusService.constructor(healthMonitor) _
     val bigQueryDAO = new MockGoogleBigQueryDAO
     val submissionCostService =
-      new MockSubmissionCostService("fakeTableName", "fakeDatePartitionColumn", "fakeServiceProject", 31, bigQueryDAO)
+      new MockSubmissionCostService("fakeTableName",
+                                    "fakeDatePartitionColumn",
+                                    "fakeServiceProject",
+                                    31,
+                                    slickDataSource,
+                                    bigQueryDAO
+      )
     val execServiceBatchSize = 3
     val maxActiveWorkflowsTotal = 10
     val maxActiveWorkflowsPerUser = 2

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -245,6 +245,7 @@ class WorkspaceServiceSpec
       "fakeDatePartitionColumn",
       "fakeServiceProject",
       31,
+      slickDataSource,
       bigQueryDAO
     )
     val execServiceBatchSize = 3


### PR DESCRIPTION
Ticket: CORE-624

Adds a new `WORKFLOW_ACTUAL_COST` table to hold the actual-cost values for workflows. Currently, those values are only available in BigQuery.

Every time an end user retrieves submission details, we would re-query BigQuery for these values, even though we don't expect them to change. Now, we save the BigQuery results into MySQL so we can read them locally and hopefully not make a request to BQ.

--- 

This PR creates a new table for actual cost, and duplicates the `EXTERNAL_ID` value from `WORKFLOW` into the new table. Instead of a new `WORKFLOW_ACTUAL_COST` table, we could add a new `ACTUAL_COST` column to the `WORKFLOW` table. I felt that modifying `WORKFLOW` is less preferable because writing the actual costs into the WORKFLOW table could contend with other reads/writes to that table. Since actual costs are only read/written in the getSubmissionStatus API, using a separate table helps to isolate its writes.

Additionally, the actual-cost queries use the workflow's external id in a SQL WHERE clause. The current `WORKFLOW` table does not have an index on this column. This means we would either have to accept the queries are slow, or create an index on the ~45-million-row table. By creating a new table (with an index on the external id), we can build the index incrementally over time.

I expect - and this is a wild guess - that the `WORKFLOW_ACTUAL_COST` table will not contain as many rows as `WORKFLOW`. In the current implementation, we only add rows to `WORKFLOW_ACTUAL_COST` when a user views submission details. Many old submissions are never viewed and thus will not populate actual cost.