### PR TITLE
[CORE-699] Update with increased sort memory

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -2147,6 +2147,7 @@ paths:
             What value the MySQL sort_buffer_size should be set to during this migration. Default is 88388608L bytes (8M).
           schema:
             type: integer
+            format: int64
             default: 88388608
       requestBody:
         description: Consent to execute

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -2141,6 +2141,13 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: sortBufferSize
+          in: query
+          description: |
+            What value the MySQL sort_buffer_size should be set to during this migration. Default is 88388608L bytes (8M).
+          schema:
+            type: integer
+            default: 88388608
       requestBody:
         description: Consent to execute
         content:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -591,7 +591,8 @@ class EntityService(protected val ctx: RawlsRequestContext,
   def quicksilverMigration(workspaceName: WorkspaceName,
                            cleanup: Boolean = false,
                            batchSize: Int = 50000,
-                           updateWorkspaceSettings: Boolean = true
+                           updateWorkspaceSettings: Boolean = true,
+                           sortBufferSize: Long = 8388608L // 8M
   ): Future[QuicksilverMigrationResult] =
     traceFutureWithParent("EntityService.quicksilverMigration", ctx) { s =>
       for {
@@ -678,7 +679,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
               s"Quicksilver migration $workspaceId: starting (${stopwatch.formatTime()}) ..."
             )
 
-            withIncreasedSortMemory(dataAccess) {
+            withIncreasedSortMemory(dataAccess, sortBufferSize) {
               for {
                 // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
                 // for each batch. later queries will use those boundaries to migrate entities in batches, which
@@ -774,14 +775,14 @@ class EntityService(protected val ctx: RawlsRequestContext,
 
   /** Executes a database operation `op` in a session using 8MB of `sort_buffer_size` memory,
     * then resets the sort buffer size back to its original value */
-  private def withIncreasedSortMemory[T](dataAccess: DataAccess)(op: => ReadWriteAction[T]): ReadWriteAction[T] =
+  private def withIncreasedSortMemory[T](dataAccess: DataAccess, sortBufferSize: Long)(op: => ReadWriteAction[T]): ReadWriteAction[T] =
     for {
       // get the current value of MySQL sort_buffer_size
       defaultSortBufferSize <- dataAccess.compactEntityQuery.getSortBufferSetting
       // set sort buffer size to 8MB; this avoids MySQL errors during migration
       // with an "Out of sort memory, consider increasing server sort buffer size" message.
       // see also https://bugs.mysql.com/bug.php?id=103225
-      _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(8388608L)
+      _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(sortBufferSize)
       // execute the requested operation, then reset sort buffer size to its original value
       result <- op andFinally dataAccess.compactEntityQuery.setSessionSortBuffer(defaultSortBufferSize)
     } yield result

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -348,7 +348,10 @@ trait EntityApiService extends UserInfoDirectives {
       path("workspaces" / Segment / Segment / "quicksilverMigration") { (workspaceNamespace, workspaceName) =>
         post {
           // read the "cleanup" query parameter, defaulting to false if not specified
-          parameters("cleanup".as[Boolean].withDefault(false)) { cleanup =>
+          parameters(
+            "cleanup".as[Boolean].withDefault(false),
+            "sortBufferSize".as[Long].withDefault(8388608L)
+          ) { (cleanup, sortBufferSize) =>
             entity(as[String]) { postBody =>
               if (postBody != "I understand that this API will delete all my data tables.") {
                 complete(StatusCodes.BadRequest -> "You must consent to use this API.")
@@ -357,7 +360,10 @@ trait EntityApiService extends UserInfoDirectives {
                   jsonFormat3(QuicksilverMigrationResult)
                 complete {
                   entityServiceConstructor(ctx)
-                    .quicksilverMigration(WorkspaceName(workspaceNamespace, workspaceName), cleanup)
+                    .quicksilverMigration(workspaceName = WorkspaceName(workspaceNamespace, workspaceName),
+                                          cleanup = cleanup,
+                                          sortBufferSize = sortBufferSize
+                    )
                 }
               }
             }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -55,7 +55,7 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.{any, anyBoolean, anyInt}
+import org.mockito.ArgumentMatchers.{any, anyBoolean, anyInt, anyLong}
 import org.mockito.Mockito.times
 import org.mockito.Mockito.{verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -1047,7 +1047,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
         ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
         any[Boolean],
         any[Int],
-        any[Boolean]
+        any[Boolean],
+        any[Long]
       )
     ).thenReturn(Future.successful(QuicksilverMigrationResult(2, 2, 2)))
 
@@ -1066,7 +1067,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
       ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
       any[Boolean],
       any[Int],
-      any[Boolean]
+      any[Boolean],
+      any[Long]
     )
   }
 
@@ -1107,7 +1109,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
         ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
         any[Boolean],
         any[Int],
-        any[Boolean]
+        any[Boolean],
+        any[Long]
       )
     ).thenReturn(Future.failed(new Exception("migration failed")))
 
@@ -1233,7 +1236,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
           ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
           any[Boolean],
           any[Int],
-          any[Boolean]
+          any[Boolean],
+          any[Long]
         )
       ).thenReturn(Future.successful(QuicksilverMigrationResult(1, 2, 3)))
 
@@ -1254,7 +1258,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
         ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
         anyBoolean(),
         anyInt(),
-        ArgumentMatchers.eq(false)
+        ArgumentMatchers.eq(false),
+        anyLong()
       )
     }
   }
@@ -1301,7 +1306,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
         ArgumentMatchers.eq(WorkspaceName(workspace.namespace, workspace.name)),
         any[Boolean],
         any[Int],
-        any[Boolean]
+        any[Boolean],
+        any[Long]
       )
     ).thenReturn(Future.successful(QuicksilverMigrationResult(1, 2, 3)))
 
@@ -1322,7 +1328,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
       any[WorkspaceName],
       anyBoolean(),
       anyInt(),
-      anyBoolean()
+      anyBoolean(),
+      anyLong()
     )
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-699

When migrating workspaces to use the new compact data tables setting, MySQL occasionally throws an "out of sort memory" error. Instead of increasing the amount of memory specified in `withIncreasedSortMemory`, this PR allows the caller to pass in a value when calling the quicksilver migration endpoint.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
