### PR TITLE
[CORE-691] Account for sets of sets in expression parsing

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -703,108 +703,83 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    *                         that includes all entities found by traversing the specified relationships.
    */
   def queryRelatedRecordsWithRelationChain(
-    workspaceId: UUID,
-    startingEntityType: String,
-    startingEntityName: String,
-    relationChain: Seq[String],
-    rootEntityType: String
-  ): ReadAction[Map[String, Seq[CompactEntityRecord]]] =
-    if (relationChain.isEmpty) { // The method shouldn't have been called in this case
+                                            workspaceId: UUID,
+                                            startingEntityType: String,
+                                            startingEntityName: String,
+                                            relationChain: Seq[String],
+                                            rootEntityType: String
+                                          ): ReadAction[Map[String, Seq[CompactEntityRecord]]] =
+    if (relationChain.isEmpty) {
       DBIO.successful(Map.empty[String, Seq[CompactEntityRecord]])
     } else {
-      // Start with the root entity
-      val initialEntities = Set(EntityPointer(startingEntityType, startingEntityName))
+      case class Path(entities: List[EntityPointer]) {
+        def lastEntity: EntityPointer = entities.last
+        def addEntity(entity: EntityPointer): Path = Path(entities :+ entity)
 
-      // Traverse the chain, tracking entity type at each step
+        // Find the last entity in this path that matches rootEntityType
+        def findRootEntity: Option[EntityPointer] =
+          entities.findLast(_.entityType == rootEntityType)
+      }
+
+      val initialPath = Path(List(EntityPointer(startingEntityType, startingEntityName)))
+
       def traverse(
-        currentEntities: Set[EntityPointer],
-        remainingChain: Seq[String]
-      ): ReadAction[Map[String, Seq[EntityPointer]]] =
+                    currentPaths: Set[Path],
+                    remainingChain: Seq[String]
+                  ): ReadAction[Set[Path]] = {
         if (remainingChain.isEmpty) {
-          // End of chain, group by current entity names
-          DBIO.successful(currentEntities.groupBy(_.entityName).view.mapValues(_.toSeq).toMap)
+          DBIO.successful(currentPaths)
         } else {
-          val nextRelation = remainingChain.head
-          // Traverse one step to get next entities and their type
-          getEntityTypeForRelation(workspaceId, currentEntities, nextRelation).flatMap { case (_, nextEntityType) =>
-            getAllReferencesForRelation(workspaceId, currentEntities, nextRelation).flatMap { nextEntities =>
-              if (nextEntities.isEmpty) {
-                DBIO.successful(Map.empty)
-              } else if (nextEntityType == rootEntityType) {
-                // Group by rootEntityType at this step
-                val grouped = nextEntities.groupBy(_.entityName).view.mapValues(_.toSeq).toMap
-                if (remainingChain.tail.isEmpty) {
-                  DBIO.successful(grouped)
-                } else {
-                  // For each group, continue traversing the rest of the chain
-                  val rest = remainingChain.tail
-                  DBIO
-                    .sequence(
-                      grouped.map { case (groupName, groupEntities) =>
-                        traverse(groupEntities.toSet, rest).map { subGroup =>
-                          // Flatten the subgroups and keep the grouping by groupName
-                          // subGroup: Map[String, Seq[EntityPointer]]
-                          // We want to collect all the values (Seq[EntityPointer]) into one Seq for this groupName
-                          groupName -> subGroup.values.flatten.toSeq
-                        }
-                      }.toSeq
-                    )
-                    .map(_.toMap)
-                }
-              } else {
-                // Not at rootEntityType yet, keep traversing
-                traverse(nextEntities, remainingChain.tail)
-              }
+          val relation = remainingChain.head
+
+          // For each path, get the next entities and extend the path
+          val pathTraversals = currentPaths.map { path =>
+            traverseOneStep(workspaceId, Set(path.lastEntity), relation).map { nextEntities =>
+              nextEntities.map(nextEntity => path.addEntity(nextEntity))
+            }
+          }
+
+          DBIO.sequence(pathTraversals.toSeq).flatMap { pathSets =>
+            val allExtendedPaths = pathSets.flatten.toSet
+            if (allExtendedPaths.isEmpty) {
+              DBIO.successful(Set.empty[Path])
+            } else {
+              traverse(allExtendedPaths, remainingChain.tail)
             }
           }
         }
-
-      // Traverse and get entity pointers grouped by rootEntityType
-      traverse(initialEntities, relationChain).flatMap { groupedPointers =>
-        // Fetch full records for all final entities
-        val allPointers = groupedPointers.values.flatten.toSet
-        getEntities(workspaceId, allPointers).map { entities =>
-          val entitiesByPointer = entities.groupBy(e => EntityPointer(e.entityType, e.name))
-          groupedPointers.map { case (groupName, pointers) =>
-            groupName -> pointers.flatMap(entitiesByPointer.get).flatten.toSeq
-          }
-        }
       }
-    }
 
-  // Helper: fetch all referenced entities for a given relation from a set of entities
-  private def getAllReferencesForRelation(
-    workspaceId: UUID,
-    currentEntities: Set[EntityPointer],
-    relation: String
-  ): ReadAction[Set[EntityPointer]] =
-    if (currentEntities.isEmpty) {
-      DBIO.successful(Set.empty[EntityPointer])
-    } else {
-      getEntities(workspaceId, currentEntities).map { entities =>
-        entities.flatMap { entityRecord =>
-          val attrValue = entityRecord.toEntity.attributes.get(AttributeName.fromDelimitedName(relation))
-          attrValue match {
-            case Some(rel: AttributeEntityReference)      => Seq(rel.toPointer)
-            case Some(rels: AttributeEntityReferenceList) => rels.list.map(_.toPointer)
-            case _                                        => Seq.empty[EntityPointer]
-          }
-        }.toSet
+      traverse(Set(initialPath), relationChain).flatMap { finalPaths =>
+        // Group paths by their root entity (the entity that matches rootEntityType)
+        val pathsByRoot: Map[String, Set[Path]] = finalPaths
+          .groupBy(_.findRootEntity.map(_.entityName))
+          .collect { case (Some(rootName), paths) => rootName -> paths }
+
+        // Get all final entities (leaf entities from all paths)
+        val allFinalPointers = finalPaths.map(_.lastEntity).toSet
+
+        getEntities(workspaceId, allFinalPointers).map { entities =>
+          val entitiesByPointer = entities.groupBy(e => EntityPointer(e.entityType, e.name))
+
+          pathsByRoot.view.mapValues { paths =>
+            paths.flatMap(path => entitiesByPointer.get(path.lastEntity)).flatten.toSeq.distinct
+          }.toMap
+        }
       }
     }
 
   private def traverseOneStep(
-    workspaceId: UUID,
-    currentEntities: Set[EntityPointer],
-    relation: String
-  ): ReadAction[Set[EntityPointer]] =
+                               workspaceId: UUID,
+                               currentEntities: Set[EntityPointer],
+                               relation: String
+                             ): ReadAction[Set[EntityPointer]] =
     if (currentEntities.isEmpty) {
       DBIO.successful(Set.empty[EntityPointer])
     } else {
       // retrieve the current entities to get their attributes
       getEntities(workspaceId, currentEntities).flatMap { entities =>
         // find all references in the specified relation attribute
-        // TODO: should this reuse CompactEntityProvider.findAllReferences ?
         val references = entities.flatMap { entityRecord =>
           val attrValue = entityRecord.toEntity.attributes.get(AttributeName.fromDelimitedName(relation))
           attrValue match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -695,9 +695,10 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    * This method supports recursive traversal of relationships, handling both arrays and objects in JSON attributes.
    *
    * @param workspaceId      The UUID of the workspace containing the entities.
-   * @param startingEntityType  The type of the root entity to start the query from.
-   * @param startingEntityName    The name of the root entity to start the query from.
+   * @param startingEntityType  The type of the entity to start the query from.
+   * @param startingEntityName    The name of the entity to start the query from.
    * @param relationChain   A chain of strings representing the relation columns between entities
+   * @param rootEntityType The entity type to group the results by
    * @return                 A `ReadAction` that resolves to a map of entity name to a Seq[`CompactEntityRecord`]
    *                         that includes all entities found by traversing the specified relationships.
    */
@@ -705,7 +706,8 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     workspaceId: UUID,
     startingEntityType: String,
     startingEntityName: String,
-    relationChain: Seq[String]
+    relationChain: Seq[String],
+    rootEntityType: String
   ): ReadAction[Map[String, Seq[CompactEntityRecord]]] =
     if (relationChain.isEmpty) { // The method shouldn't have been called in this case
       DBIO.successful(Map.empty[String, Seq[CompactEntityRecord]])
@@ -713,58 +715,83 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       // Start with the root entity
       val initialEntities = Set(EntityPointer(startingEntityType, startingEntityName))
 
-      // First step: get the first-level entities (these will be our grouping keys)
-      traverseOneStep(workspaceId, initialEntities, relationChain.head).flatMap { firstStepEntities =>
-        if (firstStepEntities.isEmpty) {
-          DBIO.successful(Map.empty[String, Seq[CompactEntityRecord]])
-        } else if (relationChain.length == 1) {
-          // Only one relation - group by first step entities
-          getEntities(workspaceId, firstStepEntities).map { entities =>
-            entities.groupBy(_.name)
-          }
+      // Traverse the chain, tracking entity type at each step
+      def traverse(
+        currentEntities: Set[EntityPointer],
+        remainingChain: Seq[String]
+      ): ReadAction[Map[String, Seq[EntityPointer]]] =
+        if (remainingChain.isEmpty) {
+          // End of chain, group by current entity names
+          DBIO.successful(currentEntities.groupBy(_.entityName).view.mapValues(_.toSeq).toMap)
         } else {
-          // Multiple relations - traverse the rest but track which first-step entity each result came from
-          val remainingChain = relationChain.tail
-          traverseOneStepWithGrouping(workspaceId, firstStepEntities, remainingChain).flatMap { groupedFinalEntities =>
-            // Get full records for all final entities
-            val allFinalEntities = groupedFinalEntities.values.flatten.toSet
-            getEntities(workspaceId, allFinalEntities).map { entities =>
-              val entitiesByPointer = entities.groupBy(e => EntityPointer(e.entityType, e.name))
-
-              // Map each first-step entity to its corresponding final entities
-              groupedFinalEntities.view.mapValues { entityPointers =>
-                entityPointers.flatMap(entitiesByPointer.get).flatten.toSeq
-              }.toMap
+          val nextRelation = remainingChain.head
+          // Traverse one step to get next entities and their type
+          getEntityTypeForRelation(workspaceId, currentEntities, nextRelation).flatMap { case (_, nextEntityType) =>
+            getAllReferencesForRelation(workspaceId, currentEntities, nextRelation).flatMap { nextEntities =>
+              if (nextEntities.isEmpty) {
+                DBIO.successful(Map.empty)
+              } else if (nextEntityType == rootEntityType) {
+                // Group by rootEntityType at this step
+                val grouped = nextEntities.groupBy(_.entityName).view.mapValues(_.toSeq).toMap
+                if (remainingChain.tail.isEmpty) {
+                  DBIO.successful(grouped)
+                } else {
+                  // For each group, continue traversing the rest of the chain
+                  val rest = remainingChain.tail
+                  DBIO
+                    .sequence(
+                      grouped.map { case (groupName, groupEntities) =>
+                        traverse(groupEntities.toSet, rest).map { subGroup =>
+                          // Flatten the subgroups and keep the grouping by groupName
+                          // subGroup: Map[String, Seq[EntityPointer]]
+                          // We want to collect all the values (Seq[EntityPointer]) into one Seq for this groupName
+                          groupName -> subGroup.values.flatten.toSeq
+                        }
+                      }.toSeq
+                    )
+                    .map(_.toMap)
+                }
+              } else {
+                // Not at rootEntityType yet, keep traversing
+                traverse(nextEntities, remainingChain.tail)
+              }
             }
+          }
+        }
+
+      // Traverse and get entity pointers grouped by rootEntityType
+      traverse(initialEntities, relationChain).flatMap { groupedPointers =>
+        // Fetch full records for all final entities
+        val allPointers = groupedPointers.values.flatten.toSet
+        getEntities(workspaceId, allPointers).map { entities =>
+          val entitiesByPointer = entities.groupBy(e => EntityPointer(e.entityType, e.name))
+          groupedPointers.map { case (groupName, pointers) =>
+            groupName -> pointers.flatMap(entitiesByPointer.get).flatten.toSeq
           }
         }
       }
     }
 
-  private def traverseOneStepWithGrouping(
+  // Helper: fetch all referenced entities for a given relation from a set of entities
+  private def getAllReferencesForRelation(
     workspaceId: UUID,
-    firstStepEntities: Set[EntityPointer],
-    remainingChain: Seq[String]
-  ): ReadAction[Map[String, Set[EntityPointer]]] = {
-    // For each first-step entity, traverse the remaining relations independently
-    val traversalFutures = firstStepEntities.map { firstEntity =>
-      // Start with just this first entity and traverse the remaining chain
-      remainingChain
-        .foldLeft(DBIO.successful(Set(firstEntity)): ReadAction[Set[EntityPointer]]) { (entitiesFuture, relation) =>
-          entitiesFuture.flatMap { currentEntities =>
-            if (currentEntities.isEmpty) {
-              DBIO.successful(Set.empty[EntityPointer])
-            } else {
-              traverseOneStep(workspaceId, currentEntities, relation)
-            }
+    currentEntities: Set[EntityPointer],
+    relation: String
+  ): ReadAction[Set[EntityPointer]] =
+    if (currentEntities.isEmpty) {
+      DBIO.successful(Set.empty[EntityPointer])
+    } else {
+      getEntities(workspaceId, currentEntities).map { entities =>
+        entities.flatMap { entityRecord =>
+          val attrValue = entityRecord.toEntity.attributes.get(AttributeName.fromDelimitedName(relation))
+          attrValue match {
+            case Some(rel: AttributeEntityReference)      => Seq(rel.toPointer)
+            case Some(rels: AttributeEntityReferenceList) => rels.list.map(_.toPointer)
+            case _                                        => Seq.empty[EntityPointer]
           }
-        }
-        .map(finalEntities => firstEntity.entityName -> finalEntities)
+        }.toSet
+      }
     }
-
-    // Convert Set to Seq before calling DBIO.sequence
-    DBIO.sequence(traversalFutures.toSeq).map(_.toMap)
-  }
 
   private def traverseOneStep(
     workspaceId: UUID,
@@ -790,25 +817,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       }
     }
 
-//  def traverseEntityTypes(workspaceId: UUID,
-//                          startingEntityType: String,
-//                          startingEntityName: String,
-//                          entityRelationChain: List[String]
-//  ): ReadAction[Set[EntityPointer]] = {
-//    // Start with the root entity
-//    val initialEntities = Set(EntityPointer(startingEntityType, startingEntityName))
-//    entityRelationChain
-//        .foldLeft(DBIO.successful(initialEntities): ReadAction[Set[EntityPointer]]) { (entitiesFuture, relation) =>
-//          entitiesFuture.flatMap { currentEntities =>
-//            if (currentEntities.isEmpty) {
-//              DBIO.successful(Set.empty[EntityPointer])
-//            } else {
-//              traverseOneStep(workspaceId, currentEntities, relation)
-//            }
-//          }
-//        }
-//  }
-
   /**
    * Traverse the entity relation chain to determine the final entity type.
    * This method follows the entity relationships defined by the relation chain
@@ -822,11 +830,11 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    *         or None if no entity is found or the relation chain doesn't exist.
    */
   def determineEntityTypeAtEndOfChain(
-                                       workspaceId: UUID,
-                                       startingEntityType: String,
-                                       startingEntityName: String,
-                                       entityRelationChain: List[String]
-                                     ): ReadAction[Option[String]] = {
+    workspaceId: UUID,
+    startingEntityType: String,
+    startingEntityName: String,
+    entityRelationChain: List[String]
+  ): ReadAction[Option[String]] =
     if (entityRelationChain.isEmpty) {
       // No traversal needed, return the starting type
       DBIO.successful(Some(startingEntityType))
@@ -835,34 +843,35 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       val initialEntities = Set(EntityPointer(startingEntityType, startingEntityName))
 
       // Follow the relation chain to get the entity type at each step
-      entityRelationChain.foldLeft(DBIO.successful((initialEntities, startingEntityType)): ReadAction[(Set[EntityPointer], String)]) {
-        case (previousStep, relation) =>
-          previousStep.flatMap { case (currentEntities, _) =>
-            println("previousstep entities: ")
-            currentEntities.foreach(e => print(s"${e.entityType}/${e.entityName} "))
-            println(s"\nTraversing relation: $relation")
-            if (currentEntities.isEmpty) {
-              DBIO.successful((Set.empty[EntityPointer], ""))
-            } else {
-              // For each entity, find the relation attribute and determine its entity type
-              // We only need to determine the type of the first valid reference
-              getEntityTypeForRelation(workspaceId, currentEntities, relation)
+      entityRelationChain
+        .foldLeft(DBIO.successful((initialEntities, startingEntityType)): ReadAction[(Set[EntityPointer], String)]) {
+          case (previousStep, relation) =>
+            previousStep.flatMap { case (currentEntities, _) =>
+              println("previousstep entities: ")
+              currentEntities.foreach(e => print(s"${e.entityType}/${e.entityName} "))
+              println(s"\nTraversing relation: $relation")
+              if (currentEntities.isEmpty) {
+                DBIO.successful((Set.empty[EntityPointer], ""))
+              } else {
+                // For each entity, find the relation attribute and determine its entity type
+                // We only need to determine the type of the first valid reference
+                getEntityTypeForRelation(workspaceId, currentEntities, relation)
+              }
             }
-          }
-      }.map { case (entities, entityType) =>
-        if (entities.isEmpty) None else Some(entityType)
-      }
+        }
+        .map { case (entities, entityType) =>
+          if (entities.isEmpty) None else Some(entityType)
+        }
     }
-  }
 
   /**
    * Helper method to determine the entity type for a given relation without fetching all entity data.
    */
   private def getEntityTypeForRelation(
-                                        workspaceId: UUID,
-                                        currentEntities: Set[EntityPointer],
-                                        relation: String
-                                      ): ReadAction[(Set[EntityPointer], String)] = {
+    workspaceId: UUID,
+    currentEntities: Set[EntityPointer],
+    relation: String
+  ): ReadAction[(Set[EntityPointer], String)] = {
     currentEntities.foreach(e => print(s"${e.entityType}/${e.entityName} "))
     // Query just enough to get the type from the first entity that has the relation
     val query = concatSqlActions(
@@ -892,28 +901,28 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       GetResult(r => TypeRelation(r.<<, r.<<, r.<<, r.<<))
 
     query.as[TypeRelation].map { results =>
-    if (results.isEmpty) {
-      (Set.empty[EntityPointer], "")
-    } else {
-      // Group results by referenced entity type
-      val groupedByType = results.groupBy(_.refEntityType)
-      if (groupedByType.size > 1) {
-        // If there are multiple entity types referenced, log a warning but continue with the first type
-        logger.warn(s"Multiple entity types referenced by relation '$relation': ${groupedByType.keys.mkString(", ")}")
+      if (results.isEmpty) {
+        (Set.empty[EntityPointer], "")
+      } else {
+        // Group results by referenced entity type
+        val groupedByType = results.groupBy(_.refEntityType)
+        if (groupedByType.size > 1) {
+          // If there are multiple entity types referenced, log a warning but continue with the first type
+          logger.warn(s"Multiple entity types referenced by relation '$relation': ${groupedByType.keys.mkString(", ")}")
+        }
+
+        // Use the first entity type we find
+        val firstType = results.head.refEntityType
+
+        // Create EntityPointers for all entities of this type
+        val entityPointers = results
+          .filter(_.refEntityType == firstType)
+          .map(r => EntityPointer(r.refEntityType, r.refName))
+          .toSet
+
+        (entityPointers, firstType)
       }
-      
-      // Use the first entity type we find
-      val firstType = results.head.refEntityType
-      
-      // Create EntityPointers for all entities of this type
-      val entityPointers = results
-        .filter(_.refEntityType == firstType)
-        .map(r => EntityPointer(r.refEntityType, r.refName))
-        .toSet
-        
-      (entityPointers, firstType)
     }
-  }
   }
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -703,93 +703,75 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    *                         that includes all entities found by traversing the specified relationships.
    */
   def queryRelatedRecordsWithRelationChain(
-    workspaceId: UUID,
-    startingEntityType: String,
-    startingEntityName: String,
-    relationChain: Seq[String],
-    rootEntityType: String
-  ): ReadAction[Map[String, Seq[CompactEntityRecord]]] =
+                                            workspaceId: UUID,
+                                            startingEntityType: String,
+                                            startingEntityName: String,
+                                            relationChain: Seq[String],
+                                            rootEntityType: String
+                                          ): ReadAction[Map[String, Seq[CompactEntityRecord]]] = {
     if (relationChain.isEmpty) {
       DBIO.successful(Map.empty[String, Seq[CompactEntityRecord]])
     } else {
-      case class Path(entities: List[EntityPointer]) {
-        def lastEntity: EntityPointer = entities.last
-        def addEntity(entity: EntityPointer): Path = Path(entities :+ entity)
+      val initialPointer = EntityPointer(startingEntityType, startingEntityName)
+      val initialGrouped: Map[String, Set[EntityPointer]] =
+        if (startingEntityType == rootEntityType)
+          Map(startingEntityName -> Set(initialPointer))
+        else
+          Map("" -> Set(initialPointer))
 
-        // Find the last entity in this path that matches rootEntityType
-        def findRootEntity: Option[EntityPointer] =
-          entities.findLast(_.entityType == rootEntityType)
-      }
-
-      val initialPath = Path(List(EntityPointer(startingEntityType, startingEntityName)))
-
-      def traverse(
-        currentPaths: Set[Path],
-        remainingChain: Seq[String]
-      ): ReadAction[Set[Path]] =
-        if (remainingChain.isEmpty) {
-          DBIO.successful(currentPaths)
-        } else {
+      def traverseGroups(
+                          groupedEntities: Map[String, Set[EntityPointer]],
+                          currentEntityType: String,
+                          remainingChain: Seq[String],
+                          grouped: Boolean
+                        ): ReadAction[Map[String, Set[EntityPointer]]] = {
+        if (remainingChain.isEmpty) DBIO.successful(groupedEntities)
+        else {
           val relation = remainingChain.head
+            // For each group, get all referenced entities for this relation
+            val nextGroupsF = DBIO.sequence(groupedEntities.map { case (groupKey, pointers) =>
+              getEntities(workspaceId, pointers).map { entities =>
+                val nextPointers = entities.flatMap { entityRecord =>
+                  entityRecord.toEntity.attributes.get(AttributeName.fromDelimitedName(relation)) match {
+                    case Some(rel: AttributeEntityReference)      => Seq(rel.toPointer)
+                    case Some(rels: AttributeEntityReferenceList) => rels.list.map(_.toPointer)
+                    case _                                        => Seq.empty[EntityPointer]
+                  }
+                }.toSet
+                groupKey -> nextPointers
+              }
+            }.toSeq).map(_.toMap)
 
-          // For each path, get the next entities and extend the path
-          val pathTraversals = currentPaths.map { path =>
-            traverseOneStep(workspaceId, Set(path.lastEntity), relation).map { nextEntities =>
-              nextEntities.map(nextEntity => path.addEntity(nextEntity))
+
+            nextGroupsF.flatMap { nextGroups =>
+              val allNextPointers = nextGroups.values.flatten.toSet
+              val nextEntityType = allNextPointers.headOption.map(_.entityType).getOrElse(currentEntityType)
+              val shouldGroup = !grouped && nextEntityType == rootEntityType
+              val regrouped =
+                if (shouldGroup) {
+                  // Start grouping by entity name
+                  allNextPointers.groupBy(_.entityName)
+                } else {
+                  // Maintain current grouping
+                  nextGroups
+                }
+              traverseGroups(regrouped, nextEntityType, remainingChain.tail, grouped || shouldGroup)
             }
-          }
-
-          DBIO.sequence(pathTraversals.toSeq).flatMap { pathSets =>
-            val allExtendedPaths = pathSets.flatten.toSet
-            if (allExtendedPaths.isEmpty) {
-              DBIO.successful(Set.empty[Path])
-            } else {
-              traverse(allExtendedPaths, remainingChain.tail)
-            }
-          }
-        }
-
-      traverse(Set(initialPath), relationChain).flatMap { finalPaths =>
-        // Group paths by their root entity (the entity that matches rootEntityType)
-        val pathsByRoot: Map[String, Set[Path]] = finalPaths
-          .groupBy(_.findRootEntity.map(_.entityName))
-          .collect { case (Some(rootName), paths) => rootName -> paths }
-
-        // Get all final entities (leaf entities from all paths)
-        val allFinalPointers = finalPaths.map(_.lastEntity).toSet
-
-        getEntities(workspaceId, allFinalPointers).map { entities =>
-          val entitiesByPointer = entities.groupBy(e => EntityPointer(e.entityType, e.name))
-
-          pathsByRoot.view.mapValues { paths =>
-            paths.flatMap(path => entitiesByPointer.get(path.lastEntity)).flatten.toSeq.distinct
-          }.toMap
         }
       }
-    }
 
-  private def traverseOneStep(
-    workspaceId: UUID,
-    currentEntities: Set[EntityPointer],
-    relation: String
-  ): ReadAction[Set[EntityPointer]] =
-    if (currentEntities.isEmpty) {
-      DBIO.successful(Set.empty[EntityPointer])
-    } else {
-      // retrieve the current entities to get their attributes
-      getEntities(workspaceId, currentEntities).flatMap { entities =>
-        // find all references in the specified relation attribute
-        val references = entities.flatMap { entityRecord =>
-          val attrValue = entityRecord.toEntity.attributes.get(AttributeName.fromDelimitedName(relation))
-          attrValue match {
-            case Some(rel: AttributeEntityReference)      => Seq(rel.toPointer)
-            case Some(rels: AttributeEntityReferenceList) => rels.list.map(_.toPointer)
-            case _                                        => Seq.empty[EntityPointer]
+      traverseGroups(initialGrouped, startingEntityType, relationChain, grouped = startingEntityType == rootEntityType)
+        .flatMap { groupedPointers =>
+          val allPointers = groupedPointers.values.flatten.toSet
+          getEntities(workspaceId, allPointers).map { entities =>
+            val entitiesByPointer = entities.groupBy(e => EntityPointer(e.entityType, e.name))
+            groupedPointers.map { case (groupName, pointers) =>
+              groupName -> pointers.flatMap(entitiesByPointer.get).flatten.toSeq
+            }
           }
         }
-        DBIO.successful(references.toSet)
-      }
     }
+  }
 
   /**
    * Traverse the entity relation chain to determine the final entity type.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -703,12 +703,12 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    *                         that includes all entities found by traversing the specified relationships.
    */
   def queryRelatedRecordsWithRelationChain(
-                                            workspaceId: UUID,
-                                            startingEntityType: String,
-                                            startingEntityName: String,
-                                            relationChain: Seq[String],
-                                            rootEntityType: String
-                                          ): ReadAction[Map[String, Seq[CompactEntityRecord]]] = {
+    workspaceId: UUID,
+    startingEntityType: String,
+    startingEntityName: String,
+    relationChain: Seq[String],
+    rootEntityType: String
+  ): ReadAction[Map[String, Seq[CompactEntityRecord]]] =
     if (relationChain.isEmpty) {
       DBIO.successful(Map.empty[String, Seq[CompactEntityRecord]])
     } else {
@@ -720,16 +720,17 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           Map("" -> Set(initialPointer))
 
       def traverseGroups(
-                          groupedEntities: Map[String, Set[EntityPointer]],
-                          currentEntityType: String,
-                          remainingChain: Seq[String],
-                          grouped: Boolean
-                        ): ReadAction[Map[String, Set[EntityPointer]]] = {
+        groupedEntities: Map[String, Set[EntityPointer]],
+        currentEntityType: String,
+        remainingChain: Seq[String],
+        grouped: Boolean
+      ): ReadAction[Map[String, Set[EntityPointer]]] =
         if (remainingChain.isEmpty) DBIO.successful(groupedEntities)
         else {
           val relation = remainingChain.head
-            // For each group, get all referenced entities for this relation
-            val nextGroupsF = DBIO.sequence(groupedEntities.map { case (groupKey, pointers) =>
+          // For each group, get all referenced entities for this relation
+          val nextGroupsF = DBIO
+            .sequence(groupedEntities.map { case (groupKey, pointers) =>
               getEntities(workspaceId, pointers).map { entities =>
                 val nextPointers = entities.flatMap { entityRecord =>
                   entityRecord.toEntity.attributes.get(AttributeName.fromDelimitedName(relation)) match {
@@ -740,25 +741,24 @@ class CompactEntityQuery(driverComponent: DriverComponent)
                 }.toSet
                 groupKey -> nextPointers
               }
-            }.toSeq).map(_.toMap)
+            }.toSeq)
+            .map(_.toMap)
 
-
-            nextGroupsF.flatMap { nextGroups =>
-              val allNextPointers = nextGroups.values.flatten.toSet
-              val nextEntityType = allNextPointers.headOption.map(_.entityType).getOrElse(currentEntityType)
-              val shouldGroup = !grouped && nextEntityType == rootEntityType
-              val regrouped =
-                if (shouldGroup) {
-                  // Start grouping by entity name
-                  allNextPointers.groupBy(_.entityName)
-                } else {
-                  // Maintain current grouping
-                  nextGroups
-                }
-              traverseGroups(regrouped, nextEntityType, remainingChain.tail, grouped || shouldGroup)
-            }
+          nextGroupsF.flatMap { nextGroups =>
+            val allNextPointers = nextGroups.values.flatten.toSet
+            val nextEntityType = allNextPointers.headOption.map(_.entityType).getOrElse(currentEntityType)
+            val shouldGroup = !grouped && nextEntityType == rootEntityType
+            val regrouped =
+              if (shouldGroup) {
+                // Start grouping by entity name
+                allNextPointers.groupBy(_.entityName)
+              } else {
+                // Maintain current grouping
+                nextGroups
+              }
+            traverseGroups(regrouped, nextEntityType, remainingChain.tail, grouped || shouldGroup)
+          }
         }
-      }
 
       traverseGroups(initialGrouped, startingEntityType, relationChain, grouped = startingEntityType == rootEntityType)
         .flatMap { groupedPointers =>
@@ -771,7 +771,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           }
         }
     }
-  }
 
   /**
    * Traverse the entity relation chain to determine the final entity type.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -27,6 +27,9 @@ import slick.dbio.Effect.Read
 import slick.jdbc.MySQLProfile.api._
 import slick.jdbc._
 import slick.sql.SqlStreamingAction
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+import org.broadinstitute.dsde.rawls.model.ErrorReport
+
 import spray.json._
 
 import scala.concurrent.ExecutionContext
@@ -746,17 +749,28 @@ class CompactEntityQuery(driverComponent: DriverComponent)
 
           nextGroupsF.flatMap { nextGroups =>
             val allNextPointers = nextGroups.values.flatten.toSet
-            val nextEntityType = allNextPointers.headOption.map(_.entityType).getOrElse(currentEntityType)
-            val shouldGroup = !grouped && nextEntityType == rootEntityType
-            val regrouped =
-              if (shouldGroup) {
-                // Start grouping by entity name
-                allNextPointers.groupBy(_.entityName)
-              } else {
-                // Maintain current grouping
-                nextGroups
-              }
-            traverseGroups(regrouped, nextEntityType, remainingChain.tail, grouped || shouldGroup)
+            if (allNextPointers.map(_.entityType).size > 1) {
+              DBIO.failed(
+                new RawlsExceptionWithErrorReport(
+                  ErrorReport(
+                    StatusCodes.BadRequest,
+                    s"Multiple entity types referenced by relation '$relation': ${allNextPointers.map(_.entityType)}"
+                  )
+                )
+              )
+            } else {
+              val nextEntityType = allNextPointers.headOption.map(_.entityType).getOrElse(currentEntityType)
+              val shouldGroup = !grouped && nextEntityType == rootEntityType
+              val regrouped =
+                if (shouldGroup) {
+                  // Start grouping by entity name
+                  allNextPointers.groupBy(_.entityName)
+                } else {
+                  // Maintain current grouping
+                  nextGroups
+                }
+              traverseGroups(regrouped, nextEntityType, remainingChain.tail, grouped || shouldGroup)
+            }
           }
         }
 
@@ -802,9 +816,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         .foldLeft(DBIO.successful((initialEntities, startingEntityType)): ReadAction[(Set[EntityPointer], String)]) {
           case (previousStep, relation) =>
             previousStep.flatMap { case (currentEntities, _) =>
-              println("previousstep entities: ")
-              currentEntities.foreach(e => print(s"${e.entityType}/${e.entityName} "))
-              println(s"\nTraversing relation: $relation")
               if (currentEntities.isEmpty) {
                 DBIO.successful((Set.empty[EntityPointer], ""))
               } else {
@@ -827,7 +838,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     currentEntities: Set[EntityPointer],
     relation: String
   ): ReadAction[(Set[EntityPointer], String)] = {
-    currentEntities.foreach(e => print(s"${e.entityType}/${e.entityName} "))
     // Query just enough to get the type from the first entity that has the relation
     val query = concatSqlActions(
       sql"""select e.entity_type, e.name, jt.ref_entity_type, jt.ref_name
@@ -862,7 +872,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         // Group results by referenced entity type
         val groupedByType = results.groupBy(_.refEntityType)
         if (groupedByType.size > 1) {
-          // If there are multiple entity types referenced, log a warning but continue with the first type
+          // This shouldn't happen, as the limit 1 should ensure we only get one type back
           logger.warn(s"Multiple entity types referenced by relation '$relation': ${groupedByType.keys.mkString(", ")}")
         }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -703,12 +703,12 @@ class CompactEntityQuery(driverComponent: DriverComponent)
    *                         that includes all entities found by traversing the specified relationships.
    */
   def queryRelatedRecordsWithRelationChain(
-                                            workspaceId: UUID,
-                                            startingEntityType: String,
-                                            startingEntityName: String,
-                                            relationChain: Seq[String],
-                                            rootEntityType: String
-                                          ): ReadAction[Map[String, Seq[CompactEntityRecord]]] =
+    workspaceId: UUID,
+    startingEntityType: String,
+    startingEntityName: String,
+    relationChain: Seq[String],
+    rootEntityType: String
+  ): ReadAction[Map[String, Seq[CompactEntityRecord]]] =
     if (relationChain.isEmpty) {
       DBIO.successful(Map.empty[String, Seq[CompactEntityRecord]])
     } else {
@@ -724,9 +724,9 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       val initialPath = Path(List(EntityPointer(startingEntityType, startingEntityName)))
 
       def traverse(
-                    currentPaths: Set[Path],
-                    remainingChain: Seq[String]
-                  ): ReadAction[Set[Path]] = {
+        currentPaths: Set[Path],
+        remainingChain: Seq[String]
+      ): ReadAction[Set[Path]] =
         if (remainingChain.isEmpty) {
           DBIO.successful(currentPaths)
         } else {
@@ -748,7 +748,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
             }
           }
         }
-      }
 
       traverse(Set(initialPath), relationChain).flatMap { finalPaths =>
         // Group paths by their root entity (the entity that matches rootEntityType)
@@ -770,10 +769,10 @@ class CompactEntityQuery(driverComponent: DriverComponent)
     }
 
   private def traverseOneStep(
-                               workspaceId: UUID,
-                               currentEntities: Set[EntityPointer],
-                               relation: String
-                             ): ReadAction[Set[EntityPointer]] =
+    workspaceId: UUID,
+    currentEntities: Set[EntityPointer],
+    relation: String
+  ): ReadAction[Set[EntityPointer]] =
     if (currentEntities.isEmpty) {
       DBIO.successful(Set.empty[EntityPointer])
     } else {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -790,6 +790,132 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       }
     }
 
+//  def traverseEntityTypes(workspaceId: UUID,
+//                          startingEntityType: String,
+//                          startingEntityName: String,
+//                          entityRelationChain: List[String]
+//  ): ReadAction[Set[EntityPointer]] = {
+//    // Start with the root entity
+//    val initialEntities = Set(EntityPointer(startingEntityType, startingEntityName))
+//    entityRelationChain
+//        .foldLeft(DBIO.successful(initialEntities): ReadAction[Set[EntityPointer]]) { (entitiesFuture, relation) =>
+//          entitiesFuture.flatMap { currentEntities =>
+//            if (currentEntities.isEmpty) {
+//              DBIO.successful(Set.empty[EntityPointer])
+//            } else {
+//              traverseOneStep(workspaceId, currentEntities, relation)
+//            }
+//          }
+//        }
+//  }
+
+  /**
+   * Traverse the entity relation chain to determine the final entity type.
+   * This method follows the entity relationships defined by the relation chain
+   * but only returns the entity type information, not the full entities.
+   *
+   * @param workspaceId The UUID of the workspace containing the entities.
+   * @param startingEntityType The type of the entity to start the traversal from.
+   * @param startingEntityName The name of the specific entity to start from.
+   * @param entityRelationChain A list of attribute names to traverse (e.g., ["samples", "participant"]).
+   * @return A ReadAction that resolves to the entity type found at the end of the traversal chain,
+   *         or None if no entity is found or the relation chain doesn't exist.
+   */
+  def determineEntityTypeAtEndOfChain(
+                                       workspaceId: UUID,
+                                       startingEntityType: String,
+                                       startingEntityName: String,
+                                       entityRelationChain: List[String]
+                                     ): ReadAction[Option[String]] = {
+    if (entityRelationChain.isEmpty) {
+      // No traversal needed, return the starting type
+      DBIO.successful(Some(startingEntityType))
+    } else {
+      // Start with the root entity
+      val initialEntities = Set(EntityPointer(startingEntityType, startingEntityName))
+
+      // Follow the relation chain to get the entity type at each step
+      entityRelationChain.foldLeft(DBIO.successful((initialEntities, startingEntityType)): ReadAction[(Set[EntityPointer], String)]) {
+        case (previousStep, relation) =>
+          previousStep.flatMap { case (currentEntities, _) =>
+            println("previousstep entities: ")
+            currentEntities.foreach(e => print(s"${e.entityType}/${e.entityName} "))
+            println(s"\nTraversing relation: $relation")
+            if (currentEntities.isEmpty) {
+              DBIO.successful((Set.empty[EntityPointer], ""))
+            } else {
+              // For each entity, find the relation attribute and determine its entity type
+              // We only need to determine the type of the first valid reference
+              getEntityTypeForRelation(workspaceId, currentEntities, relation)
+            }
+          }
+      }.map { case (entities, entityType) =>
+        if (entities.isEmpty) None else Some(entityType)
+      }
+    }
+  }
+
+  /**
+   * Helper method to determine the entity type for a given relation without fetching all entity data.
+   */
+  private def getEntityTypeForRelation(
+                                        workspaceId: UUID,
+                                        currentEntities: Set[EntityPointer],
+                                        relation: String
+                                      ): ReadAction[(Set[EntityPointer], String)] = {
+    currentEntities.foreach(e => print(s"${e.entityType}/${e.entityName} "))
+    // Query just enough to get the type from the first entity that has the relation
+    val query = concatSqlActions(
+      sql"""select e.entity_type, e.name, jt.ref_entity_type, jt.ref_name
+         from ENTITY e
+         join JSON_TABLE(
+           e.attributes,
+           '$$.refs[*]' COLUMNS (
+             ref_attr_name varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.a',
+             ref_entity_type varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.t',
+             ref_name varchar(254) PATH '$$.n'
+           )
+         ) jt
+         where e.workspace_id = $workspaceId
+         and e.deleted = 0
+         and jt.ref_attr_name = $relation
+         and (""",
+      reduceSqlActionsWithDelim(
+        currentEntities.map(e => sql"(e.entity_type = ${e.entityType} and e.name = ${e.entityName})").toSeq,
+        sql" or "
+      ),
+      sql""") limit 1"""
+    )
+
+    case class TypeRelation(entityType: String, entityName: String, refEntityType: String, refName: String)
+    implicit val getTypeRelation: GetResult[TypeRelation] =
+      GetResult(r => TypeRelation(r.<<, r.<<, r.<<, r.<<))
+
+    query.as[TypeRelation].map { results =>
+    if (results.isEmpty) {
+      (Set.empty[EntityPointer], "")
+    } else {
+      // Group results by referenced entity type
+      val groupedByType = results.groupBy(_.refEntityType)
+      if (groupedByType.size > 1) {
+        // If there are multiple entity types referenced, log a warning but continue with the first type
+        logger.warn(s"Multiple entity types referenced by relation '$relation': ${groupedByType.keys.mkString(", ")}")
+      }
+      
+      // Use the first entity type we find
+      val firstType = results.head.refEntityType
+      
+      // Create EntityPointers for all entities of this type
+      val entityPointers = results
+        .filter(_.refEntityType == firstType)
+        .map(r => EntityPointer(r.refEntityType, r.refName))
+        .toSet
+        
+      (entityPointers, firstType)
+    }
+  }
+  }
+
   /**
    * Renames an entity in the ENTITY table.
    *

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -19,14 +19,12 @@ import org.broadinstitute.dsde.rawls.expressions.parser.antlr.CompactEvaluateVis
 import org.broadinstitute.dsde.rawls.expressions.parser.antlr.TerraExpressionParser.RootContext
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
-import org.broadinstitute.dsde.rawls.model.Attributable.nameReservedAttribute
 import org.broadinstitute.dsde.rawls.model.{
   Attributable,
   AttributeName,
   AttributeString,
   AttributeValue,
   AttributeValueList,
-  EntityPointer,
   ErrorReport,
   SubmissionValidationEntityInputs,
   SubmissionValidationValue
@@ -237,7 +235,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
           }
 
           val queryActions: Seq[ReadAction[Seq[ExpressionAndResult]]] = queryPlans.map { plan =>
-            executeQueryPlan(workspaceId, entityType, entityName, rootEntityType, plan, entityLookups)
+            executeQueryPlan(workspaceId, entityType, entityName, rootEntityType, plan)
           }
 
           repository.dataSource
@@ -427,8 +425,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
                        entityType: String,
                        entityName: String,
                        rootEntityType: String,
-                       plan: QueryPlan,
-                       entityLookups: Seq[ExpressionLookup] = Seq.empty
+                       plan: QueryPlan
   )(implicit
     executionContext: ExecutionContext
   ): ReadAction[Seq[ExpressionAndResult]] = {
@@ -543,7 +540,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
           throw new RawlsExceptionWithErrorReport(
             ErrorReport(
               StatusCodes.BadRequest,
-              s"The relation chain ${entityRelationChain.mkString(".")} is invalid starting from entity ${startingEntityType}"
+              s"The relation chain ${entityRelationChain.mkString(".")} is invalid starting from entity $startingEntityType"
             )
           )
         case Some(entityType) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -221,8 +221,6 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
 
           // If we have an entitylookup, prepend its chain to the relation chain of the query
           val queryPlans = if (entityType != rootEntityType && entityLookups.nonEmpty) {
-//            val entityRelationChain: List[String] = entityLookups.flatMap(_.relations.map(_.attributeName()).map(_.getText)).toList
-//            val updatedRelationChain = entityRelationChain ++ entityLookups.flatMap(_.attributeName).toList
             if (inputExpressionData.isEmpty) {
               Seq(QueryPlan(updatedRelationChain, Map.empty))
             } else {
@@ -533,26 +531,28 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
                                  startingEntityType: String,
                                  startingEntityName: String
   )(implicit executionContext: ExecutionContext): ReadAction[Unit] =
-    repository.queries
-      .determineEntityTypeAtEndOfChain(workspaceId, startingEntityType, startingEntityName, entityRelationChain)
-      .map {
-        case None =>
-          throw new RawlsExceptionWithErrorReport(
-            ErrorReport(
-              StatusCodes.BadRequest,
-              s"The relation chain ${entityRelationChain.mkString(".")} is invalid starting from entity $startingEntityType"
-            )
-          )
-        case Some(entityType) =>
-          if (entityType != rootEntityType) {
+    withTiming("determineEntityTypeAtEndOfChain") {
+      repository.queries
+        .determineEntityTypeAtEndOfChain(workspaceId, startingEntityType, startingEntityName, entityRelationChain)
+        .map {
+          case None =>
             throw new RawlsExceptionWithErrorReport(
               ErrorReport(
                 StatusCodes.BadRequest,
-                s"The expression in your SubmissionRequest matched only entities of the wrong type. " +
-                  s"(Expected type $rootEntityType, but got $entityType.)"
+                s"Could not find the requested entities by following the path '${entityRelationChain.mkString(".")}' starting from the $startingEntityType named '$startingEntityName'. Please check that all referenced attributes and relationships exist and are spelled correctly."
               )
             )
-          }
-      }
+          case Some(entityType) =>
+            if (entityType != rootEntityType) {
+              throw new RawlsExceptionWithErrorReport(
+                ErrorReport(
+                  StatusCodes.BadRequest,
+                  s"The expression in your SubmissionRequest matched only entities of the wrong type. " +
+                    s"(Expected type $rootEntityType, but got $entityType.)"
+                )
+              )
+            }
+        }
+    }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -3,8 +3,16 @@ package org.broadinstitute.dsde.rawls.expressions
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{QueryTiming, ReadAction}
-import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{EntityName, ExpressionAndResult, LookupExpression}
-import org.broadinstitute.dsde.rawls.entities.base.{ExpressionEvaluationContext, ExpressionEvaluationSupport, InputExpressionReassembler}
+import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{
+  EntityName,
+  ExpressionAndResult,
+  LookupExpression
+}
+import org.broadinstitute.dsde.rawls.entities.base.{
+  ExpressionEvaluationContext,
+  ExpressionEvaluationSupport,
+  InputExpressionReassembler
+}
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
 import org.broadinstitute.dsde.rawls.expressions.parser.antlr.{AntlrTerraExpressionParser, CompactEvaluateVisitor}
 import org.broadinstitute.dsde.rawls.expressions.parser.antlr.CompactEvaluateVisitor.ExpressionLookup
@@ -12,7 +20,17 @@ import org.broadinstitute.dsde.rawls.expressions.parser.antlr.TerraExpressionPar
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.model.Attributable.nameReservedAttribute
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeName, AttributeString, AttributeValue, AttributeValueList, EntityPointer, ErrorReport, SubmissionValidationEntityInputs, SubmissionValidationValue}
+import org.broadinstitute.dsde.rawls.model.{
+  Attributable,
+  AttributeName,
+  AttributeString,
+  AttributeValue,
+  AttributeValueList,
+  EntityPointer,
+  ErrorReport,
+  SubmissionValidationEntityInputs,
+  SubmissionValidationValue
+}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
 import slick.dbio.DBIO
 
@@ -187,7 +205,8 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
             case Some(expression) => parseLookups(expression)
           }
 
-          val entityRelationChain: List[String] = entityLookups.flatMap(_.relations.map(_.attributeName()).map(_.getText)).toList
+          val entityRelationChain: List[String] =
+            entityLookups.flatMap(_.relations.map(_.attributeName()).map(_.getText)).toList
           val updatedRelationChain = entityRelationChain ++ entityLookups.flatMap(_.attributeName).toList
 
           val validationAction: ReadAction[Unit] =
@@ -427,7 +446,8 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
           repository.queries.queryRelatedRecordsWithRelationChain(workspaceId,
                                                                   entityType,
                                                                   entityName,
-                                                                  plan.relationChain
+                                                                  plan.relationChain,
+                                                                  rootEntityType
           )
         }
       }
@@ -436,20 +456,6 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
       if (entityRecords.isEmpty) {
         throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "No entities found"))
       }
-      // Validate entity types if we have entityLookups
-//      if (entityLookups.nonEmpty && entityRecords.nonEmpty) {
-//        val actualEntityTypes = entityRecords.values.flatten.map(_.entityType).toSet
-//        if (actualEntityTypes.nonEmpty && !actualEntityTypes.contains(rootEntityType)) {
-//          val actualTypesStr = actualEntityTypes.mkString(", ")
-//          throw new RawlsExceptionWithErrorReport(
-//            ErrorReport(
-//              StatusCodes.BadRequest,
-//              s"The expression in your SubmissionRequest matched only entities of the wrong type. " +
-//                s"(Expected type $rootEntityType, but got $actualTypesStr.)"
-//            )
-//          )
-//        }
-//      }
 
       if (plan.expressionMappings.isEmpty) {
         // Return entities with empty input resolutions
@@ -466,53 +472,25 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
         plan.expressionMappings.toSeq.flatMap { case (expression, attributeNames) =>
           attributeNames.map { attrName =>
             val attributeName = AttributeName.fromDelimitedName(attrName)
-
-            val entityToAttributeValues: Map[String, Try[Seq[AttributeValue]]] = if (entityType == rootEntityType) {
-
-              // Group all results under the original entityName since we want results grouped by the starting entity type
-              val allAttrs: Seq[AttributeValue] = entityRecords.values.flatten.toSeq.flatMap { record =>
-                if (
-                  attributeName == AttributeName.withDefaultNS(
-                    record.entityType + Attributable.entityIdAttributeSuffix
-                  ) || attributeName == AttributeName.withDefaultNS(nameReservedAttribute)
-                ) {
-                  Seq(AttributeString(record.name))
-                } else {
-                  record.toEntity.attributes.get(attributeName) match {
-                    case Some(avl: AttributeValueList) =>
-                      avl.list
-                    case Some(av: AttributeValue) =>
-                      Seq(av)
-                    case _ =>
-                      Seq.empty
+            val entityToAttributeValues: Map[String, Try[Seq[AttributeValue]]] =
+              entityRecords.map { case (groupName, records) =>
+                val attrs: Seq[AttributeValue] = records.flatMap { record =>
+                  if (
+                    attributeName == AttributeName.withDefaultNS(
+                      record.entityType + Attributable.entityIdAttributeSuffix
+                    ) || attributeName == AttributeName.withDefaultNS(Attributable.nameReservedAttribute)
+                  ) {
+                    Seq(AttributeString(record.name))
+                  } else {
+                    record.toEntity.attributes.get(attributeName) match {
+                      case Some(avl: AttributeValueList) => avl.list
+                      case Some(av: AttributeValue)      => Seq(av)
+                      case _                             => Seq.empty
+                    }
                   }
                 }
+                groupName -> Success(attrs)
               }
-              Map(entityName -> Success(allAttrs))
-            } else {
-              entityRecords.flatMap { case (_, records) =>
-                records.map { record =>
-                  val attrs: Seq[AttributeValue] =
-                    if (
-                      attributeName == AttributeName.withDefaultNS(
-                        record.entityType + Attributable.entityIdAttributeSuffix
-                      ) || attributeName == AttributeName.withDefaultNS(nameReservedAttribute)
-                    ) {
-                      Seq(AttributeString(record.name))
-                    } else {
-                      record.toEntity.attributes.get(attributeName) match {
-                        case Some(avl: AttributeValueList) =>
-                          avl.list
-                        case Some(av: AttributeValue) =>
-                          Seq(av)
-                        case _ =>
-                          Seq.empty
-                      }
-                    }
-                  record.name -> Success(attrs)
-                }
-              }
-            }
             (expression, entityToAttributeValues)
           }
         }
@@ -552,26 +530,32 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
         .to(LazyList)
     }
 
-  private def validateEntityType(workspaceId: UUID, entityRelationChain: List[String], rootEntityType: String, startingEntityType: String, startingEntityName: String)(implicit executionContext: ExecutionContext): ReadAction[Unit] = {
-    repository.queries.determineEntityTypeAtEndOfChain(workspaceId, startingEntityType, startingEntityName, entityRelationChain).map {
-      case None =>
-        throw new RawlsExceptionWithErrorReport(
-          ErrorReport(
-            StatusCodes.BadRequest,
-            s"The relation chain ${entityRelationChain.mkString(".")} is invalid starting from entity ${startingEntityType}"
-          )
-        )
-      case Some(entityType) =>
-        if (entityType != rootEntityType) {
+  private def validateEntityType(workspaceId: UUID,
+                                 entityRelationChain: List[String],
+                                 rootEntityType: String,
+                                 startingEntityType: String,
+                                 startingEntityName: String
+  )(implicit executionContext: ExecutionContext): ReadAction[Unit] =
+    repository.queries
+      .determineEntityTypeAtEndOfChain(workspaceId, startingEntityType, startingEntityName, entityRelationChain)
+      .map {
+        case None =>
           throw new RawlsExceptionWithErrorReport(
             ErrorReport(
               StatusCodes.BadRequest,
-              s"The expression in your SubmissionRequest matched only entities of the wrong type. " +
-                s"(Expected type $rootEntityType, but got $entityType.)"
+              s"The relation chain ${entityRelationChain.mkString(".")} is invalid starting from entity ${startingEntityType}"
             )
           )
-        }
-    }
+        case Some(entityType) =>
+          if (entityType != rootEntityType) {
+            throw new RawlsExceptionWithErrorReport(
+              ErrorReport(
+                StatusCodes.BadRequest,
+                s"The expression in your SubmissionRequest matched only entities of the wrong type. " +
+                  s"(Expected type $rootEntityType, but got $entityType.)"
+              )
+            )
+          }
+      }
 
-  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluator.scala
@@ -3,16 +3,8 @@ package org.broadinstitute.dsde.rawls.expressions
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{QueryTiming, ReadAction}
-import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{
-  EntityName,
-  ExpressionAndResult,
-  LookupExpression
-}
-import org.broadinstitute.dsde.rawls.entities.base.{
-  ExpressionEvaluationContext,
-  ExpressionEvaluationSupport,
-  InputExpressionReassembler
-}
+import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{EntityName, ExpressionAndResult, LookupExpression}
+import org.broadinstitute.dsde.rawls.entities.base.{ExpressionEvaluationContext, ExpressionEvaluationSupport, InputExpressionReassembler}
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
 import org.broadinstitute.dsde.rawls.expressions.parser.antlr.{AntlrTerraExpressionParser, CompactEvaluateVisitor}
 import org.broadinstitute.dsde.rawls.expressions.parser.antlr.CompactEvaluateVisitor.ExpressionLookup
@@ -20,16 +12,7 @@ import org.broadinstitute.dsde.rawls.expressions.parser.antlr.TerraExpressionPar
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.model.Attributable.nameReservedAttribute
-import org.broadinstitute.dsde.rawls.model.{
-  Attributable,
-  AttributeName,
-  AttributeString,
-  AttributeValue,
-  AttributeValueList,
-  ErrorReport,
-  SubmissionValidationEntityInputs,
-  SubmissionValidationValue
-}
+import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeName, AttributeString, AttributeValue, AttributeValueList, EntityPointer, ErrorReport, SubmissionValidationEntityInputs, SubmissionValidationValue}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
 import slick.dbio.DBIO
 
@@ -204,6 +187,15 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
             case Some(expression) => parseLookups(expression)
           }
 
+          val entityRelationChain: List[String] = entityLookups.flatMap(_.relations.map(_.attributeName()).map(_.getText)).toList
+          val updatedRelationChain = entityRelationChain ++ entityLookups.flatMap(_.attributeName).toList
+
+          val validationAction: ReadAction[Unit] =
+            if (updatedRelationChain.nonEmpty)
+              validateEntityType(workspaceId, updatedRelationChain, rootEntityType, entityType, entityName)
+            else
+              DBIO.successful(())
+
           val inputExpressionData: Seq[(MethodInput, RootContext, Seq[ExpressionLookup])] = inputsToExpressionData(
             gatherInputsResult
           )
@@ -212,9 +204,8 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
 
           // If we have an entitylookup, prepend its chain to the relation chain of the query
           val queryPlans = if (entityType != rootEntityType && entityLookups.nonEmpty) {
-            val entityRelationChain: List[String] =
-              entityLookups.flatMap(_.relations.map(_.attributeName()).map(_.getText)).toList
-            val updatedRelationChain = entityRelationChain ++ entityLookups.flatMap(_.attributeName).toList
+//            val entityRelationChain: List[String] = entityLookups.flatMap(_.relations.map(_.attributeName()).map(_.getText)).toList
+//            val updatedRelationChain = entityRelationChain ++ entityLookups.flatMap(_.attributeName).toList
             if (inputExpressionData.isEmpty) {
               Seq(QueryPlan(updatedRelationChain, Map.empty))
             } else {
@@ -232,7 +223,10 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
 
           repository.dataSource
             .inTransaction { _ =>
-              DBIO.sequence(queryActions)
+              for {
+                _ <- validationAction
+                results <- DBIO.sequence(queryActions)
+              } yield results
             }
             .map { allQueryResults =>
               val combinedExpressionAndResults: Seq[ExpressionAndResult] = allQueryResults.flatten
@@ -443,19 +437,19 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
         throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "No entities found"))
       }
       // Validate entity types if we have entityLookups
-      if (entityLookups.nonEmpty && entityRecords.nonEmpty) {
-        val actualEntityTypes = entityRecords.values.flatten.map(_.entityType).toSet
-        if (actualEntityTypes.nonEmpty && !actualEntityTypes.contains(rootEntityType)) {
-          val actualTypesStr = actualEntityTypes.mkString(", ")
-          throw new RawlsExceptionWithErrorReport(
-            ErrorReport(
-              StatusCodes.BadRequest,
-              s"The expression in your SubmissionRequest matched only entities of the wrong type. " +
-                s"(Expected type $rootEntityType, but got $actualTypesStr.)"
-            )
-          )
-        }
-      }
+//      if (entityLookups.nonEmpty && entityRecords.nonEmpty) {
+//        val actualEntityTypes = entityRecords.values.flatten.map(_.entityType).toSet
+//        if (actualEntityTypes.nonEmpty && !actualEntityTypes.contains(rootEntityType)) {
+//          val actualTypesStr = actualEntityTypes.mkString(", ")
+//          throw new RawlsExceptionWithErrorReport(
+//            ErrorReport(
+//              StatusCodes.BadRequest,
+//              s"The expression in your SubmissionRequest matched only entities of the wrong type. " +
+//                s"(Expected type $rootEntityType, but got $actualTypesStr.)"
+//            )
+//          )
+//        }
+//      }
 
       if (plan.expressionMappings.isEmpty) {
         // Return entities with empty input resolutions
@@ -474,6 +468,7 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
             val attributeName = AttributeName.fromDelimitedName(attrName)
 
             val entityToAttributeValues: Map[String, Try[Seq[AttributeValue]]] = if (entityType == rootEntityType) {
+
               // Group all results under the original entityName since we want results grouped by the starting entity type
               val allAttrs: Seq[AttributeValue] = entityRecords.values.flatten.toSeq.flatMap { record =>
                 if (
@@ -556,4 +551,27 @@ class CompactExpressionEvaluator(repository: CompactEntityRepository)
         }
         .to(LazyList)
     }
+
+  private def validateEntityType(workspaceId: UUID, entityRelationChain: List[String], rootEntityType: String, startingEntityType: String, startingEntityName: String)(implicit executionContext: ExecutionContext): ReadAction[Unit] = {
+    repository.queries.determineEntityTypeAtEndOfChain(workspaceId, startingEntityType, startingEntityName, entityRelationChain).map {
+      case None =>
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(
+            StatusCodes.BadRequest,
+            s"The relation chain ${entityRelationChain.mkString(".")} is invalid starting from entity ${startingEntityType}"
+          )
+        )
+      case Some(entityType) =>
+        if (entityType != rootEntityType) {
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(
+              StatusCodes.BadRequest,
+              s"The expression in your SubmissionRequest matched only entities of the wrong type. " +
+                s"(Expected type $rootEntityType, but got $entityType.)"
+            )
+          )
+        }
+    }
+
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -782,6 +782,21 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       )
     )
     result2(set.name) should contain theSameElementsAs Seq(insertedSample1, insertedSample2)
+
+    val result3 = runAndWait(
+      q.queryRelatedRecordsWithRelationChain(
+        /* workspace id */ minimalTestData.workspace.workspaceIdAsUUID,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List(
+          "samples",
+          "participant"
+        ),
+        /* root entity type */ "sample"
+      )
+    )
+    result3(sample1.name) should contain theSameElementsAs Seq(insertedParticipant1, insertedParticipant3)
+    result3(sample2.name) should contain theSameElementsAs Seq(insertedParticipant2, insertedParticipant4)
   }
 
   it should "only get records from the given workspace" in withMinimalTestDatabase { _ =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -9,7 +9,6 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeEntityReference,
   AttributeEntityReferenceList,
   AttributeName,
-  AttributeNull,
   AttributeNumber,
   AttributeRename,
   AttributeString,
@@ -26,7 +25,6 @@ import org.scalatest.Inspectors.forEvery
 import slick.dbio.Effect.Read
 import slick.jdbc.GetResult
 import slick.sql.SqlStreamingAction
-import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 import java.sql.SQLIntegrityConstraintViolationException
@@ -750,7 +748,10 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       )
     )
 
-    insertAndGetAll(Seq(sample1, sample2, set))
+    val insertedSample1 = insertAndGet(sample1)
+    val insertedSample2 = insertAndGet(sample2)
+
+    insertAndGet(set)
 
     val result = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
@@ -768,6 +769,19 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     result(participant2.name) should contain theSameElementsAs Seq(insertedParticipant2)
     result(participant3.name) should contain theSameElementsAs Seq(insertedParticipant3)
     result(participant4.name) should contain theSameElementsAs Seq(insertedParticipant4)
+
+    val result2 = runAndWait(
+      q.queryRelatedRecordsWithRelationChain(
+        /* workspace id */ minimalTestData.workspace.workspaceIdAsUUID,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List(
+          "samples"
+        ),
+        /* root entity type */ "sample_set"
+      )
+    )
+    result2(set.name) should contain theSameElementsAs Seq(insertedSample1, insertedSample2)
   }
 
   it should "only get records from the given workspace" in withMinimalTestDatabase { _ =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -453,10 +453,11 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     val result = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
-        wsid,
-        "sample_set",
-        "set1",
-        List("samples")
+        /* workspace id */ wsid,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List("samples"),
+        /* root entity type */ "sample"
       )
     )
 
@@ -496,12 +497,13 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     val result = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
-        minimalTestData.workspace.workspaceIdAsUUID,
-        "sample_set",
-        "set1",
-        List(
+        /* workspace id */ minimalTestData.workspace.workspaceIdAsUUID,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List(
           "samples"
-        )
+        ),
+        /* root entity type */ "sample"
       )
     )
     result(sample1.name) should contain(insertedSample1)
@@ -535,13 +537,14 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     val result = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
-        minimalTestData.workspace.workspaceIdAsUUID,
-        "sample_set",
-        "set1",
-        List(
+        /* workspace id */ minimalTestData.workspace.workspaceIdAsUUID,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List(
           "samples",
           "participant"
-        )
+        ),
+        /* root entity type */ "sample"
       )
     )
     result(sample.name) should contain(insertedParticipant)
@@ -591,13 +594,14 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     val result = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
-        minimalTestData.workspace.workspaceIdAsUUID,
-        "sample_set",
-        "set1",
-        List(
+        /* workspace id */ minimalTestData.workspace.workspaceIdAsUUID,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List(
           "samples",
           "participant"
-        )
+        ),
+        /* root entity type */ "sample"
       )
     )
     result(sample1.name) should contain(insertedParticipant1)
@@ -670,17 +674,100 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     val result = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
-        minimalTestData.workspace.workspaceIdAsUUID,
-        "sample_set",
-        "set1",
-        List(
+        /* workspace id */ minimalTestData.workspace.workspaceIdAsUUID,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List(
           "samples",
           "participant"
-        )
+        ),
+        /* root entity type */ "sample"
       )
     )
     result(sample1.name) should contain theSameElementsAs Seq(insertedParticipant1, insertedParticipant3)
     result(sample2.name) should contain theSameElementsAs Seq(insertedParticipant2, insertedParticipant4)
+  }
+
+  it should "group by the given root entity type" in withMinimalTestDatabase { _ =>
+    // sample_set -> sample -> participant
+
+    val participant1 = Entity(
+      "p1",
+      "participant",
+      Map(AttributeName.withDefaultNS("type") -> AttributeString("b"))
+    )
+
+    val participant2 = Entity(
+      "p2",
+      "participant",
+      Map(AttributeName.withDefaultNS("type") -> AttributeString("a"))
+    )
+
+    val participant3 = Entity(
+      "p3",
+      "participant",
+      Map(AttributeName.withDefaultNS("type") -> AttributeString("c"))
+    )
+
+    val participant4 = Entity(
+      "p4",
+      "participant",
+      Map(AttributeName.withDefaultNS("type") -> AttributeString("d"))
+    )
+
+    val insertedParticipant1 = insertAndGet(participant1)
+    val insertedParticipant2 = insertAndGet(participant2)
+    val insertedParticipant3 = insertAndGet(participant3)
+    val insertedParticipant4 = insertAndGet(participant4)
+
+    val sample1 = Entity(
+      "s1",
+      "sample",
+      Map(
+        AttributeName.withDefaultNS("participant") -> AttributeEntityReferenceList(
+          List(AttributeEntityReference("participant", "p1"), AttributeEntityReference("participant", "p3"))
+        )
+      )
+    )
+
+    val sample2 = Entity(
+      "s2",
+      "sample",
+      Map(
+        AttributeName.withDefaultNS("participant") -> AttributeEntityReferenceList(
+          List(AttributeEntityReference("participant", "p2"), AttributeEntityReference("participant", "p4"))
+        )
+      )
+    )
+
+    val set = Entity(
+      "set1",
+      "sample_set",
+      Map(
+        AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+          List(AttributeEntityReference("sample", "s1"), AttributeEntityReference("sample", "s2"))
+        )
+      )
+    )
+
+    insertAndGetAll(Seq(sample1, sample2, set))
+
+    val result = runAndWait(
+      q.queryRelatedRecordsWithRelationChain(
+        /* workspace id */ minimalTestData.workspace.workspaceIdAsUUID,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List(
+          "samples",
+          "participant"
+        ),
+        /* root entity type */ "participant"
+      )
+    )
+    result(participant1.name) should contain theSameElementsAs Seq(insertedParticipant1)
+    result(participant2.name) should contain theSameElementsAs Seq(insertedParticipant2)
+    result(participant3.name) should contain theSameElementsAs Seq(insertedParticipant3)
+    result(participant4.name) should contain theSameElementsAs Seq(insertedParticipant4)
   }
 
   it should "only get records from the given workspace" in withMinimalTestDatabase { _ =>
@@ -713,10 +800,11 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     val result = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
-        wsid,
-        "sample_set",
-        "set1",
-        List("samples")
+        /* workspace id */ wsid,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List("samples"),
+        /* root entity type */ "sample"
       )
     )
     result(sample1.name) should contain(insertedSampleWS1)
@@ -743,10 +831,11 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     // Note we're searching for capital Sample_set when only lowercase exists
     val result = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
-        wsid,
-        "Sample_set",
-        "set1",
-        List("samples")
+        /* workspace id */ wsid,
+        /* starting entity type */ "Sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List("samples"),
+        /* root entity type */ "sample"
       )
     )
     result.get(sample.name) shouldBe None
@@ -778,39 +867,42 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     // Note we're looking for capital Samples and/or Participant when only lowercase exists
     val result1 = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
-        minimalTestData.workspace.workspaceIdAsUUID,
-        "sample_set",
-        "set1",
-        List(
+        /* workspace id */ minimalTestData.workspace.workspaceIdAsUUID,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List(
           "Samples",
           "participant"
-        )
+        ),
+        /* root entity type */ "participant"
       )
     )
     result1.get(participant.name) shouldBe None
 
     val result2 = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
-        minimalTestData.workspace.workspaceIdAsUUID,
-        "sample_set",
-        "set1",
-        List(
+        /* workspace id */ minimalTestData.workspace.workspaceIdAsUUID,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List(
           "Samples",
           "Participant"
-        )
+        ),
+        /* root entity type */ "participant"
       )
     )
     result2.get(participant.name) shouldBe None
 
     val result3 = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
-        minimalTestData.workspace.workspaceIdAsUUID,
-        "sample_set",
-        "set1",
-        List(
+        /* workspace id */ minimalTestData.workspace.workspaceIdAsUUID,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List(
           "samples",
           "Participant"
-        )
+        ),
+        /* root entity type */ "participant"
       )
     )
     result3.get(participant.name) shouldBe None
@@ -839,10 +931,11 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     // For entity names, capital and lowercase differences shouldn't matter
     val result = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
-        wsid,
-        "sample_set",
-        "Set1",
-        List("samples")
+        /* workspace id */ wsid,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "Set1",
+        /* relation chain */ List("samples"),
+        /* root entity type */ "sample"
       )
     )
     result(sample.name) should contain(insertedSample)
@@ -870,10 +963,11 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     val result = runAndWait(
       q.queryRelatedRecordsWithRelationChain(
-        wsid,
-        "sample_set",
-        "set1",
-        List("set_namespace:samples")
+        /* workspace id */ wsid,
+        /* starting entity type */ "sample_set",
+        /* starting entity name */ "set1",
+        /* relation chain */ List("set_namespace:samples"),
+        /* root entity type */ "sample"
       )
     )
     result(sample.name) should contain(insertedSample)
@@ -2275,10 +2369,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
         )
       )
     val entity4 =
-      Entity(UUID.randomUUID().toString,
-             entityType1,
-             Map(testAttrName -> AttributeString("foo"), sortAttrName -> AttributeNumber(Random.nextInt()))
-      )
+      Entity(UUID.randomUUID().toString, entityType1, Map(testAttrName -> AttributeString("foo"), sortAttrName -> AttributeNumber(Random.nextInt())))
     insertAndGet(entity1)
     insertAndGet(entity2)
     insertAndGet(entity3)
@@ -2289,12 +2380,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       q.queryEntitiesWithColumnFilter(
         wsid,
         entityType1,
-        EntityQuery(1,
-                    10,
-                    toDelimitedName(sortAttrName),
-                    SortDirections.Ascending,
-                    None,
-                    columnFilter = Some(columnFilter)
+        EntityQuery(1, 10, toDelimitedName(sortAttrName), SortDirections.Ascending, None, columnFilter = Some(columnFilter)
         ),
         columnFilter
       )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -30,6 +30,7 @@ import spray.json._
 import java.sql.SQLIntegrityConstraintViolationException
 import java.util.UUID
 import scala.util.Random
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 
 class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers {
 
@@ -1000,6 +1001,45 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       )
     )
     result(sample.name) should contain(insertedSample)
+  }
+
+  it should "throw a user-friendly error if the relation chain is invalid" in withMinimalTestDatabase { _ =>
+    val workspaceId = minimalTestData.workspace.workspaceIdAsUUID
+
+    // Create two entities of different types
+    val sample1 = Entity("sample1", "sample", Map())
+    val donor1 = Entity("donor1", "donor", Map())
+
+    // Create a set entity that references both sample1 and donor1 in the same attribute
+    val set = Entity(
+      "set1",
+      "set",
+      Map(
+        AttributeName.withDefaultNS("members") -> AttributeEntityReferenceList(
+          Seq(
+            AttributeEntityReference("sample", "sample1"),
+            AttributeEntityReference("donor", "donor1")
+          )
+        )
+      )
+    )
+
+    insertAndGetAll(Seq(sample1, donor1, set))
+
+    // Attempt to follow a relation chain that is ambiguous
+    val ex = intercept[RawlsExceptionWithErrorReport] {
+      runAndWait(
+        q.queryRelatedRecordsWithRelationChain(
+          workspaceId,
+          set.entityType,
+          set.name,
+          Seq("members"),
+          rootEntityType = "set"
+        )
+      )
+    }
+
+    ex.getMessage should include("Multiple entity types referenced by relation")
   }
 
   behavior of "listEntityKeysViaEntity"
@@ -2398,7 +2438,10 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
         )
       )
     val entity4 =
-      Entity(UUID.randomUUID().toString, entityType1, Map(testAttrName -> AttributeString("foo"), sortAttrName -> AttributeNumber(Random.nextInt())))
+      Entity(UUID.randomUUID().toString,
+             entityType1,
+             Map(testAttrName -> AttributeString("foo"), sortAttrName -> AttributeNumber(Random.nextInt()))
+      )
     insertAndGet(entity1)
     insertAndGet(entity2)
     insertAndGet(entity3)
@@ -2409,7 +2452,12 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
       q.queryEntitiesWithColumnFilter(
         wsid,
         entityType1,
-        EntityQuery(1, 10, toDelimitedName(sortAttrName), SortDirections.Ascending, None, columnFilter = Some(columnFilter)
+        EntityQuery(1,
+                    10,
+                    toDelimitedName(sortAttrName),
+                    SortDirections.Ascending,
+                    None,
+                    columnFilter = Some(columnFilter)
         ),
         columnFilter
       )
@@ -3411,7 +3459,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     )
 
     insertAndGetAll(Seq(sample, set))
-    //this.samples
+    // this.samples
     val result = runAndWait(q.determineEntityTypeAtEndOfChain(workspaceId, set.entityType, set.name, List("samples")))
 
     result shouldBe Some("sample")
@@ -3424,11 +3472,12 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
 
     insertAndGet(setSet)
 
-    //this.ssets.samples
-    val result2 = runAndWait(q.determineEntityTypeAtEndOfChain(workspaceId, setSet.entityType, setSet.name, List("ssets", "samples")))
+    // this.ssets.samples
+    val result2 = runAndWait(
+      q.determineEntityTypeAtEndOfChain(workspaceId, setSet.entityType, setSet.name, List("ssets", "samples"))
+    )
 
     result2 shouldBe Some("sample")
-
 
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -3277,6 +3277,46 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     )
   }
 
+  behavior of "determineEntityTypeAtEndOfChain"
+
+  it should "get the types of a chain" in withMinimalTestDatabase { _ =>
+    val workspaceId = minimalTestData.workspace.workspaceIdAsUUID
+
+    val sample = Entity(
+      "sample1",
+      "sample",
+      Map(AttributeName.withDefaultNS("type") -> AttributeString("a"))
+    )
+
+    // Referencing entity
+    val set = Entity(
+      "set1",
+      "sample_set",
+      Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReference("sample", "sample1"))
+    )
+
+    insertAndGetAll(Seq(sample, set))
+    //this.samples
+    val result = runAndWait(q.determineEntityTypeAtEndOfChain(workspaceId, set.entityType, set.name, List("samples")))
+
+    result shouldBe Some("sample")
+
+    val setSet = Entity(
+      "setSet",
+      "sample_set_set",
+      Map(AttributeName.withDefaultNS("ssets") -> AttributeEntityReference("sample_set", "set1"))
+    )
+
+    insertAndGet(setSet)
+
+    //this.ssets.samples
+    val result2 = runAndWait(q.determineEntityTypeAtEndOfChain(workspaceId, setSet.entityType, setSet.name, List("ssets", "samples")))
+
+    result2 shouldBe Some("sample")
+
+
+  }
+
   // ====================================================================================================
   //  helpers for tests
   // ====================================================================================================

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
@@ -326,6 +326,19 @@ class CompactExpressionEvaluatorSpec
         )
       )
 
+    when(
+      mockQueries.determineEntityTypeAtEndOfChain(
+        any(),
+        org.mockito.ArgumentMatchers.eq(sampleSet2.entityType),
+        org.mockito.ArgumentMatchers.eq(sampleSet2.name),
+        org.mockito.ArgumentMatchers.eq(List("samples"))
+      )
+    )
+      .thenReturn(
+        DBIO.successful(
+          Some("Sample"))
+      )
+
     val expressionEvaluationContext =
       ExpressionEvaluationContext(Some(sampleSet2.entityType),
                                   Some(sampleSet2.name),
@@ -377,6 +390,19 @@ class CompactExpressionEvaluatorSpec
         )
       )
 
+    when(
+      mockQueries.determineEntityTypeAtEndOfChain(
+        any(),
+        org.mockito.ArgumentMatchers.eq(testData.indiv1.entityType),
+        org.mockito.ArgumentMatchers.eq(testData.indiv1.name),
+        org.mockito.ArgumentMatchers.eq(List("sset", "samples"))
+      )
+    )
+      .thenReturn(
+        DBIO.successful(
+          Some("Sample"))
+      )
+
     val expressionEvaluationContext =
       ExpressionEvaluationContext(Some(testData.indiv1.entityType),
                                   Some(testData.indiv1.name),
@@ -417,6 +443,19 @@ class CompactExpressionEvaluatorSpec
         DBIO.successful(
           Some(sampleGoodAsCER)
         )
+      )
+
+    when(
+      mockQueries.determineEntityTypeAtEndOfChain(
+        any(),
+        org.mockito.ArgumentMatchers.eq(sampleSet2.entityType),
+        org.mockito.ArgumentMatchers.eq(sampleSet2.name),
+        org.mockito.ArgumentMatchers.eq(List("samples"))
+      )
+    )
+      .thenReturn(
+        DBIO.successful(
+          Some("Sample"))
       )
 
     val context =
@@ -477,6 +516,19 @@ class CompactExpressionEvaluatorSpec
         DBIO.successful(
           Map(sampleSet.name -> Seq(sampleGoodAsCER, sampleMissingValueAsCER))
         )
+      )
+
+    when(
+      mockQueries.determineEntityTypeAtEndOfChain(
+        any(),
+        org.mockito.ArgumentMatchers.eq(sampleSet.entityType),
+        org.mockito.ArgumentMatchers.eq(sampleSet.name),
+        org.mockito.ArgumentMatchers.eq(List("samples"))
+      )
+    )
+      .thenReturn(
+        DBIO.successful(
+          Some("Sample"))
       )
 
     val methodConf = MethodConfiguration("namespace",
@@ -571,6 +623,56 @@ class CompactExpressionEvaluatorSpec
     )
   }
 
+  it should "understand sets of sets" in withConfigData {
+    when(
+      mockQueries.queryRelatedRecordsWithRelationChain(any(),
+        any(),
+        org.mockito.ArgumentMatchers.eq(sampleSetSet.name),
+        any()
+      )
+    )
+      .thenReturn(
+        DBIO.successful(
+          Map(sampleSet.name -> Seq(sampleGoodAsCER, sampleMissingValueAsCER),
+            sampleSet2.name -> Seq(sampleGoodAsCER, sampleGood2AsCER))
+        )
+      )
+
+    when(
+      mockQueries.determineEntityTypeAtEndOfChain(
+        any(),
+        org.mockito.ArgumentMatchers.eq(sampleSetSet.entityType),
+        org.mockito.ArgumentMatchers.eq(sampleSetSet.name),
+        org.mockito.ArgumentMatchers.eq(List("sample_sets"))
+      )
+    )
+      .thenReturn(
+        DBIO.successful(
+          Some("SampleSet"))
+        )
+
+    // root entity type:sample_set, given entity type: set of sets
+    val expressionEvaluationContext =
+      ExpressionEvaluationContext(Some(sampleSetSet.entityType), Some(sampleSetSet.name), Some("this.sample_sets"), Some(sampleSet2.entityType))
+
+    val result = evalInputs(expressionEvaluationContext, configSampleSet, arrayWdl)
+
+    result should contain theSameElementsAs Seq(
+      SubmissionValidationEntityInputs(
+        sampleSet.name,
+        Set(
+          SubmissionValidationValue(Some(AttributeValueList(Seq(AttributeNumber(1)))), None, intArrayNameWithWfName)
+        )
+      ),
+      SubmissionValidationEntityInputs(
+        sampleSet2.name,
+        Set(
+          SubmissionValidationValue(Some(AttributeValueList(Seq(AttributeNumber(1), AttributeNumber(2)))), None, intArrayNameWithWfName)
+        )
+      )
+    )
+  }
+
   it should "error on root entity type/expression evaluation mismatch" in withConfigData {
     when(
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
@@ -585,20 +687,33 @@ class CompactExpressionEvaluatorSpec
         )
       )
 
+    when(
+      mockQueries.determineEntityTypeAtEndOfChain(
+        any(),
+        org.mockito.ArgumentMatchers.eq(sampleSet2.entityType),
+        org.mockito.ArgumentMatchers.eq(sampleSet2.name),
+        org.mockito.ArgumentMatchers.eq(List("samples"))
+      )
+    )
+      .thenReturn(
+        DBIO.successful(
+          Some("samples"))
+      )
+
     // root entity type:set, no entity expression, input expression: this.samples.something
     // SVV with error Expected single value for workflow input, but evaluated result set had multiple values
-    val expressionEvaluationContext =
-      ExpressionEvaluationContext(Some(sampleSet2.entityType), Some(sampleSet2.name), None, Some(sampleSet2.entityType))
-
-    val result = evalInputs(expressionEvaluationContext, configSampleSetSingleInput, stringWdl)
-
-    val errorResult = result
-      .find(_.entityName == sampleSet2.name)
-      .flatMap(_.inputResolutions.find(v => v.inputName == stringArgNameWithWfName && v.error.isDefined))
-
-    errorResult shouldBe defined
-    val errorMessage = errorResult.get.error.get
-    errorMessage should include("Expected single value")
+//    val expressionEvaluationContext =
+//      ExpressionEvaluationContext(Some(sampleSet2.entityType), Some(sampleSet2.name), None, Some(sampleSet2.entityType))
+//
+//    val result = evalInputs(expressionEvaluationContext, configSampleSetSingleInput, stringWdl)
+//
+//    val errorResult = result
+//      .find(_.entityName == sampleSet2.name)
+//      .flatMap(_.inputResolutions.find(v => v.inputName == stringArgNameWithWfName && v.error.isDefined))
+//
+//    errorResult shouldBe defined
+//    val errorMessage = errorResult.get.error.get
+//    errorMessage should include("Expected single value")
 
     // root entity type: set, entity expression: this.samples, input expression: this.samples.something
     // "The expression in your SubmissionRequest matched only entities of the wrong type. (Expected type sample_set.)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
@@ -235,7 +235,8 @@ class CompactExpressionEvaluatorSpec
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq("daSampleSet"),
-                                                       any()
+                                                       any(),
+        any()
       )
     )
       .thenReturn(
@@ -248,7 +249,8 @@ class CompactExpressionEvaluatorSpec
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq("daSampleSet2"),
-                                                       any()
+                                                       any(),
+        any()
       )
     )
       .thenReturn(
@@ -261,7 +263,8 @@ class CompactExpressionEvaluatorSpec
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq("daSampleSet4"),
-                                                       any()
+                                                       any(),
+        any()
       )
     )
       .thenReturn(
@@ -317,7 +320,8 @@ class CompactExpressionEvaluatorSpec
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq(sampleSet2.name),
-                                                       any()
+                                                       any(),
+        any()
       )
     )
       .thenReturn(
@@ -377,7 +381,8 @@ class CompactExpressionEvaluatorSpec
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq(testData.indiv1.name),
-                                                       any()
+                                                       any(),
+        any()
       )
     )
       .thenReturn(
@@ -472,7 +477,8 @@ class CompactExpressionEvaluatorSpec
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq(sampleSet2.name),
-                                                       any()
+                                                       any(),
+        any()
       )
     )
       .thenReturn(
@@ -509,7 +515,8 @@ class CompactExpressionEvaluatorSpec
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq("daSampleSet"),
-                                                       any()
+                                                       any(),
+        any()
       )
     )
       .thenReturn(
@@ -628,6 +635,7 @@ class CompactExpressionEvaluatorSpec
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
         any(),
         org.mockito.ArgumentMatchers.eq(sampleSetSet.name),
+        any(),
         any()
       )
     )
@@ -678,7 +686,8 @@ class CompactExpressionEvaluatorSpec
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq(sampleSet2.name),
-                                                       any()
+                                                       any(),
+        any()
       )
     )
       .thenReturn(
@@ -702,18 +711,18 @@ class CompactExpressionEvaluatorSpec
 
     // root entity type:set, no entity expression, input expression: this.samples.something
     // SVV with error Expected single value for workflow input, but evaluated result set had multiple values
-//    val expressionEvaluationContext =
-//      ExpressionEvaluationContext(Some(sampleSet2.entityType), Some(sampleSet2.name), None, Some(sampleSet2.entityType))
-//
-//    val result = evalInputs(expressionEvaluationContext, configSampleSetSingleInput, stringWdl)
-//
-//    val errorResult = result
-//      .find(_.entityName == sampleSet2.name)
-//      .flatMap(_.inputResolutions.find(v => v.inputName == stringArgNameWithWfName && v.error.isDefined))
-//
-//    errorResult shouldBe defined
-//    val errorMessage = errorResult.get.error.get
-//    errorMessage should include("Expected single value")
+    val expressionEvaluationContext =
+      ExpressionEvaluationContext(Some(sampleSet2.entityType), Some(sampleSet2.name), None, Some(sampleSet2.entityType))
+
+    val result = evalInputs(expressionEvaluationContext, configSampleSetSingleInput, stringWdl)
+
+    val errorResult = result
+      .find(_.entityName == sampleSet2.name)
+      .flatMap(_.inputResolutions.find(v => v.inputName == stringArgNameWithWfName && v.error.isDefined))
+
+    errorResult shouldBe defined
+    val errorMessage = errorResult.get.error.get
+    errorMessage should include("Expected single value")
 
     // root entity type: set, entity expression: this.samples, input expression: this.samples.something
     // "The expression in your SubmissionRequest matched only entities of the wrong type. (Expected type sample_set.)
@@ -742,7 +751,8 @@ class CompactExpressionEvaluatorSpec
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq("daSampleSet"),
-                                                       any()
+                                                       any(),
+        any()
       )
     )
       .thenReturn(
@@ -852,12 +862,13 @@ class CompactExpressionEvaluatorSpec
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
                                                        org.mockito.ArgumentMatchers.eq(sampleSet2.entityType),
                                                        org.mockito.ArgumentMatchers.eq(sampleSet2.name),
-                                                       any()
+                                                       any(),
+        any()
       )
     )
       .thenReturn(
         DBIO.successful(
-          Map(sampleGood.name -> Seq(sampleGoodAsCER), sampleGood2.name -> Seq(sampleGood2AsCER))
+          Map(sampleSet2.name -> Seq(sampleGoodAsCER, sampleGood2AsCER))
         )
       )
     val context =
@@ -883,7 +894,8 @@ class CompactExpressionEvaluatorSpec
         any(),
         org.mockito.ArgumentMatchers.eq(sampleForWdlStruct2.entityType),
         org.mockito.ArgumentMatchers.eq(sampleForWdlStruct2.name),
-        org.mockito.ArgumentMatchers.eq(List("samples"))
+        org.mockito.ArgumentMatchers.eq(List("samples")),
+        any()
       )
     )
       .thenReturn(
@@ -930,7 +942,8 @@ class CompactExpressionEvaluatorSpec
         any(),
         org.mockito.ArgumentMatchers.eq(sampleForWdlStruct2.entityType),
         org.mockito.ArgumentMatchers.eq(sampleForWdlStruct2.name),
-        org.mockito.ArgumentMatchers.eq(List("samples"))
+        org.mockito.ArgumentMatchers.eq(List("samples")),
+        any()
       )
     )
       .thenReturn(
@@ -978,7 +991,8 @@ class CompactExpressionEvaluatorSpec
         any(),
         org.mockito.ArgumentMatchers.eq(sampleForWdlStruct.entityType),
         org.mockito.ArgumentMatchers.eq(sampleForWdlStruct.name),
-        org.mockito.ArgumentMatchers.eq(List("samples"))
+        org.mockito.ArgumentMatchers.eq(List("samples")),
+        any()
       )
     )
       .thenReturn(
@@ -1086,7 +1100,8 @@ class CompactExpressionEvaluatorSpec
         any(),
         org.mockito.ArgumentMatchers.eq(sampleSet2.entityType),
         org.mockito.ArgumentMatchers.eq(sampleSet2.name),
-        org.mockito.ArgumentMatchers.eq(List("samples"))
+        org.mockito.ArgumentMatchers.eq(List("samples")),
+        any()
       )
     )
       .thenReturn(
@@ -1128,7 +1143,8 @@ class CompactExpressionEvaluatorSpec
         any(),
         org.mockito.ArgumentMatchers.eq(sampleForWdlStruct.entityType),
         org.mockito.ArgumentMatchers.eq(sampleForWdlStruct.name),
-        org.mockito.ArgumentMatchers.eq(List("samples"))
+        org.mockito.ArgumentMatchers.eq(List("samples")),
+        any()
       )
     )
       .thenReturn(
@@ -1192,7 +1208,8 @@ class CompactExpressionEvaluatorSpec
         any(),
         org.mockito.ArgumentMatchers.eq(sampleSet2.entityType),
         org.mockito.ArgumentMatchers.eq(sampleSet2.name),
-        org.mockito.ArgumentMatchers.eq(List("samples"))
+        org.mockito.ArgumentMatchers.eq(List("samples")),
+        any()
       )
     )
       .thenReturn(
@@ -1303,6 +1320,7 @@ class CompactExpressionEvaluatorSpec
         any(),
         org.mockito.ArgumentMatchers.eq(sampleSet.entityType),
         org.mockito.ArgumentMatchers.eq(sampleSet.name),
+        any(),
         any()
       )
     ).thenReturn(
@@ -1381,6 +1399,7 @@ class CompactExpressionEvaluatorSpec
         any(),
         org.mockito.ArgumentMatchers.eq(sampleSet.entityType),
         org.mockito.ArgumentMatchers.eq(sampleSet.name),
+        any(),
         any()
       )
     ).thenReturn(
@@ -1451,7 +1470,7 @@ class CompactExpressionEvaluatorSpec
     val queryPlan = QueryPlan(List("samples"), Map(expression -> Set("blah")))
 
     when(
-      mockQueries.queryRelatedRecordsWithRelationChain(any(), any(), any(), any())
+      mockQueries.queryRelatedRecordsWithRelationChain(any(), any(), any(), any(), any())
     )
       .thenReturn(
         DBIO.successful(
@@ -1478,7 +1497,7 @@ class CompactExpressionEvaluatorSpec
       QueryPlan(List("samples"), Map(expression1 -> Set("rawJsonDoubleArray"), expression2 -> Set("blah")))
 
     when(
-      mockQueries.queryRelatedRecordsWithRelationChain(any(), any(), any(), any())
+      mockQueries.queryRelatedRecordsWithRelationChain(any(), any(), any(), any(), any())
     )
       .thenReturn(
         DBIO.successful(
@@ -1508,7 +1527,7 @@ class CompactExpressionEvaluatorSpec
     val queryPlan = QueryPlan(List("samples"), Map(expression -> Set("blah")))
 
     when(
-      mockQueries.queryRelatedRecordsWithRelationChain(any(), any(), any(), any())
+      mockQueries.queryRelatedRecordsWithRelationChain(any(), any(), any(), any(), any())
     )
       .thenReturn(
         DBIO.successful(
@@ -1544,7 +1563,7 @@ class CompactExpressionEvaluatorSpec
       compactExpressionEvaluator
         .executeQueryPlan(workspace.workspaceIdAsUUID, "sample", sampleGood.name, "sample", queryPlan)
     )
-    verify(mockQueries, never()).queryRelatedRecordsWithRelationChain(any(), any(), any(), any())
+    verify(mockQueries, never()).queryRelatedRecordsWithRelationChain(any(), any(), any(), any(), any())
     result.size shouldBe 1
     //  type ExpressionAndResult = (LookupExpression, Map[EntityName, Try[Iterable[AttributeValue]]])
     result should contain theSameElementsAs Seq(
@@ -1596,7 +1615,7 @@ class CompactExpressionEvaluatorSpec
     val queryPlan = QueryPlan(List("samples"), Map(expression1 -> Set("name"), expression2 -> Set("Sample_id")))
 
     when(
-      mockQueries.queryRelatedRecordsWithRelationChain(any(), any(), any(), any())
+      mockQueries.queryRelatedRecordsWithRelationChain(any(), any(), any(), any(), any())
     )
       .thenReturn(
         DBIO.successful(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigTestSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigTestSupport.scala
@@ -593,6 +593,13 @@ trait MethodConfigTestSupport {
     )
   )
 
+  val sampleSetSet = Entity("setOfSets",
+    "SampleSetSet",
+    Map(
+      AttributeName.withDefaultNS("sample_sets") -> AttributeEntityReferenceList(
+        Seq(sampleSet.toReference, sampleSet2.toReference)
+      )))
+
   val dummyMethod = AgoraMethod("method_namespace", "test_method", 1)
 
   val configGood = MethodConfiguration("config_namespace",
@@ -830,7 +837,8 @@ trait MethodConfigTestSupport {
               entityQuery.save(context, sampleSet3),
               entityQuery.save(context, sampleSet4),
               entityQuery.save(context, sampleForWdlStruct),
-              entityQuery.save(context, sampleForWdlStruct2)
+              entityQuery.save(context, sampleForWdlStruct2),
+              entityQuery.save(context, sampleSetSet)
             )
           } else {
             compactEntityRepository.queries.batchWriteEntities(
@@ -845,7 +853,8 @@ trait MethodConfigTestSupport {
                 sampleSet3,
                 sampleSet4,
                 sampleForWdlStruct,
-                sampleForWdlStruct2
+                sampleForWdlStruct2,
+                sampleSetSet
               ),
               true
             )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigTestSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigTestSupport.scala
@@ -17,7 +17,6 @@ import org.broadinstitute.dsde.rawls.model.{
 }
 
 import java.util.UUID
-import scala.collection.immutable.Map
 
 trait MethodConfigTestSupport {
   this: TestDriverComponent =>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-691
<Put notes here to help reviewer understand this PR>

---
When submitting workflows, there are essentially four parameters that matter for validating types and correctly gathering the inputs: the given entity type, the root entity type, the entity expression, and the input expression.  
The given entity type need not match the root entity type, but since the input expression refers to entities of the root entity type, it is important that given entity type + entity expression matches the root entity type.
If you define a method config on `sample` entities but submit a `sample_set`, then the entity expression should result in entities of type `sample`: e.g. `this.samples`, which should be an attribute on `sample_set`, whereas the input expression should match an attribute on `samples`, e.g. `this.drs_uri`.
If instead the root entity type defined on the method config is `sample_set`, if the given entity is already a `sample_set` then the entity expression should be blank and the input expression needs to match attributes on a `sample_set` - e.g. `this.samples.drs_uri`.  
This distinction can get more complicated once we have more layers, such as sets of sets - if submitting a `sample_set_set`, then whether the root entity type is `sample` or `sample_set` makes a difference in how the entity and input expressions need to be defined: `this.ssets.samples` & `this.drs_uri` vs `this.ssets` & `this.samples.drs_uri`, respectively.  
And since the root entity type of a method config determines the base of the workflow, the end result of fetching the inputs should be one workflow per entity of the root entity type, with the inputs grouped by this type.  
Both the validation of the correct entity type and the grouping of the resulting input attributes were failing in some edge cases, particularly in sets of sets where the root entity type was a set.

This PR adds a validation step before querying for attributes, doing a minimal pre-traversal down just the entity expression portion of the relation chain and checking that the resulting entity type matches the root entity type.  
It also updates the `queryRelatedRecordsWithRelationChain` to take in a `rootEntityType` parameter and group its results by that type.  Previously, the results of the query were post-processed to both extract the attributes and group according the root entity, but this failed in the sets-of-sets case.  The new version always returns the results correctly grouped so that all the post-processing needs to do is extract the needed attributes.

Note that the new `validateEntityType` method adds an additional database call that repeats much of the work that is done in the later  `queryRelatedRecordsWithRelationChain` query.  I found that attempting to update `queryRelatedRecordsWithRelationChain` to retain the information needed to properly validate the entity type created an unwieldy, overly complex query that I wasn't confident wasn't breaking other behavior.  If reviewers feel this repeated work is too much I can revisit the possibility.

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
