### PR TITLE
CORE-702: use Sam forget-project API in delete-workspace

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
@@ -577,15 +577,6 @@ class HttpSamDAO(baseSamServiceURL: String,
       callback.future
     }
 
-  override def deleteUserPetServiceAccount(googleProject: GoogleProjectId, ctx: RawlsRequestContext): Future[Unit] =
-    retry(when401or5xx) { () =>
-      val callback = new SamApiCallback[Void]("deletePetServiceAccount")
-
-      googleApi(ctx).deletePetServiceAccountAsync(googleProject.value, callback)
-
-      callback.future.map(_ => ())
-    }
-
   override def getDefaultPetServiceAccountKeyForUser(ctx: RawlsRequestContext): Future[String] =
     retry(when401or5xx) { () =>
       val callback = new SamApiCallback[String]("getArbitraryPetServiceAccountKey")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
@@ -164,8 +164,6 @@ trait SamDAO {
 
   def getUserPetServiceAccount(ctx: RawlsRequestContext, googleProjectId: GoogleProjectId): Future[WorkbenchEmail]
 
-  def deleteUserPetServiceAccount(googleProject: GoogleProjectId, ctx: RawlsRequestContext): Future[Unit]
-
   def getStatus(): Future[SubsystemStatus]
 
   def listResourceChildren(resourceTypeName: SamResourceTypeName,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -659,45 +659,15 @@ class WorkspaceService(
   private def deleteGoogleProject(googleProjectId: GoogleProjectId,
                                   parentContext: RawlsRequestContext
   ): Future[Unit] = {
-    def destroyPet(userIdInfo: UserIdInfo, projectName: GoogleProjectId, ctx: RawlsRequestContext): Future[Unit] =
-      for {
-        petSAJson <- traceFutureWithParent("getPetServiceAccountKeyForUser", ctx)(_ =>
-          samDAO.getPetServiceAccountKeyForUser(projectName, RawlsUserEmail(userIdInfo.userEmail))
-        )
-        petUserInfo <- traceFutureWithParent("getUserInfoUsingJson", ctx)(_ => gcsDAO.getUserInfoUsingJson(petSAJson))
-        _ <- traceFutureWithParent("deleteUserPetServiceAccount", ctx)(_ =>
-          samDAO.deleteUserPetServiceAccount(projectName, ctx.copy(userInfo = petUserInfo))
-        )
-      } yield ()
-
-    def deletePetsInProject(projectName: GoogleProjectId, ctx: RawlsRequestContext): Future[Unit] =
-      for {
-        projectUsers <- traceFutureWithParent("listAllResourceMemberIds", ctx)(_ =>
-          samDAO
-            .listAllResourceMemberIds(SamResourceTypeNames.googleProject, projectName.value, ctx)
-            .recover {
-              case regrets: RawlsExceptionWithErrorReport
-                  if regrets.errorReport.statusCode == Option(StatusCodes.NotFound) =>
-                logger.info(
-                  s"google-project resource ${projectName.value} not found in Sam. Continuing with workspace deletion"
-                )
-                Set[UserIdInfo]()
-            }
-        )
-        _ <- projectUsers.toList.traverse(destroyPet(_, projectName, parentContext))
-      } yield ()
     for {
-      _ <- traceFutureWithParent("deletePetsInProject", parentContext)(innerCtx =>
-        deletePetsInProject(googleProjectId, innerCtx)
-      )
+      // delete the project from the cloud
       _ <- traceFutureWithParent("gcsDAO.deleteGoogleProject", parentContext)(_ =>
         gcsDAO.deleteGoogleProject(googleProjectId)
       )
-      _ <- traceFutureWithParent("samDAO.deleteResource", parentContext)(_ =>
+      // delete the project, its children, and its pets from Sam
+      _ <- traceFutureWithParent("samDAO.forgetProject", parentContext)(_ =>
         samDAO
-          .recursiveDeleteResource(SamResourceTypeNames.googleProject, googleProjectId.value, ctx)(executionContext,
-                                                                                                   logger
-          )
+          .forgetProject(googleProjectId, ctx)
           .recover {
             case regrets: RawlsExceptionWithErrorReport
                 if regrets.errorReport.statusCode.contains(StatusCodes.NotFound) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -656,9 +656,7 @@ class WorkspaceService(
     WorkspaceDeletionResult.fromGcpBucketName(workspace.bucketName)
   }
 
-  private def deleteGoogleProject(googleProjectId: GoogleProjectId,
-                                  parentContext: RawlsRequestContext
-  ): Future[Unit] = {
+  private def deleteGoogleProject(googleProjectId: GoogleProjectId, parentContext: RawlsRequestContext): Future[Unit] =
     for {
       // delete the project from the cloud
       _ <- traceFutureWithParent("gcsDAO.deleteGoogleProject", parentContext)(_ =>
@@ -677,7 +675,6 @@ class WorkspaceService(
           }
       )
     } yield ()
-  }
 
   def updateWorkspace(workspaceName: WorkspaceName,
                       operations: Seq[AttributeUpdateOperation]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/CompactExpressionEvaluatorSpec.scala
@@ -236,7 +236,7 @@ class CompactExpressionEvaluatorSpec
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq("daSampleSet"),
                                                        any(),
-        any()
+                                                       any()
       )
     )
       .thenReturn(
@@ -250,7 +250,7 @@ class CompactExpressionEvaluatorSpec
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq("daSampleSet2"),
                                                        any(),
-        any()
+                                                       any()
       )
     )
       .thenReturn(
@@ -264,7 +264,7 @@ class CompactExpressionEvaluatorSpec
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq("daSampleSet4"),
                                                        any(),
-        any()
+                                                       any()
       )
     )
       .thenReturn(
@@ -321,7 +321,7 @@ class CompactExpressionEvaluatorSpec
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq(sampleSet2.name),
                                                        any(),
-        any()
+                                                       any()
       )
     )
       .thenReturn(
@@ -339,8 +339,7 @@ class CompactExpressionEvaluatorSpec
       )
     )
       .thenReturn(
-        DBIO.successful(
-          Some("Sample"))
+        DBIO.successful(Some("Sample"))
       )
 
     val expressionEvaluationContext =
@@ -382,7 +381,7 @@ class CompactExpressionEvaluatorSpec
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq(testData.indiv1.name),
                                                        any(),
-        any()
+                                                       any()
       )
     )
       .thenReturn(
@@ -404,8 +403,7 @@ class CompactExpressionEvaluatorSpec
       )
     )
       .thenReturn(
-        DBIO.successful(
-          Some("Sample"))
+        DBIO.successful(Some("Sample"))
       )
 
     val expressionEvaluationContext =
@@ -459,8 +457,7 @@ class CompactExpressionEvaluatorSpec
       )
     )
       .thenReturn(
-        DBIO.successful(
-          Some("Sample"))
+        DBIO.successful(Some("Sample"))
       )
 
     val context =
@@ -478,7 +475,7 @@ class CompactExpressionEvaluatorSpec
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq(sampleSet2.name),
                                                        any(),
-        any()
+                                                       any()
       )
     )
       .thenReturn(
@@ -516,7 +513,7 @@ class CompactExpressionEvaluatorSpec
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq("daSampleSet"),
                                                        any(),
-        any()
+                                                       any()
       )
     )
       .thenReturn(
@@ -534,8 +531,7 @@ class CompactExpressionEvaluatorSpec
       )
     )
       .thenReturn(
-        DBIO.successful(
-          Some("Sample"))
+        DBIO.successful(Some("Sample"))
       )
 
     val methodConf = MethodConfiguration("namespace",
@@ -633,16 +629,17 @@ class CompactExpressionEvaluatorSpec
   it should "understand sets of sets" in withConfigData {
     when(
       mockQueries.queryRelatedRecordsWithRelationChain(any(),
-        any(),
-        org.mockito.ArgumentMatchers.eq(sampleSetSet.name),
-        any(),
-        any()
+                                                       any(),
+                                                       org.mockito.ArgumentMatchers.eq(sampleSetSet.name),
+                                                       any(),
+                                                       any()
       )
     )
       .thenReturn(
         DBIO.successful(
           Map(sampleSet.name -> Seq(sampleGoodAsCER, sampleMissingValueAsCER),
-            sampleSet2.name -> Seq(sampleGoodAsCER, sampleGood2AsCER))
+              sampleSet2.name -> Seq(sampleGoodAsCER, sampleGood2AsCER)
+          )
         )
       )
 
@@ -655,13 +652,16 @@ class CompactExpressionEvaluatorSpec
       )
     )
       .thenReturn(
-        DBIO.successful(
-          Some("SampleSet"))
-        )
+        DBIO.successful(Some("SampleSet"))
+      )
 
     // root entity type:sample_set, given entity type: set of sets
     val expressionEvaluationContext =
-      ExpressionEvaluationContext(Some(sampleSetSet.entityType), Some(sampleSetSet.name), Some("this.sample_sets"), Some(sampleSet2.entityType))
+      ExpressionEvaluationContext(Some(sampleSetSet.entityType),
+                                  Some(sampleSetSet.name),
+                                  Some("this.sample_sets"),
+                                  Some(sampleSet2.entityType)
+      )
 
     val result = evalInputs(expressionEvaluationContext, configSampleSet, arrayWdl)
 
@@ -675,7 +675,10 @@ class CompactExpressionEvaluatorSpec
       SubmissionValidationEntityInputs(
         sampleSet2.name,
         Set(
-          SubmissionValidationValue(Some(AttributeValueList(Seq(AttributeNumber(1), AttributeNumber(2)))), None, intArrayNameWithWfName)
+          SubmissionValidationValue(Some(AttributeValueList(Seq(AttributeNumber(1), AttributeNumber(2)))),
+                                    None,
+                                    intArrayNameWithWfName
+          )
         )
       )
     )
@@ -687,7 +690,7 @@ class CompactExpressionEvaluatorSpec
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq(sampleSet2.name),
                                                        any(),
-        any()
+                                                       any()
       )
     )
       .thenReturn(
@@ -705,8 +708,7 @@ class CompactExpressionEvaluatorSpec
       )
     )
       .thenReturn(
-        DBIO.successful(
-          Some("samples"))
+        DBIO.successful(Some("samples"))
       )
 
     // root entity type:set, no entity expression, input expression: this.samples.something
@@ -752,7 +754,7 @@ class CompactExpressionEvaluatorSpec
                                                        any(),
                                                        org.mockito.ArgumentMatchers.eq("daSampleSet"),
                                                        any(),
-        any()
+                                                       any()
       )
     )
       .thenReturn(
@@ -863,7 +865,7 @@ class CompactExpressionEvaluatorSpec
                                                        org.mockito.ArgumentMatchers.eq(sampleSet2.entityType),
                                                        org.mockito.ArgumentMatchers.eq(sampleSet2.name),
                                                        any(),
-        any()
+                                                       any()
       )
     )
       .thenReturn(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigTestSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigTestSupport.scala
@@ -592,12 +592,15 @@ trait MethodConfigTestSupport {
     )
   )
 
-  val sampleSetSet = Entity("setOfSets",
+  val sampleSetSet = Entity(
+    "setOfSets",
     "SampleSetSet",
     Map(
       AttributeName.withDefaultNS("sample_sets") -> AttributeEntityReferenceList(
         Seq(sampleSet.toReference, sampleSet2.toReference)
-      )))
+      )
+    )
+  )
 
   val dummyMethod = AgoraMethod("method_namespace", "test_method", 1)
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
@@ -185,8 +185,6 @@ class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: Executi
                                         googleProjectId: GoogleProjectId
   ): Future[WorkbenchEmail] =
     Future.successful(WorkbenchEmail("pet-110347448408766049948@broad-dsde-dev.iam.gserviceaccount.com"))
-  override def deleteUserPetServiceAccount(googleProject: GoogleProjectId, ctx: RawlsRequestContext): Future[Unit] =
-    Future.unit
 
   override def getStatus(): Future[SubsystemStatus] = Future.successful(SubsystemStatus(true, None))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -317,7 +317,6 @@ class UserServiceSpec
                                                            testContext
       )
       verify(mockSamDAO, never()).getPetServiceAccountKeyForUser(any[GoogleProjectId], any[RawlsUserEmail])
-      verify(mockSamDAO, never()).deleteUserPetServiceAccount(project.googleProjectId, testContext)
       verify(mockSamDAO).forgetProject(project.googleProjectId, testContext)
       verify(mockSamDAO).deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, testContext)
       verify(mockGcsDAO).deleteV1Project(project.googleProjectId)
@@ -368,7 +367,6 @@ class UserServiceSpec
                                                            testContext
       )
       verify(mockSamDAO, never()).getPetServiceAccountKeyForUser(any[GoogleProjectId], any[RawlsUserEmail])
-      verify(mockSamDAO, never()).deleteUserPetServiceAccount(project.googleProjectId, testContext)
       verify(mockSamDAO).forgetProject(project.googleProjectId, testContext)
       verify(mockSamDAO).deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, testContext)
       verify(mockGcsDAO, never()).deleteV1Project(project.googleProjectId)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -559,8 +559,7 @@ class WorkspaceServiceUnitTests
     when(sam.listAllResourceMemberIds(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
       .thenReturn(Future(Set()))
     when(gcs.deleteGoogleProject(workspace.googleProjectId)).thenReturn(Future())
-    when(sam.deleteResource(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
-      .thenReturn(Future())
+    when(sam.forgetProject(workspace.googleProjectId, ctx)).thenReturn(Future())
     // delete workspace and associated records
     when(repo.deleteRawlsWorkspace(workspace)).thenReturn(Future())
     // delete workflow collection in sam
@@ -584,6 +583,7 @@ class WorkspaceServiceUnitTests
     val result = Await.result(service.deleteWorkspace(workspace.toWorkspaceName), Duration.Inf)
 
     result shouldBe WorkspaceDeletionResult.fromGcpBucketName(workspace.bucketName)
+    verify(sam).forgetProject(workspace.googleProjectId, ctx)
     verify(repo).deleteRawlsWorkspace(workspace)
     verify(sam).deleteResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
   }
@@ -618,8 +618,8 @@ class WorkspaceServiceUnitTests
     when(sam.listAllResourceMemberIds(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
       .thenReturn(Future(Set()))
     when(gcs.deleteGoogleProject(workspace.googleProjectId)).thenReturn(Future())
-    // throw 404 when deleting the google project resource in sam
-    when(sam.deleteResource(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
+    // throw 404 when forgetting the google project resource in sam
+    when(sam.forgetProject(workspace.googleProjectId, ctx))
       .thenReturn(Future.failed(RawlsExceptionWithErrorReport(StatusCodes.NotFound, "")))
     // delete workspace and associated records
     when(repo.deleteRawlsWorkspace(workspace)).thenReturn(Future())
@@ -643,7 +643,7 @@ class WorkspaceServiceUnitTests
     val result = Await.result(service.deleteWorkspace(workspace.toWorkspaceName), Duration.Inf)
 
     result shouldBe WorkspaceDeletionResult.fromGcpBucketName(workspace.bucketName)
-    verify(sam).deleteResource(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx)
+    verify(sam).forgetProject(workspace.googleProjectId, ctx)
   }
 
   it should "ignore 404 errors from sam when deleting the workflow collection resource" in {
@@ -676,8 +676,7 @@ class WorkspaceServiceUnitTests
     when(sam.listAllResourceMemberIds(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
       .thenReturn(Future(Set()))
     when(gcs.deleteGoogleProject(workspace.googleProjectId)).thenReturn(Future())
-    when(sam.deleteResource(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
-      .thenReturn(Future())
+    when(sam.forgetProject(workspace.googleProjectId, ctx)).thenReturn(Future())
     // delete workspace and associated records
     when(repo.deleteRawlsWorkspace(workspace)).thenReturn(Future())
     // delete workspace pao in tps
@@ -732,8 +731,7 @@ class WorkspaceServiceUnitTests
     when(sam.listAllResourceMemberIds(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
       .thenReturn(Future(Set()))
     when(gcs.deleteGoogleProject(workspace.googleProjectId)).thenReturn(Future())
-    when(sam.deleteResource(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
-      .thenReturn(Future())
+    when(sam.forgetProject(workspace.googleProjectId, ctx)).thenReturn(Future())
     // delete workspace and associated records
     when(repo.deleteRawlsWorkspace(workspace)).thenReturn(Future())
     // throw exception when deleting workflow collection in sam
@@ -788,8 +786,7 @@ class WorkspaceServiceUnitTests
     when(sam.listAllResourceMemberIds(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
       .thenReturn(Future(Set()))
     when(gcs.deleteGoogleProject(workspace.googleProjectId)).thenReturn(Future())
-    when(sam.deleteResource(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
-      .thenReturn(Future())
+    when(sam.forgetProject(workspace.googleProjectId, ctx)).thenReturn(Future())
     // delete workspace and associated records
     when(repo.deleteRawlsWorkspace(workspace)).thenReturn(Future())
     // delete workspace pao in tps
@@ -848,8 +845,7 @@ class WorkspaceServiceUnitTests
     when(sam.listAllResourceMemberIds(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
       .thenReturn(Future(Set()))
     when(gcs.deleteGoogleProject(workspace.googleProjectId)).thenReturn(Future())
-    when(sam.deleteResource(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
-      .thenReturn(Future())
+    when(sam.forgetProject(workspace.googleProjectId, ctx)).thenReturn(Future())
     // delete workspace and associated records
     when(repo.deleteRawlsWorkspace(workspace)).thenReturn(Future())
     // delete workspace pao in tps
@@ -879,136 +875,6 @@ class WorkspaceServiceUnitTests
     }
 
     exception shouldBe samError
-  }
-
-  it should "delete pets when deleting the google project" in {
-    val sam = mock[SamDAO]
-    val repo = mock[WorkspaceRepository]
-    val requesterPaysService = mock[RequesterPaysSetupService]
-    val submissionsRepository = mock[SubmissionsRepository]
-    val leo = mock[LeonardoService]
-    val fastPass = mock[FastPassService]
-    val gcs = mock[GoogleServicesDAO]
-    val tps = mock[PolicyService]
-    // mocked operations are defined in the order they are called by the service
-    // initial auth checks/workspace retrieval
-    when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
-    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.delete, ctx))
-      .thenReturn(Future(true))
-    when(sam.listResourceChildren(any[SamResourceTypeName], anyString, any[RawlsRequestContext]))
-      .thenReturn(Future(Seq.empty))
-    when(repo.getWorkspace(ArgumentMatchers.eq(workspace.toWorkspaceName), any[Option[WorkspaceAttributeSpecs]]))
-      .thenReturn(Future(Some(workspace)))
-    // delete requester pays records
-    when(requesterPaysService.deleteAllRecordsForWorkspace(workspace)).thenReturn(Future(1))
-    // abort workflows
-    when(submissionsRepository.getActiveWorkflowsAndSetStatusToAborted(workspace)).thenReturn(Future(Seq()))
-    // delete fast pass grants
-    when(fastPass.removeFastPassGrantsForWorkspace(workspace)).thenReturn(Future())
-    // notify leo to clean up resources
-    when(leo.cleanupResources(workspace.googleProjectId, workspace.workspaceIdAsUUID, ctx)).thenReturn(Future())
-    // delete pets in project
-    val pet = UserIdInfo(UUID.randomUUID().toString, "pet-email", None)
-    when(sam.listAllResourceMemberIds(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
-      .thenReturn(Future(Set(pet)))
-    val petKeyJson = "fake-json"
-    when(sam.getPetServiceAccountKeyForUser(workspace.googleProjectId, RawlsUserEmail(pet.userEmail)))
-      .thenReturn(Future(petKeyJson))
-    val petUserInfo = mock[UserInfo]
-    when(gcs.getUserInfoUsingJson(petKeyJson)).thenReturn(Future(petUserInfo))
-    when(sam.deleteUserPetServiceAccount(workspace.googleProjectId, ctx.copy(userInfo = petUserInfo)))
-      .thenReturn(Future())
-    // delete google project
-    when(gcs.deleteGoogleProject(workspace.googleProjectId)).thenReturn(Future())
-    when(sam.deleteResource(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
-      .thenReturn(Future())
-    // delete workspace and associated records
-    when(repo.deleteRawlsWorkspace(workspace)).thenReturn(Future())
-    // delete workspace pao in tps
-    when(tps.deleteWorkspacePao(any(), any())).thenReturn(Future.unit)
-    // delete workflow collection in sam
-    when(sam.deleteResource(SamResourceTypeNames.workflowCollection, workspace.workflowCollectionName.get, ctx))
-      .thenReturn(Future())
-    // delete workspace in sam
-    when(sam.deleteResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)).thenReturn(Future())
-    val service = workspaceServiceConstructor(
-      samDAO = sam,
-      requesterPaysSetupService = requesterPaysService,
-      fastPassServiceConstructor = _ => fastPass,
-      leonardoService = leo,
-      workspaceRepository = repo,
-      gcsDAO = gcs,
-      submissionsRepository = submissionsRepository,
-      policyService = tps
-    )(ctx)
-
-    val result = Await.result(service.deleteWorkspace(workspace.toWorkspaceName), Duration.Inf)
-
-    result shouldBe WorkspaceDeletionResult.fromGcpBucketName(workspace.bucketName)
-    verify(sam).listAllResourceMemberIds(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx)
-    verify(sam).getPetServiceAccountKeyForUser(workspace.googleProjectId, RawlsUserEmail(pet.userEmail))
-    verify(gcs).getUserInfoUsingJson(petKeyJson)
-    verify(sam).deleteUserPetServiceAccount(workspace.googleProjectId, ctx.copy(userInfo = petUserInfo))
-  }
-
-  it should "ignore 404s from Sam when retrieving pets" in {
-    val sam = mock[SamDAO]
-    val repo = mock[WorkspaceRepository]
-    val requesterPaysService = mock[RequesterPaysSetupService]
-    val submissionsRepository = mock[SubmissionsRepository]
-    val leo = mock[LeonardoService]
-    val fastPass = mock[FastPassService]
-    val gcs = mock[GoogleServicesDAO]
-    val tps = mock[PolicyService]
-    // mocked operations are defined in the order they are called by the service
-    // initial auth checks/workspace retrieval
-    when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
-    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.delete, ctx))
-      .thenReturn(Future(true))
-    when(sam.listResourceChildren(any[SamResourceTypeName], anyString, any[RawlsRequestContext]))
-      .thenReturn(Future(Seq.empty))
-    when(repo.getWorkspace(ArgumentMatchers.eq(workspace.toWorkspaceName), any[Option[WorkspaceAttributeSpecs]]))
-      .thenReturn(Future(Some(workspace)))
-    // delete requester pays records
-    when(requesterPaysService.deleteAllRecordsForWorkspace(workspace)).thenReturn(Future(1))
-    // abort workflows
-    when(submissionsRepository.getActiveWorkflowsAndSetStatusToAborted(workspace)).thenReturn(Future(Seq()))
-    // delete fast pass grants
-    when(fastPass.removeFastPassGrantsForWorkspace(workspace)).thenReturn(Future())
-    // notify leo to clean up resources
-    when(leo.cleanupResources(workspace.googleProjectId, workspace.workspaceIdAsUUID, ctx)).thenReturn(Future())
-    // delete pets in project
-    val pet = UserIdInfo(UUID.randomUUID().toString, "pet-email", None)
-    when(sam.listAllResourceMemberIds(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
-      .thenReturn(Future.failed(RawlsExceptionWithErrorReport(StatusCodes.NotFound, "")))
-    // delete google project
-    when(gcs.deleteGoogleProject(workspace.googleProjectId)).thenReturn(Future())
-    when(sam.deleteResource(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx))
-      .thenReturn(Future())
-    // delete workspace and associated records
-    when(repo.deleteRawlsWorkspace(workspace)).thenReturn(Future())
-    // delete workspace pao in tps
-    when(tps.deleteWorkspacePao(any(), any())).thenReturn(Future.unit)
-    // delete workflow collection in sam
-    when(sam.deleteResource(SamResourceTypeNames.workflowCollection, workspace.workflowCollectionName.get, ctx))
-      .thenReturn(Future())
-    // delete workspace in sam
-    when(sam.deleteResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)).thenReturn(Future())
-    val service = workspaceServiceConstructor(
-      samDAO = sam,
-      requesterPaysSetupService = requesterPaysService,
-      fastPassServiceConstructor = _ => fastPass,
-      leonardoService = leo,
-      workspaceRepository = repo,
-      gcsDAO = gcs,
-      submissionsRepository = submissionsRepository,
-      policyService = tps
-    )(ctx)
-
-    val result = Await.result(service.deleteWorkspace(workspace.toWorkspaceName), Duration.Inf)
-
-    result shouldBe WorkspaceDeletionResult.fromGcpBucketName(workspace.bucketName)
-    verify(sam).listAllResourceMemberIds(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx)
   }
 
   behavior of "getAcl"


### PR DESCRIPTION
Ticket: CORE-702

As of https://github.com/broadinstitute/sam/pull/1716, Sam has an API that encapsulates a bunch of functionality that Rawls implemented in its delete-workspace flow.

This PR removes the Rawls custom logic and replaces it with a single API call to Sam.