### PR TITLE
CORE-698: roll back workspace setting on failed Quicksilver migration

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -45,6 +45,7 @@ import spray.json.RootJsonFormat
 import java.sql.SQLException
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 object EntityService {
   def constructor(dataSource: SlickDataSource,
@@ -604,14 +605,18 @@ class EntityService(protected val ctx: RawlsRequestContext,
         // Else, check if the user is an owner of the workspace; retrieve it if so.
         workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", s) { _ =>
           if (userIsAdmin) {
-            logger.info(s"Executing Quicksilver migration as admin for $workspaceName")
-            getV2WorkspaceContext(workspaceName, Some(WorkspaceAttributeSpecs(all = false)))
+            getV2WorkspaceContext(workspaceName, Some(WorkspaceAttributeSpecs(all = false))) map { ctx =>
+              logger.info(s"Quicksilver migration ${ctx.workspaceId} executing as admin for $workspaceName")
+              ctx
+            }
           } else {
-            logger.info(s"Executing Quicksilver migration as user for $workspaceName")
             getV2WorkspaceContextAndPermissions(workspaceName,
                                                 SamWorkspaceActions.own,
                                                 Some(WorkspaceAttributeSpecs(all = false))
-            )
+            ) map { ctx =>
+              logger.info(s"Quicksilver migration ${ctx.workspaceId} executing as user for $workspaceName")
+              ctx
+            }
           }
         }
         workspaceId = workspaceContext.workspaceIdAsUUID
@@ -627,7 +632,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
             .asInstanceOf[Option[CompactDataTablesSetting]]
             .exists(_.config.enabled)
         ) {
-          throw new RawlsExceptionWithErrorReport(ErrorReport("Quicksilver already enabled for this workspace"))
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(s"Quicksilver migration $workspaceId failed: Quicksilver already enabled for this workspace")
+          )
         }
 
         // Check if there are any pending compactDataTables settings for this workspace
@@ -641,7 +648,10 @@ class EntityService(protected val ctx: RawlsRequestContext,
         // Prevent starting another migration to avoid conflicts or an inconsistent state.
         _ = if (hasPendingSettings && updateWorkspaceSettings) {
           throw new RawlsExceptionWithErrorReport(
-            ErrorReport(StatusCodes.BadRequest, "Quicksilver migration is already in progress for this workspace")
+            ErrorReport(
+              StatusCodes.BadRequest,
+              s"Quicksilver migration $workspaceId failed: Quicksilver migration is already in progress for this workspace"
+            )
           )
         }
 
@@ -658,79 +668,100 @@ class EntityService(protected val ctx: RawlsRequestContext,
         }
 
         // start a transaction; here's where we do a bunch of writes
-        userResult <- dataSource.inTransaction { dataAccess =>
-          val shardId: String = dataAccess.determineShard(workspaceId)
+        userResult <- dataSource
+          .inTransaction { dataAccess =>
+            val shardId: String = dataAccess.determineShard(workspaceId)
 
-          val stopwatch = StopWatch.createStarted()
+            val stopwatch = StopWatch.createStarted()
 
-          logger.info(
-            s"Quicksilver migration $workspaceId: starting (${stopwatch.formatTime()}) ..."
-          )
+            logger.info(
+              s"Quicksilver migration $workspaceId: starting (${stopwatch.formatTime()}) ..."
+            )
 
-          withIncreasedSortMemory(dataAccess) {
-            for {
-              // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
-              // for each batch. later queries will use those boundaries to migrate entities in batches, which
-              // prevents the temp tables from growing too large.
-              batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
-              // niceties for logging
-              indexedBoundaries = batchBoundaries.zipWithIndex
+            withIncreasedSortMemory(dataAccess) {
+              for {
+                // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
+                // for each batch. later queries will use those boundaries to migrate entities in batches, which
+                // prevents the temp tables from growing too large.
+                batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
+                // niceties for logging
+                indexedBoundaries = batchBoundaries.zipWithIndex
 
-              // for each batch, migrate the entities in that batch
-              updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
-                quicksilverMigrateBatch(workspaceId,
-                                        shardId,
-                                        boundary,
-                                        dataAccess,
-                                        idx,
-                                        indexedBoundaries.size,
-                                        stopwatch,
-                                        s
+                // for each batch, migrate the entities in that batch
+                updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
+                  quicksilverMigrateBatch(workspaceId,
+                                          shardId,
+                                          boundary,
+                                          dataAccess,
+                                          idx,
+                                          indexedBoundaries.size,
+                                          stopwatch,
+                                          s
+                  )
+                })
+                numEntitiesUpdated = updateCounts.sum
+
+                (numAttributesDeleted, numEntitiesDeleted) <-
+                  if (cleanup) {
+                    // hard delete legacy data if requested
+                    hardDeleteLegacyData(workspaceId, shardId, dataAccess)
+                  } else {
+                    // otherwise, just log that we did not delete legacy data
+                    DBIO.successful((0, 0))
+                  }
+
+                _ = logger.info(
+                  s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
                 )
-              })
-              numEntitiesUpdated = updateCounts.sum
+              } yield Success(QuicksilverMigrationResult(numEntitiesUpdated, numEntitiesDeleted, numAttributesDeleted))
+            }
 
-              (numAttributesDeleted, numEntitiesDeleted) <-
-                if (cleanup) {
-                  // hard delete legacy data if requested
-                  hardDeleteLegacyData(workspaceId, shardId, dataAccess)
-                } else {
-                  // otherwise, just log that we did not delete legacy data
-                  DBIO.successful((0, 0))
-                }
-
-              _ = logger.info(
-                s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
-              )
-            } yield QuicksilverMigrationResult(numEntitiesUpdated, numEntitiesDeleted, numAttributesDeleted)
           }
-
-        }
+          .recover { case t: Throwable =>
+            Failure(t)
+          }
 
         // Apply the workspace setting to mark the migration as finalized
-        _ = if (updateWorkspaceSettings) {
-          traceFutureWithParent("applyWorkspaceSettings", s) { _ =>
-            settingsRepo.markWorkspaceSettingApplied(
-              workspaceContext.workspaceIdAsUUID,
-              WorkspaceSettingTypes.CompactDataTables
-            )
-          }
+        finalResult = userResult match {
+          case Success(result) =>
+            if (updateWorkspaceSettings) {
+              traceFutureWithParent("applyWorkspaceSettings", s) { _ =>
+                settingsRepo.markWorkspaceSettingApplied(
+                  workspaceContext.workspaceIdAsUUID,
+                  WorkspaceSettingTypes.CompactDataTables
+                )
+              }
+            }
+            result
+          case Failure(t) =>
+            if (updateWorkspaceSettings) {
+              logger.warn(
+                s"Quicksilver migration $workspaceId: FAILED with ${t.getClass.getSimpleName}: ${t.getMessage}"
+              )
+              traceFutureWithParent("rollBackWorkspaceSettings", s) { _ =>
+                settingsRepo.removePendingSetting(
+                  workspaceContext.workspaceIdAsUUID,
+                  WorkspaceSettingTypes.CompactDataTables
+                )
+              }
+            }
+            throw t
         }
 
         // return a count of entities updated
-      } yield userResult
+      } yield finalResult
     }
 
   private def hardDeleteLegacyData(workspaceId: UUID,
                                    shardId: String,
                                    dataAccess: DataAccess
   ): ReadWriteAction[(Int, Int)] = {
-    logger.info(s"Quicksilver migration: deleting legacy attributes ...")
+    logger.info(s"Quicksilver migration $workspaceId: deleting legacy attributes ...")
     for {
       // delete legacy attributes from the ENTITY_ATTRIBUTE_xx_xx table
       numAttributesDeleted <- dataAccess.compactEntityQuery.migrationDeleteLegacyAttributes(workspaceId, shardId)
       // delete the all_attribute_values column for this workspace
-      _ = logger.info(s"Quicksilver migration: clearing all_attribute_values ...")
+      _ = logger.info(s"Quicksilver migration $workspaceId: clearing all_attribute_values ...")
       numEntitiesDeleted <- dataAccess.compactEntityQuery.migrationHardDeleteEntitiesMarkedForDeletion(workspaceId)
     } yield (numAttributesDeleted, numEntitiesDeleted) // return count of attributes and entities deleted
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -721,31 +721,37 @@ class EntityService(protected val ctx: RawlsRequestContext,
             Failure(t)
           }
 
-        // Apply the workspace setting to mark the migration as finalized
-        finalResult = userResult match {
+        // Apply the workspace setting to mark the migration as finalized, or roll it back if the migration failed
+        finalResult <- userResult match {
           case Success(result) =>
-            if (updateWorkspaceSettings) {
+            val applyFuture = if (updateWorkspaceSettings) {
               traceFutureWithParent("applyWorkspaceSettings", s) { _ =>
                 settingsRepo.markWorkspaceSettingApplied(
                   workspaceContext.workspaceIdAsUUID,
                   WorkspaceSettingTypes.CompactDataTables
                 )
               }
+            } else {
+              Future.successful(())
             }
-            result
+            applyFuture map (_ => result)
           case Failure(t) =>
-            if (updateWorkspaceSettings) {
-              logger.warn(
-                s"Quicksilver migration $workspaceId: FAILED with ${t.getClass.getSimpleName}: ${t.getMessage}"
-              )
+            logger.warn(
+              s"Quicksilver migration $workspaceId: FAILED with ${t.getClass.getSimpleName}: ${t.getMessage}"
+            )
+            val rollbackFuture = if (updateWorkspaceSettings) {
               traceFutureWithParent("rollBackWorkspaceSettings", s) { _ =>
                 settingsRepo.removePendingSetting(
                   workspaceContext.workspaceIdAsUUID,
                   WorkspaceSettingTypes.CompactDataTables
-                )
+                ) map { _ =>
+                  logger.warn(
+                    s"Quicksilver migration $workspaceId: rolled back CompactDataTables workspace setting."
+                  )
+                }
               }
-            }
-            throw t
+            } else Future.successful(())
+            rollbackFuture map (_ => throw t)
         }
 
         // return a count of entities updated

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -8,7 +8,7 @@ import cats.effect.unsafe.implicits.global
 import com.typesafe.config.ConfigFactory
 import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{QuicksilverMigrationResult, TestDriverComponent}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{QuicksilverMigrationResult, RawSqlQuery, TestDriverComponent}
 import org.broadinstitute.dsde.rawls.dataaccess.{
   GoogleBigQueryServiceFactoryImpl,
   MockBigQueryServiceFactory,
@@ -25,6 +25,7 @@ import org.broadinstitute.dsde.rawls.entities.local.LocalEntityProvider
 import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
 import org.broadinstitute.dsde.rawls.mock.MockSamDAO
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.CompactDataTables
 import org.broadinstitute.dsde.rawls.model.{
   Attribute,
   AttributeBoolean,
@@ -60,10 +61,13 @@ import org.scalatest.Inspectors.forEvery
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import slick.jdbc.TransactionIsolation
 import spray.json._
 
+import java.util.UUID
 import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.{Failure, Try}
 
 class EntityServiceCompactMigrationSpec
     extends AnyFlatSpec
@@ -75,7 +79,8 @@ class EntityServiceCompactMigrationSpec
     with ScalaFutures
     with MockitoTestUtils
     with RawlsStatsDTestUtils
-    with CompactEntitySerialization {
+    with CompactEntitySerialization
+    with RawSqlQuery {
 
   // noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
   class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit
@@ -412,6 +417,36 @@ class EntityServiceCompactMigrationSpec
     // numEntitiesUpdated: test data has 18, but we soft-deleted 2
     // numEntitiesDeleted: 1 soft-deleted entity were hard-deleted
     // numAttributesDeleted: we delete all attributes in the workspace, not just the soft-deleted ones
+  }
+
+  it should s"roll back the CompactDataTables setting on failed migration" in withTestDataServices { apiService =>
+    val workspace = legacyTestData.workspace // has some entities we can use to test references
+
+    /** Locks all entities of the given workspace for ${lockSeconds} seconds. Use this to simulate database contention. */
+    def lockAllEntities(dataSource: SlickDataSource, workspaceId: UUID, lockSeconds: Int): Future[Unit] = {
+      import dataSource.dataAccess.driver.api._
+      val locker = for {
+        _ <- sql"""select * from ENTITY where workspace_id = $workspaceId for update;""".as[Unit]
+        _ <- sql"""select sleep(${lockSeconds + 2});""".as[Unit]
+      } yield ()
+      dataSource.database.run(locker.transactionally.withTransactionIsolation(TransactionIsolation.Serializable))
+    }
+
+    // lock entities; do NOT wait for this Future to complete so it is still running when we kick off the migration
+    lockAllEntities(slickDataSource, workspace.workspaceIdAsUUID, 60)
+    // ask to perform migration
+    val migrationResult =
+      Try(Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName), atMost))
+
+    migrationResult shouldBe a[Failure[_]]
+
+    // check if the setting exists
+    val repo = new WorkspaceSettingRepository(slickDataSource)
+    Await.result(repo.hasPendingSettings(workspace.workspaceIdAsUUID, CompactDataTables), Duration.Inf) shouldBe false
+    Await.result(repo.getWorkspaceSettingOfType(workspace.workspaceIdAsUUID, CompactDataTables),
+                 Duration.Inf
+    ) shouldBe empty
+
   }
 
 }


### PR DESCRIPTION
Ticket: CORE-698

* Catch failures in the Quickilver migration transaction, and roll back any pending CompactDataTables workspace setting on failure
* Tweak some log statements so all migration-related logs have the same format to help with monitoring

_Reviewer:_ please see my comments&questions inline!
