### PR TITLE
CORE-695: handle Cromwell-archived workflow metadata

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4730,6 +4730,12 @@ components:
         workflowId:
           type: string
           description: The id of this workflow
+        message:
+          type: string
+          description: Informational message from Cromwell, if available
+        metadataArchiveStatus:
+          type: string
+          description: Present if this workflow's metadata has been archived
       description: Outputs and logs from all tasks in a workflow
     WorkflowQueueStatusByUserResponse:
       required:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -25,6 +25,7 @@ import org.broadinstitute.dsde.rawls.jobexec.SubmissionSupervisor.{
 }
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.Attributable.{attributeCount, safePrint, AttributeMap}
+import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.OutputType
 import org.broadinstitute.dsde.rawls.model.SubmissionStatuses.SubmissionStatus
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
 import org.broadinstitute.dsde.rawls.model._
@@ -826,7 +827,16 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
                     ignoreEmptyOutputs: Boolean
   ): Seq[Either[(Option[WorkflowEntityUpdate], Option[Workspace]), (WorkflowRecord, Seq[AttributeString])]] =
     workflowsWithOutputs.map { case (workflowRecord, outputsResponse) =>
-      val outputs = outputsResponse.outputs
+      // outputsResponse.outputs will be None if Cromwell has archived this workflow's metadata. This should never
+      // happen for a running submission, but here's a sanity check:
+      val outputs = outputsResponse.outputs.getOrElse(
+        throw new RawlsFatalExceptionWithErrorReport(
+          ErrorReport(
+            s"""Unable to read workflow outputs for workflow ${workflowRecord.externalId}: ${outputsResponse.message
+                .getOrElse("")}"""
+          )
+        )
+      )
       logger.debug(
         s"attaching outputs for ${submissionId.toString}/${workflowRecord.externalId
             .getOrElse("MISSING_WORKFLOW")}: ${outputExpressionMap.size} expressions, ${outputs.size} attribute values"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -25,6 +25,7 @@ import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
 import org.broadinstitute.dsde.rawls.methods.MethodConfigurationUtils
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
+import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.OutputType
 import org.broadinstitute.dsde.rawls.model.WorkflowFailureModes.WorkflowFailureMode
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
 import org.broadinstitute.dsde.rawls.model.{
@@ -918,7 +919,9 @@ class SubmissionsService(
                                    execLogs: ExecutionServiceLogs,
                                    workflowId: String
   ): WorkflowOutputs = {
-    val outs = execOuts.outputs
+    // execOuts.outputs  will be None if Cromwell has archived this workflow's metadata; in that case, treat it as an
+    // empty map here
+    val outs = execOuts.outputs.getOrElse(Map.empty[String, OutputType])
     val logs = execLogs.calls getOrElse Map()
 
     // Cromwell workflow outputs look like workflow_name.task_name.output_name.
@@ -928,7 +931,7 @@ class SubmissionsService(
 
     val taskMap =
       (outsByTask.keySet ++ logs.keySet).map(key => key -> TaskOutput(logs.get(key), outsByTask.get(key))).toMap
-    WorkflowOutputs(workflowId, taskMap)
+    WorkflowOutputs(workflowId, taskMap, execOuts.message, execOuts.metadataArchiveStatus)
   }
 
   /**

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAOSpec.scala
@@ -115,7 +115,8 @@ class HttpExecutionServiceDAOSpec
     withStatsD {
       val result = test.outputs("69d1d92f-3895-4a7b-880a-82535e9a096e", userInfo).futureValue
       result.id shouldBe "this_workflow_exists"
-      result.outputs.size shouldBe 3
+      result.outputs should not be empty
+      result.outputs.get.size shouldBe 3
     } { capturedMetrics =>
       capturedMetrics should contain allElementsOf (expectedHttpRequestMetrics("get",
                                                                                "api.workflows.v1.redacted.outputs",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockExecutionServiceDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockExecutionServiceDAO.scala
@@ -64,7 +64,7 @@ class MockExecutionServiceDAO(timeout: Boolean = false, val identifier: String =
   )
 
   override def outputs(id: String, userInfo: UserInfo) =
-    Future.successful(ExecutionServiceOutputs(id, Map("foo" -> Left(AttributeString("bar")))))
+    Future.successful(ExecutionServiceOutputs(id, Option(Map("foo" -> Left(AttributeString("bar")))), None, None))
 
   override def abort(id: String, userInfo: UserInfo) = Future.successful(Success(ExecutionServiceStatus(id, "Aborted")))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -125,7 +125,13 @@ class SubmissionMonitorSpec(_system: ActorSystem)
               scala.util.Success(
                 Option(
                   (workflowRec.copy(status = WorkflowStatuses.Succeeded.toString, cost = Option(BigDecimal.valueOf(0))),
-                   Some(ExecutionServiceOutputs(workflowRec.externalId.get, Map("o1" -> Left(AttributeString("foo")))))
+                   Some(
+                     ExecutionServiceOutputs(workflowRec.externalId.get,
+                                             Option(Map("o1" -> Left(AttributeString("foo")))),
+                                             None,
+                                             None
+                     )
+                   )
                   )
                 )
               )
@@ -465,22 +471,35 @@ class SubmissionMonitorSpec(_system: ActorSystem)
 
   private val outputs = ExecutionServiceOutputs(
     "foo",
-    Map(
-      "output" -> Left(AttributeString("hello world!")),
-      "output2" -> Left(AttributeString("hello world.")),
-      "output3" -> Left(AttributeString("hello workspace.")),
-      "extra" -> Left(AttributeString("hello world!"))
-    )
+    Option(
+      Map(
+        "output" -> Left(AttributeString("hello world!")),
+        "output2" -> Left(AttributeString("hello world.")),
+        "output3" -> Left(AttributeString("hello workspace.")),
+        "extra" -> Left(AttributeString("hello world!"))
+      )
+    ),
+    None,
+    None
   )
-  private val emptyOutputs = ExecutionServiceOutputs("foo",
-                                                     Map("output" -> Left(AttributeString("")),
-                                                         "output2" -> Left(AttributeString("")),
-                                                         "output3" -> Left(AttributeNull),
-                                                         "extra" -> Left(AttributeNull)
-                                                     )
+  private val emptyOutputs = ExecutionServiceOutputs(
+    "foo",
+    Option(
+      Map("output" -> Left(AttributeString("")),
+          "output2" -> Left(AttributeString("")),
+          "output3" -> Left(AttributeNull),
+          "extra" -> Left(AttributeNull)
+      )
+    ),
+    None,
+    None
   )
   private val partiallyEmptyOutputs =
-    ExecutionServiceOutputs("foo", Map("output" -> Left(AttributeString("hello")), "output2" -> Left(AttributeNull)))
+    ExecutionServiceOutputs("foo",
+                            Option(Map("output" -> Left(AttributeString("hello")), "output2" -> Left(AttributeNull))),
+                            None,
+                            None
+    )
 
   it should "attachOutputs normal" in withDefaultTestDatabase { dataSource: SlickDataSource =>
     val entityId = 0.toLong
@@ -807,7 +826,11 @@ class SubmissionMonitorSpec(_system: ActorSystem)
                                         None
     )
     val workflowsWithOutputs: Seq[(WorkflowRecord, ExecutionServiceOutputs)] =
-      Seq((workflowRecord, ExecutionServiceOutputs("foo", Map("output" -> Left(AttributeString("hello world!"))))))
+      Seq(
+        (workflowRecord,
+         ExecutionServiceOutputs("foo", Option(Map("output" -> Left(AttributeString("hello world!")))), None, None)
+        )
+      )
     val entitiesById: Map[Long, Entity] = Map(entityId -> entity)
     val outputExpressions: Map[String, String] = Map("missing" -> "this.bar")
 
@@ -871,7 +894,9 @@ class SubmissionMonitorSpec(_system: ActorSystem)
     runAndWait(
       monitor.handleOutputs(
         workflowRecs.map(r =>
-          (r, ExecutionServiceOutputs(r.externalId.get, Map("o1" -> Left(AttributeString("result")))))
+          (r,
+           ExecutionServiceOutputs(r.externalId.get, Option(Map("o1" -> Left(AttributeString("result")))), None, None)
+          )
         ),
         this,
         RawlsTracingContext(Option.empty)
@@ -938,7 +963,13 @@ class SubmissionMonitorSpec(_system: ActorSystem)
       runAndWait(
         monitor.handleOutputs(
           workflowRecs.map(r =>
-            (r, ExecutionServiceOutputs(r.externalId.get, Map("o1_lib" -> Left(AttributeString("result")))))
+            (r,
+             ExecutionServiceOutputs(r.externalId.get,
+                                     Option(Map("o1_lib" -> Left(AttributeString("result")))),
+                                     None,
+                                     None
+             )
+            )
           ),
           this,
           RawlsTracingContext(Option.empty)
@@ -998,7 +1029,13 @@ class SubmissionMonitorSpec(_system: ActorSystem)
       runAndWait(
         monitor2.handleOutputs(
           workflowRecs2.map(r =>
-            (r, ExecutionServiceOutputs(r.externalId.get, Map("o2_lib" -> Left(AttributeString("result2")))))
+            (r,
+             ExecutionServiceOutputs(r.externalId.get,
+                                     Option(Map("o2_lib" -> Left(AttributeString("result2")))),
+                                     None,
+                                     None
+             )
+            )
           ),
           this,
           RawlsTracingContext(Option.empty)
@@ -1038,7 +1075,9 @@ class SubmissionMonitorSpec(_system: ActorSystem)
           (r,
            ExecutionServiceOutputs(
              r.externalId.get,
-             Map("o1" -> Left(AttributeValueList(Vector(AttributeString("abc"), AttributeString("def")))))
+             Option(Map("o1" -> Left(AttributeValueList(Vector(AttributeString("abc"), AttributeString("def")))))),
+             None,
+             None
            )
           )
         ),
@@ -1087,7 +1126,9 @@ class SubmissionMonitorSpec(_system: ActorSystem)
             (r,
              ExecutionServiceOutputs(
                r.externalId.get,
-               Map("o1" -> Left(AttributeValueList(Vector(AttributeString("abc"), AttributeString("def")))))
+               Option(Map("o1" -> Left(AttributeValueList(Vector(AttributeString("abc"), AttributeString("def")))))),
+               None,
+               None
              )
             )
           ),
@@ -1120,9 +1161,10 @@ class SubmissionMonitorSpec(_system: ActorSystem)
         "o1" -> Left(AttributeValueList(Vector(AttributeString("123"), AttributeString("456"), AttributeString("789"))))
       )
       runAndWait(
-        monitor.handleOutputs(workflowRecs.map(r => (r, ExecutionServiceOutputs(r.externalId.get, newOutputs))),
-                              this,
-                              RawlsTracingContext(Option.empty)
+        monitor.handleOutputs(
+          workflowRecs.map(r => (r, ExecutionServiceOutputs(r.externalId.get, Option(newOutputs), None, None))),
+          this,
+          RawlsTracingContext(Option.empty)
         )
       )
 
@@ -1166,11 +1208,15 @@ class SubmissionMonitorSpec(_system: ActorSystem)
             (r,
              ExecutionServiceOutputs(
                r.externalId.get,
-               Map(
-                 "o1" -> Left(
-                   AttributeValueList(Vector(AttributeString("abc"), AttributeString("def"), AttributeString("xyz")))
+               Option(
+                 Map(
+                   "o1" -> Left(
+                     AttributeValueList(Vector(AttributeString("abc"), AttributeString("def"), AttributeString("xyz")))
+                   )
                  )
-               )
+               ),
+               None,
+               None
              )
             )
           ),
@@ -1204,7 +1250,9 @@ class SubmissionMonitorSpec(_system: ActorSystem)
           workflowRecs.map(r =>
             (r,
              ExecutionServiceOutputs(r.externalId.get,
-                                     Map("o1" -> Left(AttributeValueList(Vector(AttributeString("123")))))
+                                     Option(Map("o1" -> Left(AttributeValueList(Vector(AttributeString("123")))))),
+                                     None,
+                                     None
              )
             )
           ),
@@ -1346,7 +1394,13 @@ class SubmissionMonitorSpec(_system: ActorSystem)
                 scala.util.Success(
                   Option(
                     (r.copy(status = status.toString),
-                     Option(ExecutionServiceOutputs(r.externalId.get, Map("o1" -> Left(AttributeString("result")))))
+                     Option(
+                       ExecutionServiceOutputs(r.externalId.get,
+                                               Option(Map("o1" -> Left(AttributeString("result")))),
+                                               None,
+                                               None
+                       )
+                     )
                     )
                   )
                 )
@@ -1811,9 +1865,10 @@ class SubmissionMonitorSpec(_system: ActorSystem)
         runAndWait(workflowQuery.listWorkflowRecsForSubmission(UUID.fromString(subUnboundExpr.submissionId))).head
 
       runAndWait(
-        monitor.handleOutputs(Seq((workflowRec, ExecutionServiceOutputs(workflowRec.externalId.get, execOutputs))),
-                              this,
-                              RawlsTracingContext(Option.empty)
+        monitor.handleOutputs(
+          Seq((workflowRec, ExecutionServiceOutputs(workflowRec.externalId.get, Option(execOutputs), None, None))),
+          this,
+          RawlsTracingContext(Option.empty)
         )
       )
 
@@ -1898,7 +1953,13 @@ class SubmissionMonitorSpec(_system: ActorSystem)
       runAndWait(
         monitor.handleOutputs(
           workflowRecs.map(r =>
-            (r, ExecutionServiceOutputs(r.externalId.get, Map("bad1" -> Left(AttributeString("result")))))
+            (r,
+             ExecutionServiceOutputs(r.externalId.get,
+                                     Option(Map("bad1" -> Left(AttributeString("result")))),
+                                     None,
+                                     None
+             )
+            )
           ),
           this,
           RawlsTracingContext(Option.empty)
@@ -1971,7 +2032,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
       )
 
       val outputs = Map("o1" -> Left(AttributeString("result")))
-      val executionServiceOutputs = ExecutionServiceOutputs(workflowRecBefore.externalId.get, outputs)
+      val executionServiceOutputs =
+        ExecutionServiceOutputs(workflowRecBefore.externalId.get, Option(outputs), None, None)
       val executionServiceStatusResponse =
         ExecutionServiceStatusResponse(Seq(Try(Option(workflowRecBefore -> Option(executionServiceOutputs)))))
 
@@ -2028,25 +2090,29 @@ class SubmissionMonitorSpec(_system: ActorSystem)
             (r,
              ExecutionServiceOutputs(
                r.externalId.get,
-               Map(
-                 "o1" -> Left(
-                   AttributeValueList(
-                     Vector(
-                       AttributeString("entry 1"),
-                       AttributeString("entry 2"),
-                       AttributeString("entry 3"),
-                       AttributeString("entry 4"),
-                       AttributeString("entry 5"),
-                       AttributeString("entry 6"),
-                       AttributeString("entry 7"),
-                       AttributeString("entry 8"),
-                       AttributeString("entry 9"),
-                       AttributeString("entry 10"),
-                       AttributeString("entry 11")
+               Option(
+                 Map(
+                   "o1" -> Left(
+                     AttributeValueList(
+                       Vector(
+                         AttributeString("entry 1"),
+                         AttributeString("entry 2"),
+                         AttributeString("entry 3"),
+                         AttributeString("entry 4"),
+                         AttributeString("entry 5"),
+                         AttributeString("entry 6"),
+                         AttributeString("entry 7"),
+                         AttributeString("entry 8"),
+                         AttributeString("entry 9"),
+                         AttributeString("entry 10"),
+                         AttributeString("entry 11")
+                       )
                      )
                    )
                  )
-               )
+               ),
+               None,
+               None
              )
             )
           ),
@@ -2102,25 +2168,29 @@ class SubmissionMonitorSpec(_system: ActorSystem)
             (r,
              ExecutionServiceOutputs(
                r.externalId.get,
-               Map(
-                 "o1" -> Left(
-                   AttributeValueList(
-                     Vector(
-                       AttributeString("entry 1"),
-                       AttributeString("entry 2"),
-                       AttributeString("entry 3"),
-                       AttributeString("entry 4"),
-                       AttributeString("entry 5"),
-                       AttributeString("entry 6"),
-                       AttributeString("entry 7"),
-                       AttributeString("entry 8"),
-                       AttributeString("entry 9"),
-                       AttributeString("entry 10"),
-                       AttributeString("entry 11")
+               Option(
+                 Map(
+                   "o1" -> Left(
+                     AttributeValueList(
+                       Vector(
+                         AttributeString("entry 1"),
+                         AttributeString("entry 2"),
+                         AttributeString("entry 3"),
+                         AttributeString("entry 4"),
+                         AttributeString("entry 5"),
+                         AttributeString("entry 6"),
+                         AttributeString("entry 7"),
+                         AttributeString("entry 8"),
+                         AttributeString("entry 9"),
+                         AttributeString("entry 10"),
+                         AttributeString("entry 11")
+                       )
                      )
                    )
                  )
-               )
+               ),
+               None,
+               None
              )
             )
           ),
@@ -2474,7 +2544,7 @@ class SubmissionTestExecutionServiceDAO(workflowStatus: => String, workflowCost:
   ) = Future.successful(Seq(Left(ExecutionServiceStatus("test_id", workflowStatus))))
 
   override def outputs(id: String, userInfo: UserInfo) =
-    Future.successful(ExecutionServiceOutputs(id, Map("o1" -> Left(AttributeString("foo")))))
+    Future.successful(ExecutionServiceOutputs(id, Option(Map("o1" -> Left(AttributeString("foo")))), None, None))
 
   override def logs(id: String, userInfo: UserInfo) = Future.successful(
     ExecutionServiceLogs(id, Option(Map("task1" -> Seq(ExecutionServiceCallLogs(stdout = "foo", stderr = "bar")))))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -416,7 +416,9 @@ class SubmissionSpec(_system: ActorSystem)
           ),
           Some(Map("wf.x.four" -> Left(AttributeNumber(4)), "wf.x.five" -> Left(AttributeNumber(4))))
         )
-      )
+      ),
+      None,
+      None
     )
 
     override def save() =
@@ -1808,17 +1810,21 @@ class SubmissionSpec(_system: ActorSystem)
     assertResult(
       ExecutionServiceOutputs(
         workflowId,
-        Map(
-          "aggregate_data_workflow.aggregate_data.output_array" -> Left(
-            AttributeValueRawJson(
-              JsArray(
-                Vector(JsArray(Vector(JsString("foo"), JsString("bar"))),
-                       JsArray(Vector(JsString("baz"), JsString("qux")))
+        Option(
+          Map(
+            "aggregate_data_workflow.aggregate_data.output_array" -> Left(
+              AttributeValueRawJson(
+                JsArray(
+                  Vector(JsArray(Vector(JsString("foo"), JsString("bar"))),
+                         JsArray(Vector(JsString("baz"), JsString("qux")))
+                  )
                 )
               )
             )
           )
-        )
+        ),
+        None,
+        None
       )
     ) {
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -771,7 +771,9 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
                 )
               )
             )
-          )
+          ),
+          None,
+          None
         )
         assertResult(expectedOutputs) {
           responseAs[WorkflowOutputs]

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -73,7 +73,9 @@ case class UnsupportedOutputType(json: JsValue)
 
 case class ExecutionServiceOutputs(
   id: String,
-  outputs: Map[String, OutputType]
+  outputs: Option[Map[String, OutputType]],
+  message: Option[String],
+  metadataArchiveStatus: Option[String]
 )
 
 case class ExecutionServiceLogs(
@@ -162,7 +164,9 @@ case class TaskOutput(
 
 case class WorkflowOutputs(
   workflowId: String,
-  tasks: Map[String, TaskOutput]
+  tasks: Map[String, TaskOutput],
+  message: Option[String],
+  metadataArchiveStatus: Option[String]
 )
 
 case class WorkflowCost(
@@ -481,7 +485,7 @@ trait ExecutionJsonSupport extends JsonSupport {
     ExecutionServiceValidation
   )
 
-  implicit val ExecutionServiceOutputsFormat: RootJsonFormat[ExecutionServiceOutputs] = jsonFormat2(
+  implicit val ExecutionServiceOutputsFormat: RootJsonFormat[ExecutionServiceOutputs] = jsonFormat4(
     ExecutionServiceOutputs
   )
 
@@ -501,7 +505,7 @@ trait ExecutionJsonSupport extends JsonSupport {
 
   implicit val TaskOutputFormat: RootJsonFormat[TaskOutput] = jsonFormat2(TaskOutput)
 
-  implicit val WorkflowOutputsFormat: RootJsonFormat[WorkflowOutputs] = jsonFormat2(WorkflowOutputs)
+  implicit val WorkflowOutputsFormat: RootJsonFormat[WorkflowOutputs] = jsonFormat4(WorkflowOutputs)
 
   implicit val WorkflowCostFormat: RootJsonFormat[WorkflowCost] = jsonFormat2(WorkflowCost)
 

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/ExecutionModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/ExecutionModelSpec.scala
@@ -76,4 +76,47 @@ class ExecutionModelSpec extends AnyFlatSpec with Assertions with Matchers {
     serializedObj should include(bigDecimalString)
   }
 
+  behavior of "ExecutionServiceOutputs deserialization"
+
+  it should "deserialize not-yet-archived outputs responses" in {
+    val jsonString =
+      """{
+        | "id": "00112233-4455-6677-8899-aabbccddeeff",
+        | "outputs": {
+        |   "echo_strings.echo_files.out": "Hello World"
+        | }
+        |}""".stripMargin
+
+    val jsonObj = ExecutionServiceOutputsFormat.read(jsonString.parseJson)
+    jsonObj shouldBe ExecutionServiceOutputs(
+      id = "00112233-4455-6677-8899-aabbccddeeff",
+      outputs = Option(
+        Map(
+          "echo_strings.echo_files.out" -> Left(AttributeString("Hello World"))
+        )
+      ),
+      message = None,
+      metadataArchiveStatus = None
+    )
+  }
+
+  it should "deserialize archived outputs responses" in {
+    val jsonString =
+      """{
+        | "id": "00112233-4455-6677-8899-aabbccddeeff",
+        | "message": "Cromwell has archived this workflow's metadata according to the lifecycle policy. The workflow completed at 2025-02-28T14:46:51.011Z, which was 17385233716 milliseconds ago. It is available in the archive bucket, or via a support request in the case of a managed instance.",
+        | "metadataArchiveStatus": "ArchivedAndDeleted"
+        |}""".stripMargin
+
+    val jsonObj = ExecutionServiceOutputsFormat.read(jsonString.parseJson)
+    jsonObj shouldBe ExecutionServiceOutputs(
+      id = "00112233-4455-6677-8899-aabbccddeeff",
+      outputs = None,
+      message = Option(
+        "Cromwell has archived this workflow's metadata according to the lifecycle policy. The workflow completed at 2025-02-28T14:46:51.011Z, which was 17385233716 milliseconds ago. It is available in the archive bucket, or via a support request in the case of a managed instance."
+      ),
+      metadataArchiveStatus = Option("ArchivedAndDeleted")
+    )
+  }
+
 }


### PR DESCRIPTION
Ticket: CORE-695

Cromwell archives older workflow metadata to save space in its db. In this case, it will not return any `outputs` in its response when Rawls asks it for metadata. Rawls always expected an `outputs` key in the response and the Rawls `getWorkflowOutputs` API would fail for archived workflows.

This PR changes the `ExecutionServiceOutputs` from:
```scala
case class ExecutionServiceOutputs(
  id: String,
  outputs: Map[String, OutputType]
}
```
to
```scala
case class ExecutionServiceOutputs(
  id: String,
  outputs: Option[Map[String, OutputType]],
  message: Option[String],
  metadataArchiveStatus: Option[String]
)
```

to handle the potentially-missing `outputs`, and to include the informational `message` and `metadataArchiveStatus` returned by Cromwell for archived workflows. This causes a bunch of downstream syntax changes for compatibility.

_Note: CORE-695 appears to have more than one root cause of failure. This PR only targets this one cause; I will follow up with more PRs to address any others. See: https://github.com/DataBiosphere/terra-ui/pull/5418_

## getWorkflowOutputs API

### Before
<img width="1765" height="888" alt="Screenshot 18-09-2025 at 09 52" src="https://github.com/user-attachments/assets/c63b712a-f6ba-48ab-a2d6-f636282c656f" />

### After
<img width="1765" height="888" alt="Screenshot 18-09-2025 at 09 54" src="https://github.com/user-attachments/assets/d14eeaba-185e-4517-a795-3abb414ab75d" />


