### PR TITLE
CORE-708: retry with more sort memory for vulnerable Quicksilver queries

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -128,7 +128,7 @@ object EntityManager {
                                      queryTimeout,
                                      metricsPrefix
       ) // implicit executionContext, system
-    val compactEntityProviderBuilder = new CompactEntityProviderBuilder(dataSource)
+    val compactEntityProviderBuilder = new CompactEntityProviderBuilder(dataSource, metricsPrefix)
 
     new EntityManager(
       Set(defaultEntityProviderBuilder, compactEntityProviderBuilder),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.{
 }
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.base.{AuditLoggingEntityProvider, EntityProvider}
+import org.broadinstitute.dsde.rawls.entities.compact.SortMemoryRetry
 import org.broadinstitute.dsde.rawls.entities.exceptions.{
   DataEntityException,
   DeleteEntitiesConflictException,
@@ -79,7 +80,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
     with EntitySupport
     with AttributeSupport
     with LazyLogging
-    with RawlsInstrumented
+    with SortMemoryRetry
     with JsonFilterUtils
     with StringValidationUtils {
 
@@ -669,54 +670,56 @@ class EntityService(protected val ctx: RawlsRequestContext,
         }
 
         // start a transaction; here's where we do a bunch of writes
-        userResult <- EntityUtils
-          .retryWithSortMemory(dataSource, startingSortBufferSize = sortBufferSize.toInt) {
-            val dataAccess = dataSource.dataAccess
-            val shardId: String = dataAccess.determineShard(workspaceId)
+        userResult <- retryWithSortMemory(dataSource,
+                                          "quicksilverMigration",
+                                          startingSortBufferSize = sortBufferSize.toInt
+        ) {
+          val dataAccess = dataSource.dataAccess
+          val shardId: String = dataAccess.determineShard(workspaceId)
 
-            val stopwatch = StopWatch.createStarted()
+          val stopwatch = StopWatch.createStarted()
 
-            logger.info(
-              s"Quicksilver migration $workspaceId: starting (${stopwatch.formatTime()}) ..."
-            )
+          logger.info(
+            s"Quicksilver migration $workspaceId: starting (${stopwatch.formatTime()}) ..."
+          )
 
-            for {
-              // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
-              // for each batch. later queries will use those boundaries to migrate entities in batches, which
-              // prevents the temp tables from growing too large.
-              batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
-              // niceties for logging
-              indexedBoundaries = batchBoundaries.zipWithIndex
+          for {
+            // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
+            // for each batch. later queries will use those boundaries to migrate entities in batches, which
+            // prevents the temp tables from growing too large.
+            batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
+            // niceties for logging
+            indexedBoundaries = batchBoundaries.zipWithIndex
 
-              // for each batch, migrate the entities in that batch
-              updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
-                quicksilverMigrateBatch(workspaceId,
-                                        shardId,
-                                        boundary,
-                                        dataAccess,
-                                        idx,
-                                        indexedBoundaries.size,
-                                        stopwatch,
-                                        s
-                )
-              })
-              numEntitiesUpdated = updateCounts.sum
-
-              (numAttributesDeleted, numEntitiesDeleted) <-
-                if (cleanup) {
-                  // hard delete legacy data if requested
-                  hardDeleteLegacyData(workspaceId, shardId, dataAccess)
-                } else {
-                  // otherwise, just log that we did not delete legacy data
-                  DBIO.successful((0, 0))
-                }
-
-              _ = logger.info(
-                s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
+            // for each batch, migrate the entities in that batch
+            updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
+              quicksilverMigrateBatch(workspaceId,
+                                      shardId,
+                                      boundary,
+                                      dataAccess,
+                                      idx,
+                                      indexedBoundaries.size,
+                                      stopwatch,
+                                      s
               )
-            } yield Success(QuicksilverMigrationResult(numEntitiesUpdated, numEntitiesDeleted, numAttributesDeleted))
+            })
+            numEntitiesUpdated = updateCounts.sum
 
-          }
+            (numAttributesDeleted, numEntitiesDeleted) <-
+              if (cleanup) {
+                // hard delete legacy data if requested
+                hardDeleteLegacyData(workspaceId, shardId, dataAccess)
+              } else {
+                // otherwise, just log that we did not delete legacy data
+                DBIO.successful((0, 0))
+              }
+
+            _ = logger.info(
+              s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
+            )
+          } yield Success(QuicksilverMigrationResult(numEntitiesUpdated, numEntitiesDeleted, numAttributesDeleted))
+
+        }
           .recover { case t: Throwable =>
             Failure(t)
           }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -669,8 +669,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
         }
 
         // start a transaction; here's where we do a bunch of writes
-        userResult <- dataSource
-          .inTransaction { dataAccess =>
+        userResult <- EntityUtils
+          .retryWithSortMemory(dataSource, startingSortBufferSize = sortBufferSize.toInt) {
+            val dataAccess = dataSource.dataAccess
             val shardId: String = dataAccess.determineShard(workspaceId)
 
             val stopwatch = StopWatch.createStarted()
@@ -679,43 +680,41 @@ class EntityService(protected val ctx: RawlsRequestContext,
               s"Quicksilver migration $workspaceId: starting (${stopwatch.formatTime()}) ..."
             )
 
-            withIncreasedSortMemory(dataAccess, sortBufferSize) {
-              for {
-                // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
-                // for each batch. later queries will use those boundaries to migrate entities in batches, which
-                // prevents the temp tables from growing too large.
-                batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
-                // niceties for logging
-                indexedBoundaries = batchBoundaries.zipWithIndex
+            for {
+              // batch into groups of $batchSize entities, currently 50k. This method returns the min and max entity ids
+              // for each batch. later queries will use those boundaries to migrate entities in batches, which
+              // prevents the temp tables from growing too large.
+              batchBoundaries <- quicksilverCalculateBatches(workspaceId, batchSize, dataAccess)
+              // niceties for logging
+              indexedBoundaries = batchBoundaries.zipWithIndex
 
-                // for each batch, migrate the entities in that batch
-                updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
-                  quicksilverMigrateBatch(workspaceId,
-                                          shardId,
-                                          boundary,
-                                          dataAccess,
-                                          idx,
-                                          indexedBoundaries.size,
-                                          stopwatch,
-                                          s
-                  )
-                })
-                numEntitiesUpdated = updateCounts.sum
-
-                (numAttributesDeleted, numEntitiesDeleted) <-
-                  if (cleanup) {
-                    // hard delete legacy data if requested
-                    hardDeleteLegacyData(workspaceId, shardId, dataAccess)
-                  } else {
-                    // otherwise, just log that we did not delete legacy data
-                    DBIO.successful((0, 0))
-                  }
-
-                _ = logger.info(
-                  s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
+              // for each batch, migrate the entities in that batch
+              updateCounts <- DBIO.sequence(indexedBoundaries.map { case (boundary, idx) =>
+                quicksilverMigrateBatch(workspaceId,
+                                        shardId,
+                                        boundary,
+                                        dataAccess,
+                                        idx,
+                                        indexedBoundaries.size,
+                                        stopwatch,
+                                        s
                 )
-              } yield Success(QuicksilverMigrationResult(numEntitiesUpdated, numEntitiesDeleted, numAttributesDeleted))
-            }
+              })
+              numEntitiesUpdated = updateCounts.sum
+
+              (numAttributesDeleted, numEntitiesDeleted) <-
+                if (cleanup) {
+                  // hard delete legacy data if requested
+                  hardDeleteLegacyData(workspaceId, shardId, dataAccess)
+                } else {
+                  // otherwise, just log that we did not delete legacy data
+                  DBIO.successful((0, 0))
+                }
+
+              _ = logger.info(
+                s"Quicksilver migration $workspaceId: done! $numEntitiesUpdated entities updated. (${stopwatch.formatTime()})"
+              )
+            } yield Success(QuicksilverMigrationResult(numEntitiesUpdated, numEntitiesDeleted, numAttributesDeleted))
 
           }
           .recover { case t: Throwable =>
@@ -772,20 +771,6 @@ class EntityService(protected val ctx: RawlsRequestContext,
       numEntitiesDeleted <- dataAccess.compactEntityQuery.migrationHardDeleteEntitiesMarkedForDeletion(workspaceId)
     } yield (numAttributesDeleted, numEntitiesDeleted) // return count of attributes and entities deleted
   }
-
-  /** Executes a database operation `op` in a session using 8MB of `sort_buffer_size` memory,
-    * then resets the sort buffer size back to its original value */
-  private def withIncreasedSortMemory[T](dataAccess: DataAccess, sortBufferSize: Long)(op: => ReadWriteAction[T]): ReadWriteAction[T] =
-    for {
-      // get the current value of MySQL sort_buffer_size
-      defaultSortBufferSize <- dataAccess.compactEntityQuery.getSortBufferSetting
-      // set sort buffer size to 8MB; this avoids MySQL errors during migration
-      // with an "Out of sort memory, consider increasing server sort buffer size" message.
-      // see also https://bugs.mysql.com/bug.php?id=103225
-      _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(sortBufferSize)
-      // execute the requested operation, then reset sort buffer size to its original value
-      result <- op andFinally dataAccess.compactEntityQuery.setSessionSortBuffer(defaultSortBufferSize)
-    } yield result
 
   private case class MigrationBoundary(startEntityId: Long, endEntityId: Long)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityUtils.scala
@@ -1,15 +1,8 @@
 package org.broadinstitute.dsde.rawls.entities
 
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.rawls.StringValidationUtils
-import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
-import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadWriteAction
 import org.broadinstitute.dsde.rawls.model.{AttributeName, Entity, ErrorReportSource}
-import slick.jdbc.TransactionIsolation
-
-import java.sql.SQLException
-import scala.concurrent.{ExecutionContext, Future}
 
 object EntityUtils extends StringValidationUtils with LazyLogging {
   implicit override val errorReportSource: ErrorReportSource = ErrorReportSource("rawls")
@@ -23,72 +16,6 @@ object EntityUtils extends StringValidationUtils with LazyLogging {
     validateEntityType(entity.entityType)
     validateEntityName(entity.name)
     entity.attributes.keys.foreach(attrName => validateAttrName(attrName, entity.entityType))
-  }
-
-  /**
-   * Retries a given query at increasing `sort_buffer_size` allocations. This method is designed to work around
-   * the "Out of sort memory, consider increasing server sort buffer size" MySQL error, which manifests as a
-   * SQLException with error code 1038.
-   *
-   * See also: https://bugs.mysql.com/bug.php?id=103318, https://bugs.mysql.com/bug.php?id=103225
-   *
-   * @param dataSource Slick data source to use for queries
-   * @param query the query to execute
-   * @param startingSortBufferSize sort_buffer_size value, in bytes, to use for the first attempt
-   * @param maxSortBufferSize maximum sort_buffer_size value, in bytes, to allow
-   * @param multiplier factor by which each subsequent query attempt increases its sort_buffer_size value
-   * @param executionContext context for executing queries
-   * @return the query result
-   */
-  def retryWithSortMemory[T](dataSource: SlickDataSource,
-                             startingSortBufferSize: Int = 2097152, // 2MB
-                             maxSortBufferSize: Int = 268435456, // 256MB
-                             multiplier: Double = 2,
-                             isolationLevel: TransactionIsolation = TransactionIsolation.RepeatableRead
-  )(op: => ReadWriteAction[T])(implicit
-    executionContext: ExecutionContext
-  ): Future[T] = {
-
-    // generate a short id to uniquely identify this query attempt; this is purely for nice log messages
-    val queryId = RandomStringUtils.insecure().nextAlphanumeric(8)
-
-    // helper method to actually execute the query
-    def tryQuery(sortBufferSize: Long, retryIndex: Int): Future[(T, Int)] =
-      dataSource
-        .inTransaction(isolationLevel) { dataAccess =>
-          for {
-            // get the current value of MySQL sort_buffer_size
-            defaultSortBufferSize <- dataAccess.compactEntityQuery.getSortBufferSetting
-            // set sort buffer size to the ${sortBufferSize} argument
-            _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(sortBufferSize)
-            // execute the requested operation, then reset sort buffer size to its original value
-            result <- op andFinally dataAccess.compactEntityQuery.setSessionSortBuffer(defaultSortBufferSize)
-          } yield (result, retryIndex)
-        }
-        .recoverWith {
-          // TODO CORE-708: register some Prometheus metrics?
-          // catch and handle error code 1038 "Out of sort memory, consider increasing server sort buffer size"
-          case sqlEx: SQLException if sqlEx.getErrorCode == 1038 =>
-            val nextMemoryAllocation = Math.round(sortBufferSize * multiplier)
-            if (nextMemoryAllocation > maxSortBufferSize) {
-              logger.warn(
-                s"Out of retries for SQL query [$queryId] after ${retryIndex + 1} attempt(s); requested sort memory allocation $nextMemoryAllocation is greater than allowed maximum $maxSortBufferSize"
-              )
-              Future.failed(sqlEx)
-            } else {
-              logger.info(
-                s"SQL query [$queryId] retry attempt #${retryIndex + 1} with sort memory allocation $sortBufferSize"
-              )
-              tryQuery(nextMemoryAllocation, retryIndex + 1)
-            }
-        }
-
-    tryQuery(startingSortBufferSize, 0) map { case (result, retryIndex: Int) =>
-      if (retryIndex > 0) {
-        logger.info(s"SQL query [$queryId] succeeded after $retryIndex retries.")
-      }
-      result
-    }
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityUtils.scala
@@ -1,9 +1,18 @@
 package org.broadinstitute.dsde.rawls.entities
 
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.StringValidationUtils
+import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadWriteAction
 import org.broadinstitute.dsde.rawls.model.{AttributeName, Entity, ErrorReportSource}
+import slick.dbio.Effect
+import slick.jdbc.{ResultSetConcurrency, TransactionIsolation}
+import slick.sql.SqlStreamingAction
 
-object EntityUtils extends StringValidationUtils {
+import java.sql.SQLException
+import scala.concurrent.{ExecutionContext, Future}
+
+object EntityUtils extends StringValidationUtils with LazyLogging {
   implicit override val errorReportSource: ErrorReportSource = ErrorReportSource("rawls")
 
   def validateAttrName(attrName: AttributeName, entityType: String): Unit = {
@@ -16,4 +25,61 @@ object EntityUtils extends StringValidationUtils {
     validateEntityName(entity.name)
     entity.attributes.keys.foreach(attrName => validateAttrName(attrName, entity.entityType))
   }
+
+  /**
+   * Retries a given query at increasing `sort_buffer_size` allocations. This method is designed to work around
+   * the "Out of sort memory, consider increasing server sort buffer size" MySQL error, which manifests as a
+   * SQLException with error code 1038.
+   *
+   * See also: https://bugs.mysql.com/bug.php?id=103318, https://bugs.mysql.com/bug.php?id=103225
+   *
+   * @param dataSource Slick data source to use for queries
+   * @param query the query to execute
+   * @param startingSortBufferSize sort_buffer_size value, in bytes, to use for the first attempt
+   * @param maxSortBufferSize maximum sort_buffer_size value, in bytes, to allow
+   * @param multiplier factor by which each subsequent query attempt increases its sort_buffer_size value
+   * @param executionContext context for executing queries
+   * @return the query result
+   */
+  def retryWithSortMemory[T](dataSource: SlickDataSource,
+                             startingSortBufferSize: Int = 2097152, // 2MB
+                             maxSortBufferSize: Int = 268435456, // 256MB
+                             multiplier: Double = 2,
+                             isolationLevel: TransactionIsolation = TransactionIsolation.RepeatableRead
+  )(op: => ReadWriteAction[T])(implicit
+    executionContext: ExecutionContext
+  ): Future[T] = {
+
+    // helper method to actually execute the query
+    def tryQuery(sortBufferSize: Long): Future[T] =
+      dataSource
+        .inTransaction(isolationLevel) { dataAccess =>
+          for {
+            // get the current value of MySQL sort_buffer_size
+            defaultSortBufferSize <- dataAccess.compactEntityQuery.getSortBufferSetting
+            // set sort buffer size to the ${sortBufferSize} argument
+            _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(sortBufferSize)
+            // execute the requested operation, then reset sort buffer size to its original value
+            result <- op andFinally dataAccess.compactEntityQuery.setSessionSortBuffer(defaultSortBufferSize)
+          } yield result
+        }
+        .recoverWith {
+          // TODO CORE-708: register some Prometheus metrics?
+          // catch and handle error code 1038 "Out of sort memory, consider increasing server sort buffer size"
+          case sqlEx: SQLException if sqlEx.getErrorCode == 1038 =>
+            val nextMemoryAllocation = Math.round(sortBufferSize * multiplier)
+            if (nextMemoryAllocation > maxSortBufferSize) {
+              logger.warn(
+                s"Out of retries for SQL query; requested sort memory allocation $nextMemoryAllocation is greater than allowed maximum $maxSortBufferSize"
+              )
+              Future.failed(sqlEx)
+            } else {
+              logger.warn(s"Retrying SQL query with sort memory allocation $sortBufferSize")
+              tryQuery(nextMemoryAllocation)
+            }
+        }
+
+    tryQuery(startingSortBufferSize)
+  }
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityUtils.scala
@@ -1,13 +1,12 @@
 package org.broadinstitute.dsde.rawls.entities
 
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.rawls.StringValidationUtils
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadWriteAction
 import org.broadinstitute.dsde.rawls.model.{AttributeName, Entity, ErrorReportSource}
-import slick.dbio.Effect
-import slick.jdbc.{ResultSetConcurrency, TransactionIsolation}
-import slick.sql.SqlStreamingAction
+import slick.jdbc.TransactionIsolation
 
 import java.sql.SQLException
 import scala.concurrent.{ExecutionContext, Future}
@@ -50,8 +49,11 @@ object EntityUtils extends StringValidationUtils with LazyLogging {
     executionContext: ExecutionContext
   ): Future[T] = {
 
+    // generate a short id to uniquely identify this query attempt; this is purely for nice log messages
+    val queryId = RandomStringUtils.insecure().nextAlphanumeric(8)
+
     // helper method to actually execute the query
-    def tryQuery(sortBufferSize: Long): Future[T] =
+    def tryQuery(sortBufferSize: Long, retryIndex: Int): Future[(T, Int)] =
       dataSource
         .inTransaction(isolationLevel) { dataAccess =>
           for {
@@ -61,7 +63,7 @@ object EntityUtils extends StringValidationUtils with LazyLogging {
             _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(sortBufferSize)
             // execute the requested operation, then reset sort buffer size to its original value
             result <- op andFinally dataAccess.compactEntityQuery.setSessionSortBuffer(defaultSortBufferSize)
-          } yield result
+          } yield (result, retryIndex)
         }
         .recoverWith {
           // TODO CORE-708: register some Prometheus metrics?
@@ -70,16 +72,23 @@ object EntityUtils extends StringValidationUtils with LazyLogging {
             val nextMemoryAllocation = Math.round(sortBufferSize * multiplier)
             if (nextMemoryAllocation > maxSortBufferSize) {
               logger.warn(
-                s"Out of retries for SQL query; requested sort memory allocation $nextMemoryAllocation is greater than allowed maximum $maxSortBufferSize"
+                s"Out of retries for SQL query [$queryId] after ${retryIndex + 1} attempt(s); requested sort memory allocation $nextMemoryAllocation is greater than allowed maximum $maxSortBufferSize"
               )
               Future.failed(sqlEx)
             } else {
-              logger.warn(s"Retrying SQL query with sort memory allocation $sortBufferSize")
-              tryQuery(nextMemoryAllocation)
+              logger.info(
+                s"SQL query [$queryId] retry attempt #${retryIndex + 1} with sort memory allocation $sortBufferSize"
+              )
+              tryQuery(nextMemoryAllocation, retryIndex + 1)
             }
         }
 
-    tryQuery(startingSortBufferSize)
+    tryQuery(startingSortBufferSize, 0) map { case (result, retryIndex: Int) =>
+      if (retryIndex > 0) {
+        logger.info(s"SQL query [$queryId] succeeded after $retryIndex retries.")
+      }
+      result
+    }
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
@@ -39,6 +39,8 @@ trait EntityProviderMetrics extends RawlsInstrumented {
     meter
       .histogramBuilder(s"${PREFIX}_sortmemretry_retries")
       .ofLongs()
+      // this counts the number of query attempts, so we can be pretty sure of the bucket boundaries
+      .setExplicitBucketBoundariesAdvice(java.util.List.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
       .setDescription("Number of sort-memory retries required to complete a query")
       .setUnit("retries")
       .build()
@@ -47,6 +49,11 @@ trait EntityProviderMetrics extends RawlsInstrumented {
     meter
       .histogramBuilder(s"${PREFIX}_sortmemretry_allocation")
       .ofLongs()
+      // bucket boundaries are powers of 2, starting at 2Mb and ending with 512Mb
+      .setExplicitBucketBoundariesAdvice(
+        List[java.lang.Long](2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456,
+                             536870912).asJava
+      )
       .setDescription("Sort memory allocation required to complete a query")
       .setUnit("bytes")
       .build()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.entities.base
 
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.{AttributeKey, Attributes}
-import io.opentelemetry.api.metrics.{DoubleHistogram, LongCounter}
+import io.opentelemetry.api.metrics.{DoubleHistogram, LongCounter, LongHistogram}
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 
 import scala.jdk.CollectionConverters._
@@ -35,6 +35,22 @@ trait EntityProviderMetrics extends RawlsInstrumented {
       .setUnit("error")
       .build()
 
+  private def sortMemoryRetryAttempts: LongHistogram =
+    meter
+      .histogramBuilder(s"${PREFIX}_sortmemretry_retries")
+      .ofLongs()
+      .setDescription("Number of sort-memory retries required to complete a query")
+      .setUnit("retries")
+      .build()
+
+  private def sortMemoryRetryAllocation: LongHistogram =
+    meter
+      .histogramBuilder(s"${PREFIX}_sortmemretry_allocation")
+      .ofLongs()
+      .setDescription("Sort memory allocation required to complete a query")
+      .setUnit("bytes")
+      .build()
+
   private def nameOf(provider: EntityProvider): String = provider.getClass.getSimpleName
 
   private def nameOf(error: Throwable): String = error.getClass.getSimpleName
@@ -61,4 +77,12 @@ trait EntityProviderMetrics extends RawlsInstrumented {
     entityProviderErrorCount.add(1, attrs)
   }
 
+  def recordSortMemoryRetryResult(functionName: String, numRetries: Long, byteAllocation: Long): Unit = {
+    val attrs = Attributes.of(
+      FunctionKey,
+      functionName
+    )
+    sortMemoryRetryAttempts.record(numRetries, attrs)
+    sortMemoryRetryAllocation.record(byteAllocation, attrs)
+  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
@@ -45,15 +45,14 @@ trait EntityProviderMetrics extends RawlsInstrumented {
       .setUnit("retries")
       .build()
 
+  // bucket boundaries are powers of 2, starting at 2Mb and ending with 512Mb
+  private val allocationBuckets: List[java.lang.Long] =
+    List(1, 2, 4, 8, 16, 32, 64, 128, 256).map(multiplier => 2 * 1024 * 1024 * multiplier)
   private def sortMemoryRetryAllocation: LongHistogram =
     meter
       .histogramBuilder(s"${PREFIX}_sortmemretry_allocation")
       .ofLongs()
-      // bucket boundaries are powers of 2, starting at 2Mb and ending with 512Mb
-      .setExplicitBucketBoundariesAdvice(
-        List[java.lang.Long](2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456,
-                             536870912).asJava
-      )
+      .setExplicitBucketBoundariesAdvice(allocationBuckets.asJava)
       .setDescription("Sort memory allocation required to complete a query")
       .setUnit("bytes")
       .build()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -67,6 +67,7 @@ import scala.util.Try
   */
 class CompactEntityProvider(requestArguments: EntityRequestArguments,
                             val repository: CompactEntityRepository,
+                            metricsPrefix: String,
                             config: CompactEntityProviderConfig = CompactEntityProviderConfig()
 )(implicit
   protected val executionContext: ExecutionContext,
@@ -561,7 +562,7 @@ class CompactEntityProvider(requestArguments: EntityRequestArguments,
         Future.successful((EntityQueryResultMetadata(0, 0, 0), Source.empty))
       } else {
         EntityQueryStrategy
-          .choose(repository, workspaceId, entityType, entityQuery, unfilteredCount)
+          .choose(repository, workspaceId, entityType, entityQuery, unfilteredCount, metricsPrefix)
           .getCountAndSource
           .map(prepareQueryEntitiesResult(entityQuery, unfilteredCount, _))
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderBuilder.scala
@@ -9,7 +9,7 @@ import scala.concurrent.ExecutionContext
 import scala.reflect.runtime.universe._
 import scala.util.{Success, Try}
 
-class CompactEntityProviderBuilder(dataSource: SlickDataSource)(implicit
+class CompactEntityProviderBuilder(dataSource: SlickDataSource, metricsPrefix: String)(implicit
   protected val executionContext: ExecutionContext,
   actorSystem: ActorSystem
 ) extends EntityProviderBuilder[CompactEntityProvider] {
@@ -21,5 +21,5 @@ class CompactEntityProviderBuilder(dataSource: SlickDataSource)(implicit
   /** create the EntityProvider this builder knows how to create.
     */
   override def build(requestArguments: EntityRequestArguments): Try[CompactEntityProvider] =
-    Success(new CompactEntityProvider(requestArguments, new CompactEntityRepository(dataSource)))
+    Success(new CompactEntityProvider(requestArguments, new CompactEntityRepository(dataSource), metricsPrefix))
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/SortMemoryRetry.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/SortMemoryRetry.scala
@@ -1,0 +1,95 @@
+package org.broadinstitute.dsde.rawls.entities.compact
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.commons.lang3.RandomStringUtils
+import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadWriteAction
+import org.broadinstitute.dsde.rawls.entities.base.EntityProviderMetrics
+import slick.jdbc.TransactionIsolation
+
+import java.sql.SQLException
+import scala.concurrent.{ExecutionContext, Future}
+import scala.math.random
+
+/**
+ * Trait that adds support for retrying a given SQL query with increasingly larger `sort_buffer_size`
+ * memory allocations.
+ */
+trait SortMemoryRetry extends EntityProviderMetrics with LazyLogging {
+
+  /**
+   * Retries a given query at increasing `sort_buffer_size` allocations. This method is designed to work around
+   * the "Out of sort memory, consider increasing server sort buffer size" MySQL error, which manifests as a
+   * SQLException with error code 1038.
+   *
+   * See also: https://bugs.mysql.com/bug.php?id=103318, https://bugs.mysql.com/bug.php?id=103225
+   *
+   * @param dataSource Slick data source to use for queries
+   * @param functionName hint, for metrics, describing the caller who requires retries
+   * @param startingSortBufferSize sort_buffer_size value, in bytes, to use for the first attempt
+   * @param maxSortBufferSize maximum sort_buffer_size value, in bytes, to allow
+   * @param multiplier factor by which each subsequent query attempt increases its sort_buffer_size value
+   * @param executionContext context for executing queries
+   * @return the query result
+   */
+  def retryWithSortMemory[T](dataSource: SlickDataSource,
+                             functionName: String,
+                             startingSortBufferSize: Int = 2097152, // 2MB
+                             maxSortBufferSize: Int = 268435456, // 256MB
+                             multiplier: Double = 1.66,
+                             isolationLevel: TransactionIsolation = TransactionIsolation.RepeatableRead
+  )(op: => ReadWriteAction[T])(implicit
+    executionContext: ExecutionContext
+  ): Future[T] = {
+
+    // encapsulate query results and retry metadata
+    case class RetryResult(result: T, numAttempts: Int, finalAllocation: Long)
+
+    // generate a short id to uniquely identify this query attempt; this is purely for nice log messages
+    val queryId = RandomStringUtils.insecure().nextAlphanumeric(8)
+    logger.trace(s"SQL query with retryWithSortMemory [$queryId] attempts starting ...")
+
+    // helper method to actually execute the query
+    def tryQuery(sortBufferSize: Long, retryIndex: Int): Future[RetryResult] =
+      dataSource
+        .inTransaction(isolationLevel) { dataAccess =>
+          for {
+            // get the current value of MySQL sort_buffer_size
+            defaultSortBufferSize <- dataAccess.compactEntityQuery.getSortBufferSetting
+            // set sort buffer size to the ${sortBufferSize} argument
+            _ <- dataAccess.compactEntityQuery.setSessionSortBuffer(sortBufferSize)
+            // execute the requested operation, then reset sort buffer size to its original value
+            result <- op andFinally dataAccess.compactEntityQuery.setSessionSortBuffer(defaultSortBufferSize)
+          } yield RetryResult(result, retryIndex, sortBufferSize)
+        }
+        .recoverWith {
+          // catch and handle error code 1038 "Out of sort memory, consider increasing server sort buffer size"
+          case sqlEx: SQLException if sqlEx.getErrorCode == 1038 =>
+            // Generate a jitter factor between 0.85 and 1.15. Since the MySQL bug is not easily predictable, but
+            // IS deterministic for a given dataset+memory allocation, we apply jitter here to the allocation to
+            // avoid getting stuck in a deterministic failure state.
+            val jitter = 0.85 + (random * (1.15 - 0.85))
+            val nextMemoryAllocation = Math.round(sortBufferSize * multiplier * jitter)
+            if (nextMemoryAllocation > maxSortBufferSize) {
+              logger.warn(
+                s"Out of retries for SQL query with retryWithSortMemory [$queryId] after ${retryIndex + 1} attempt(s); requested sort memory allocation $nextMemoryAllocation is greater than allowed maximum $maxSortBufferSize"
+              )
+              Future.failed(sqlEx)
+            } else {
+              logger.trace(
+                s"SQL query with retryWithSortMemory [$queryId] retry attempt #${retryIndex + 1} with sort memory allocation $sortBufferSize"
+              )
+              tryQuery(nextMemoryAllocation, retryIndex + 1)
+            }
+        }
+
+    tryQuery(startingSortBufferSize, 0) map { r: RetryResult =>
+      if (r.numAttempts > 0) {
+        logger.info(s"SQL query with retryWithSortMemory [$queryId] succeeded after ${r.numAttempts} retries.")
+      }
+      // send metrics to Prometheus
+      recordSortMemoryRetryResult(functionName, r.numAttempts, r.finalAllocation)
+      r.result
+    }
+  }
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/AllEntitiesStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/AllEntitiesStrategy.scala
@@ -3,9 +3,8 @@ package org.broadinstitute.dsde.rawls.entities.compact.entityQuery
 import akka.stream.scaladsl.Source
 import org.broadinstitute.dsde.rawls.entities.EntityUtils
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
-import org.broadinstitute.dsde.rawls.model.EntityQuery
+import org.broadinstitute.dsde.rawls.model.{Entity, EntityQuery}
 import slick.jdbc.TransactionIsolation
-import slick.jdbc.TransactionIsolation.ReadCommitted
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
@@ -23,7 +22,9 @@ class AllEntitiesStrategy(override val repository: CompactEntityRepository,
 ) extends EntityQueryStrategy {
 
   override def getCountAndSource: Future[CountAndSource] =
-    EntityUtils.retryWithSortMemory(repository.dataSource, isolationLevel = TransactionIsolation.ReadCommitted) {
+    EntityUtils.retryWithSortMemory[Seq[Entity]](repository.dataSource,
+                                                 isolationLevel = TransactionIsolation.ReadCommitted
+    ) {
       repository.queries.queryEntitiesWithNoFilter(workspaceId, entityType, entityQuery)
     } map { sourceQueryMaterializedResult =>
       val source = Source(sourceQueryMaterializedResult)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/AllEntitiesStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/AllEntitiesStrategy.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.compact.entityQuery
 
 import akka.stream.scaladsl.Source
-import org.broadinstitute.dsde.rawls.entities.EntityUtils
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
 import org.broadinstitute.dsde.rawls.model.{Entity, EntityQuery}
 import slick.jdbc.TransactionIsolation
@@ -16,13 +15,17 @@ class AllEntitiesStrategy(override val repository: CompactEntityRepository,
                           workspaceId: UUID,
                           entityType: String,
                           entityQuery: EntityQuery,
-                          unfilteredCount: Int
+                          unfilteredCount: Int,
+                          override val workbenchMetricBaseName: String
 )(implicit
   executionContext: ExecutionContext
 ) extends EntityQueryStrategy {
 
   override def getCountAndSource: Future[CountAndSource] =
-    withSortMemoryRetries[Seq[Entity]](entityQuery, entityType, isolationLevel = TransactionIsolation.ReadCommitted) {
+    withSortMemoryRetries[Seq[Entity]](entityQuery,
+                                       this.getClass.getSimpleName,
+                                       isolationLevel = TransactionIsolation.ReadCommitted
+    ) {
       repository.queries.queryEntitiesWithNoFilter(workspaceId, entityType, entityQuery)
     } map { sourceQueryMaterializedResult =>
       val source = Source(sourceQueryMaterializedResult)
@@ -32,5 +35,4 @@ class AllEntitiesStrategy(override val repository: CompactEntityRepository,
         source
       )
     }
-
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/AllEntitiesStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/AllEntitiesStrategy.scala
@@ -22,9 +22,7 @@ class AllEntitiesStrategy(override val repository: CompactEntityRepository,
 ) extends EntityQueryStrategy {
 
   override def getCountAndSource: Future[CountAndSource] =
-    EntityUtils.retryWithSortMemory[Seq[Entity]](repository.dataSource,
-                                                 isolationLevel = TransactionIsolation.ReadCommitted
-    ) {
+    withSortMemoryRetries[Seq[Entity]](entityQuery, entityType, isolationLevel = TransactionIsolation.ReadCommitted) {
       repository.queries.queryEntitiesWithNoFilter(workspaceId, entityType, entityQuery)
     } map { sourceQueryMaterializedResult =>
       val source = Source(sourceQueryMaterializedResult)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/AllEntitiesStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/AllEntitiesStrategy.scala
@@ -1,10 +1,14 @@
 package org.broadinstitute.dsde.rawls.entities.compact.entityQuery
 
+import akka.stream.scaladsl.Source
+import org.broadinstitute.dsde.rawls.entities.EntityUtils
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
 import org.broadinstitute.dsde.rawls.model.EntityQuery
+import slick.jdbc.TransactionIsolation
+import slick.jdbc.TransactionIsolation.ReadCommitted
 
 import java.util.UUID
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Paginated query without any filters.
@@ -14,15 +18,20 @@ class AllEntitiesStrategy(override val repository: CompactEntityRepository,
                           entityType: String,
                           entityQuery: EntityQuery,
                           unfilteredCount: Int
+)(implicit
+  executionContext: ExecutionContext
 ) extends EntityQueryStrategy {
 
   override def getCountAndSource: Future[CountAndSource] =
-    // there is no filter so we can just use the unfiltered count
-    Future.successful(
+    EntityUtils.retryWithSortMemory(repository.dataSource, isolationLevel = TransactionIsolation.ReadCommitted) {
+      repository.queries.queryEntitiesWithNoFilter(workspaceId, entityType, entityQuery)
+    } map { sourceQueryMaterializedResult =>
+      val source = Source(sourceQueryMaterializedResult)
+      // there is no filter so we can just use the unfiltered count
       CountAndSource(
         unfilteredCount,
-        streamQuery(unfilteredCount, repository.queries.queryEntitiesWithNoFilter(workspaceId, entityType, entityQuery))
+        source
       )
-    )
+    }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategy.scala
@@ -2,9 +2,8 @@ package org.broadinstitute.dsde.rawls.entities.compact.entityQuery
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{CompactEntityRecord, ReadWriteAction}
-import org.broadinstitute.dsde.rawls.entities.EntityUtils
-import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
+import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadWriteAction
+import org.broadinstitute.dsde.rawls.entities.compact.{CompactEntityRepository, SortMemoryRetry}
 import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeName, Entity, EntityColumnFilter, EntityQuery}
 import slick.dbio.Effect
 import slick.jdbc.TransactionIsolation.ReadCommitted
@@ -16,7 +15,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case class CountAndSource(count: Int, source: Source[Entity, _])
 
-trait EntityQueryStrategy {
+trait EntityQueryStrategy extends SortMemoryRetry {
   val repository: CompactEntityRepository
 
   def getCountAndSource: Future[CountAndSource]
@@ -45,7 +44,7 @@ trait EntityQueryStrategy {
   }
 
   protected def withSortMemoryRetries[T](entityQuery: EntityQuery,
-                                         entityType: String,
+                                         functionName: String,
                                          isolationLevel: TransactionIsolation = TransactionIsolation.RepeatableRead
   )(op: => ReadWriteAction[T])(implicit
     executionContext: ExecutionContext
@@ -55,10 +54,9 @@ trait EntityQueryStrategy {
       case Attributable.nameReservedAttribute =>
         repository.dataSource.inTransaction(isolationLevel)(_ => op)
       case _ =>
-        EntityUtils
-          .retryWithSortMemory[T](repository.dataSource, isolationLevel = isolationLevel) {
-            op
-          }
+        retryWithSortMemory[T](repository.dataSource, functionName, isolationLevel = isolationLevel) {
+          op
+        }
     }
 
 }
@@ -77,19 +75,26 @@ object EntityQueryStrategy {
              workspaceId: UUID,
              entityType: String,
              entityQuery: EntityQuery,
-             unfilteredCount: Int
+             unfilteredCount: Int,
+             metricsPrefix: String
   )(implicit executionContext: ExecutionContext): EntityQueryStrategy = {
     val idAttributeName = AttributeName.withDefaultNS(entityType + Attributable.entityIdAttributeSuffix)
 
     (entityQuery.filterTerms, entityQuery.columnFilter) match {
       case (Some(filterTerms), _) =>
-        new SearchStrategy(repository, workspaceId, entityType, entityQuery, filterTerms.split(" ").toSeq)
+        new SearchStrategy(repository,
+                           workspaceId,
+                           entityType,
+                           entityQuery,
+                           filterTerms.split(" ").toSeq,
+                           metricsPrefix
+        )
       case (_, Some(EntityColumnFilter(`idAttributeName`, _))) =>
-        new FilterByNameStrategy(repository, workspaceId, entityType, entityQuery)
+        new FilterByNameStrategy(repository, workspaceId, entityType, entityQuery, metricsPrefix)
       case (_, Some(_)) =>
-        new FilterByColumnStrategy(repository, workspaceId, entityType, entityQuery)
+        new FilterByColumnStrategy(repository, workspaceId, entityType, entityQuery, metricsPrefix)
       case _ =>
-        new AllEntitiesStrategy(repository, workspaceId, entityType, entityQuery, unfilteredCount)
+        new AllEntitiesStrategy(repository, workspaceId, entityType, entityQuery, unfilteredCount, metricsPrefix)
     }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategy.scala
@@ -2,12 +2,13 @@ package org.broadinstitute.dsde.rawls.entities.compact.entityQuery
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import org.broadinstitute.dsde.rawls.dataaccess.slick.CompactEntityRecord
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{CompactEntityRecord, ReadWriteAction}
+import org.broadinstitute.dsde.rawls.entities.EntityUtils
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
 import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeName, Entity, EntityColumnFilter, EntityQuery}
 import slick.dbio.Effect
 import slick.jdbc.TransactionIsolation.ReadCommitted
-import slick.jdbc.{ResultSetConcurrency, ResultSetType}
+import slick.jdbc.{ResultSetConcurrency, ResultSetType, TransactionIsolation}
 import slick.sql.SqlStreamingAction
 
 import java.util.UUID
@@ -42,6 +43,24 @@ trait EntityQueryStrategy {
       )
     }
   }
+
+  protected def withSortMemoryRetries[T](entityQuery: EntityQuery,
+                                         entityType: String,
+                                         isolationLevel: TransactionIsolation = TransactionIsolation.RepeatableRead
+  )(op: => ReadWriteAction[T])(implicit
+    executionContext: ExecutionContext
+  ): Future[T] =
+    // is this a sort by name/id? If so, no need to retry with extra sort memory.
+    entityQuery.sortField match {
+      case Attributable.nameReservedAttribute =>
+        repository.dataSource.inTransaction(isolationLevel)(_ => op)
+      case _ =>
+        EntityUtils
+          .retryWithSortMemory[T](repository.dataSource, isolationLevel = isolationLevel) {
+            op
+          }
+    }
+
 }
 
 object EntityQueryStrategy {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByColumnStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByColumnStrategy.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.entities.compact.entityQuery
 import akka.stream.scaladsl.Source
 import org.broadinstitute.dsde.rawls.entities.EntityUtils
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
-import org.broadinstitute.dsde.rawls.model.EntityQuery
+import org.broadinstitute.dsde.rawls.model.{Entity, EntityQuery}
 import slick.jdbc.TransactionIsolation
 import slick.jdbc.TransactionIsolation.ReadCommitted
 
@@ -26,9 +26,10 @@ class FilterByColumnStrategy(override val repository: CompactEntityRepository,
         repository.queries.countEntitiesWithColumnFilter(workspaceId, entityType, columnFilter)
       }
       .flatMap { count =>
-        EntityUtils.retryWithSortMemory(repository.dataSource, isolationLevel = TransactionIsolation.ReadCommitted) {
-          repository.queries.queryEntitiesWithColumnFilter(workspaceId, entityType, entityQuery, columnFilter)
-        } map { sourceQueryMaterializedResult =>
+        EntityUtils
+          .retryWithSortMemory[Seq[Entity]](repository.dataSource, isolationLevel = TransactionIsolation.ReadCommitted) {
+            repository.queries.queryEntitiesWithColumnFilter(workspaceId, entityType, entityQuery, columnFilter)
+          } map { sourceQueryMaterializedResult =>
           val source = Source(sourceQueryMaterializedResult)
           CountAndSource(
             count,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByColumnStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByColumnStrategy.scala
@@ -16,7 +16,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class FilterByColumnStrategy(override val repository: CompactEntityRepository,
                              workspaceId: UUID,
                              entityType: String,
-                             entityQuery: EntityQuery
+                             entityQuery: EntityQuery,
+                             override val workbenchMetricBaseName: String
 )(implicit val executionContext: ExecutionContext)
     extends EntityQueryStrategy {
   override def getCountAndSource: Future[CountAndSource] = {
@@ -27,7 +28,7 @@ class FilterByColumnStrategy(override val repository: CompactEntityRepository,
       }
       .flatMap { count =>
         withSortMemoryRetries[Seq[Entity]](entityQuery,
-                                           entityType,
+                                           this.getClass.getSimpleName,
                                            isolationLevel = TransactionIsolation.ReadCommitted
         ) {
           repository.queries.queryEntitiesWithColumnFilter(workspaceId, entityType, entityQuery, columnFilter)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByColumnStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByColumnStrategy.scala
@@ -26,10 +26,12 @@ class FilterByColumnStrategy(override val repository: CompactEntityRepository,
         repository.queries.countEntitiesWithColumnFilter(workspaceId, entityType, columnFilter)
       }
       .flatMap { count =>
-        EntityUtils
-          .retryWithSortMemory[Seq[Entity]](repository.dataSource, isolationLevel = TransactionIsolation.ReadCommitted) {
-            repository.queries.queryEntitiesWithColumnFilter(workspaceId, entityType, entityQuery, columnFilter)
-          } map { sourceQueryMaterializedResult =>
+        withSortMemoryRetries[Seq[Entity]](entityQuery,
+                                           entityType,
+                                           isolationLevel = TransactionIsolation.ReadCommitted
+        ) {
+          repository.queries.queryEntitiesWithColumnFilter(workspaceId, entityType, entityQuery, columnFilter)
+        } map { sourceQueryMaterializedResult =>
           val source = Source(sourceQueryMaterializedResult)
           CountAndSource(
             count,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByColumnStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByColumnStrategy.scala
@@ -1,7 +1,10 @@
 package org.broadinstitute.dsde.rawls.entities.compact.entityQuery
 
+import akka.stream.scaladsl.Source
+import org.broadinstitute.dsde.rawls.entities.EntityUtils
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
 import org.broadinstitute.dsde.rawls.model.EntityQuery
+import slick.jdbc.TransactionIsolation
 import slick.jdbc.TransactionIsolation.ReadCommitted
 
 import java.util.UUID
@@ -22,14 +25,16 @@ class FilterByColumnStrategy(override val repository: CompactEntityRepository,
       .inTransaction(ReadCommitted) { _ =>
         repository.queries.countEntitiesWithColumnFilter(workspaceId, entityType, columnFilter)
       }
-      .map { count =>
-        CountAndSource(
-          count,
-          streamQuery(count,
-                      repository.queries
-                        .queryEntitiesWithColumnFilter(workspaceId, entityType, entityQuery, columnFilter)
+      .flatMap { count =>
+        EntityUtils.retryWithSortMemory(repository.dataSource, isolationLevel = TransactionIsolation.ReadCommitted) {
+          repository.queries.queryEntitiesWithColumnFilter(workspaceId, entityType, entityQuery, columnFilter)
+        } map { sourceQueryMaterializedResult =>
+          val source = Source(sourceQueryMaterializedResult)
+          CountAndSource(
+            count,
+            source
           )
-        )
+        }
       }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByNameStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByNameStrategy.scala
@@ -14,7 +14,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class FilterByNameStrategy(override val repository: CompactEntityRepository,
                            workspaceId: UUID,
                            entityType: String,
-                           entityQuery: EntityQuery
+                           entityQuery: EntityQuery,
+                           override val workbenchMetricBaseName: String
 )(implicit val executionContext: ExecutionContext)
     extends EntityQueryStrategy {
   override def getCountAndSource: Future[CountAndSource] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategy.scala
@@ -22,7 +22,8 @@ class SearchStrategy(override val repository: CompactEntityRepository,
                      workspaceId: UUID,
                      entityType: String,
                      entityQuery: EntityQuery,
-                     filterTerms: Seq[String]
+                     filterTerms: Seq[String],
+                     override val workbenchMetricBaseName: String
 )(implicit val executionContext: ExecutionContext)
     extends EntityQueryStrategy {
   override def getCountAndSource: Future[CountAndSource] = {
@@ -37,7 +38,7 @@ class SearchStrategy(override val repository: CompactEntityRepository,
       }
       .flatMap { count =>
         withSortMemoryRetries[Seq[Entity]](entityQuery,
-                                           entityType,
+                                           this.getClass.getSimpleName,
                                            isolationLevel = TransactionIsolation.ReadCommitted
         ) {
           repository.queries.queryEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, filterTerms)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategy.scala
@@ -6,7 +6,7 @@ import io.sentry.Sentry
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.entities.EntityUtils
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
-import org.broadinstitute.dsde.rawls.model.{EntityQuery, ErrorReport}
+import org.broadinstitute.dsde.rawls.model.{Entity, EntityQuery, ErrorReport}
 import org.broadinstitute.dsde.rawls.webservice.RawlsApiService.logger
 import slick.jdbc.TransactionIsolation
 import slick.jdbc.TransactionIsolation.ReadCommitted
@@ -36,9 +36,10 @@ class SearchStrategy(override val repository: CompactEntityRepository,
         repository.queries.countEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, filterTerms)
       }
       .flatMap { count =>
-        EntityUtils.retryWithSortMemory(repository.dataSource, isolationLevel = TransactionIsolation.ReadCommitted) {
-          repository.queries.queryEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, filterTerms)
-        } map { sourceQueryMaterializedResult =>
+        EntityUtils
+          .retryWithSortMemory[Seq[Entity]](repository.dataSource, isolationLevel = TransactionIsolation.ReadCommitted) {
+            repository.queries.queryEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, filterTerms)
+          } map { sourceQueryMaterializedResult =>
           val source = Source(sourceQueryMaterializedResult)
           CountAndSource(
             count,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategy.scala
@@ -1,11 +1,17 @@
 package org.broadinstitute.dsde.rawls.entities.compact.entityQuery
 
 import akka.http.scaladsl.model.StatusCodes
+import akka.stream.scaladsl.Source
+import io.sentry.Sentry
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+import org.broadinstitute.dsde.rawls.entities.EntityUtils
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntityRepository
 import org.broadinstitute.dsde.rawls.model.{EntityQuery, ErrorReport}
+import org.broadinstitute.dsde.rawls.webservice.RawlsApiService.logger
+import slick.jdbc.TransactionIsolation
 import slick.jdbc.TransactionIsolation.ReadCommitted
 
+import java.sql.SQLException
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -29,13 +35,16 @@ class SearchStrategy(override val repository: CompactEntityRepository,
       .inTransaction(ReadCommitted) { _ =>
         repository.queries.countEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, filterTerms)
       }
-      .map { count =>
-        CountAndSource(
-          count,
-          streamQuery(count,
-                      repository.queries.queryEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, filterTerms)
+      .flatMap { count =>
+        EntityUtils.retryWithSortMemory(repository.dataSource, isolationLevel = TransactionIsolation.ReadCommitted) {
+          repository.queries.queryEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, filterTerms)
+        } map { sourceQueryMaterializedResult =>
+          val source = Source(sourceQueryMaterializedResult)
+          CountAndSource(
+            count,
+            source
           )
-        )
+        }
       }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategy.scala
@@ -36,10 +36,12 @@ class SearchStrategy(override val repository: CompactEntityRepository,
         repository.queries.countEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, filterTerms)
       }
       .flatMap { count =>
-        EntityUtils
-          .retryWithSortMemory[Seq[Entity]](repository.dataSource, isolationLevel = TransactionIsolation.ReadCommitted) {
-            repository.queries.queryEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, filterTerms)
-          } map { sourceQueryMaterializedResult =>
+        withSortMemoryRetries[Seq[Entity]](entityQuery,
+                                           entityType,
+                                           isolationLevel = TransactionIsolation.ReadCommitted
+        ) {
+          repository.queries.queryEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, filterTerms)
+        } map { sourceQueryMaterializedResult =>
           val source = Source(sourceQueryMaterializedResult)
           CountAndSource(
             count,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -180,6 +180,7 @@ class EntityServiceCompactMigrationSpec
 
         val compactProvider = new CompactEntityProvider(requestArguments,
                                                         new CompactEntityRepository(slickDataSource),
+                                                        "testMetricPrefix",
                                                         CompactEntityProviderConfig()
         )
 
@@ -266,6 +267,7 @@ class EntityServiceCompactMigrationSpec
 
     val compactProvider = new CompactEntityProvider(requestArguments,
                                                     new CompactEntityRepository(slickDataSource),
+                                                    "testMetricPrefix",
                                                     CompactEntityProviderConfig()
     )
 
@@ -351,6 +353,7 @@ class EntityServiceCompactMigrationSpec
 
     val compactProvider = new CompactEntityProvider(requestArguments,
                                                     new CompactEntityRepository(slickDataSource),
+                                                    "testMetricPrefix",
                                                     CompactEntityProviderConfig()
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderE2ESpec.scala
@@ -326,7 +326,8 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
     val repository = new CompactEntityRepository(slickDataSource)
     val config = CompactEntityProviderConfig(batchUpsertBatchSize = 250) // pretty small to force batching
 
-    val provider = new CompactEntityProvider(defaultEntityRequestArguments, repository, config)(ec, system)
+    val provider =
+      new CompactEntityProvider(defaultEntityRequestArguments, repository, "testMetricPrefix", config)(ec, system)
 
     val metadataBefore = Await.result(provider.entityTypeMetadata(useCache = false, defaultRequestContext), atMost)
     metadataBefore shouldBe empty
@@ -356,7 +357,8 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
     val repository = new CompactEntityRepository(slickDataSource)
     val config = CompactEntityProviderConfig(batchUpsertBatchSize = 1) // should execute one update per batch
 
-    val provider = new CompactEntityProvider(defaultEntityRequestArguments, repository, config)(ec, system)
+    val provider =
+      new CompactEntityProvider(defaultEntityRequestArguments, repository, "testMetricPrefix", config)(ec, system)
 
     // the fourth update in this list has an unsupported character in its name and will cause a SQL error
     val updates: Seq[EntityUpdateDefinition] = Seq(
@@ -888,10 +890,12 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
   it should "delete attributes from entities" in withMinimalTestDatabase { _ =>
     // create providers for workspace1 and workspace2
     val repository = new CompactEntityRepository(slickDataSource)
-    val ws1Provider = new CompactEntityProvider(defaultEntityRequestArguments, repository)(ec, system)
+    val ws1Provider =
+      new CompactEntityProvider(defaultEntityRequestArguments, repository, "testMetricPrefix")(ec, system)
     val ws2Provider = new CompactEntityProvider(
       defaultEntityRequestArguments.copy(workspace = minimalTestData.workspace2),
-      repository
+      repository,
+      "testMetricPrefix"
     )(ec, system)
 
     // define attributes
@@ -974,10 +978,12 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
   it should "delete attributes containing references" in withMinimalTestDatabase { _ =>
     // create providers for workspace1 and workspace2
     val repository = new CompactEntityRepository(slickDataSource)
-    val ws1Provider = new CompactEntityProvider(defaultEntityRequestArguments, repository)(ec, system)
+    val ws1Provider =
+      new CompactEntityProvider(defaultEntityRequestArguments, repository, "testMetricPrefix")(ec, system)
     val ws2Provider = new CompactEntityProvider(
       defaultEntityRequestArguments.copy(workspace = minimalTestData.workspace2),
-      repository
+      repository,
+      "testMetricPrefix"
     )(ec, system)
 
     // insert target entities into both workspaces
@@ -1070,12 +1076,14 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
 
     val sourceProvider = new CompactEntityProvider(
       defaultEntityRequestArguments.copy(workspace = sourceWorkspace),
-      new CompactEntityRepository(slickDataSource)
+      new CompactEntityRepository(slickDataSource),
+      "testMetricPrefix"
     )(ec, system)
 
     val destinationProvider = new CompactEntityProvider(
       defaultEntityRequestArguments.copy(workspace = destinationWorkspace),
-      new CompactEntityRepository(slickDataSource)
+      new CompactEntityRepository(slickDataSource),
+      "testMetricPrefix"
     )(ec, system)
 
     // insert entities to be copied to source workspace
@@ -1285,7 +1293,7 @@ class CompactEntityProviderE2ESpec extends TestDriverComponentWithFlatSpecAndMat
   // ====================================================================================================
   def defaultProvider(): CompactEntityProvider = {
     val repository = new CompactEntityRepository(slickDataSource)
-    new CompactEntityProvider(defaultEntityRequestArguments, repository)(ec, system)
+    new CompactEntityProvider(defaultEntityRequestArguments, repository, "testMetricPrefix")(ec, system)
   }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderKeysCacheSpec.scala
@@ -462,12 +462,14 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
 
     val sourceProvider = new CompactEntityProvider(
       defaultEntityRequestArguments.copy(workspace = sourceWorkspace),
-      new CompactEntityRepository(slickDataSource)
+      new CompactEntityRepository(slickDataSource),
+      "testMetricPrefix"
     )(ec, system)
 
     val destinationProvider = new CompactEntityProvider(
       defaultEntityRequestArguments.copy(workspace = destinationWorkspace),
-      new CompactEntityRepository(slickDataSource)
+      new CompactEntityRepository(slickDataSource),
+      "testMetricPrefix"
     )(ec, system)
 
     // insert entities to be copied to source workspace
@@ -624,7 +626,7 @@ class CompactEntityProviderKeysCacheSpec extends TestDriverComponentWithFlatSpec
   // ====================================================================================================
   def defaultProvider(): CompactEntityProvider = {
     val repository = new CompactEntityRepository(slickDataSource)
-    new CompactEntityProvider(defaultEntityRequestArguments, repository)(ec, system)
+    new CompactEntityProvider(defaultEntityRequestArguments, repository, "testMetricPrefix")(ec, system)
   }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProviderSpec.scala
@@ -1973,11 +1973,11 @@ class CompactEntityProviderSpec
                                 requestArguments: EntityRequestArguments,
                                 config: CompactEntityProviderConfig
   ): CompactEntityProvider =
-    new CompactEntityProvider(requestArguments, repository, config)(ec, system)
+    new CompactEntityProvider(requestArguments, repository, "testMetricPrefix", config)(ec, system)
 
   private def providerWithMocks(repository: CompactEntityRepository,
                                 requestArguments: EntityRequestArguments
   ): CompactEntityProvider =
-    new CompactEntityProvider(requestArguments, repository)(ec, system)
+    new CompactEntityProvider(requestArguments, repository, "testMetricPrefix")(ec, system)
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/AllEntitiesStrategySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/AllEntitiesStrategySpec.scala
@@ -32,7 +32,7 @@ class AllEntitiesStrategySpec
     val entityQuery = EntityQuery(0, 0, "", SortDirections.Ascending, None)
     val workspaceId = UUID.randomUUID()
     val entityType = "testType"
-    val strategy = new AllEntitiesStrategy(mockRepository, workspaceId, entityType, entityQuery, 10)
+    val strategy = new AllEntitiesStrategy(mockRepository, workspaceId, entityType, entityQuery, 10, "testMetricPrefix")
 
     when(mockRepository.queries.queryEntitiesWithNoFilter(workspaceId, entityType, entityQuery))
       .thenReturn(sql"SELECT 1".as[Entity])

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategySpec.scala
@@ -29,7 +29,8 @@ class EntityQueryStrategySpec
   it should "choose the SearchStrategy when filterTerms is defined" in {
     val repository = mock[CompactEntityRepository]
     val entityQuery = EntityQuery(0, 0, "", SortDirections.Ascending, Some("test"))
-    val strategy = EntityQueryStrategy.choose(repository, UUID.randomUUID(), "testType", entityQuery, 0)
+    val strategy =
+      EntityQueryStrategy.choose(repository, UUID.randomUUID(), "testType", entityQuery, 0, "metricsPrefix")
 
     strategy shouldBe a[SearchStrategy]
   }
@@ -46,7 +47,8 @@ class EntityQueryStrategySpec
       columnFilter =
         Some(EntityColumnFilter(AttributeName.withDefaultNS(entityType + Attributable.entityIdAttributeSuffix), "test"))
     )
-    val strategy = EntityQueryStrategy.choose(repository, UUID.randomUUID(), entityType, entityQuery, 1)
+    val strategy =
+      EntityQueryStrategy.choose(repository, UUID.randomUUID(), entityType, entityQuery, 1, "metricsPrefix")
 
     strategy shouldBe a[FilterByNameStrategy]
   }
@@ -60,7 +62,8 @@ class EntityQueryStrategySpec
                                   None,
                                   columnFilter = Some(EntityColumnFilter(AttributeName.withDefaultNS("foo"), "test"))
     )
-    val strategy = EntityQueryStrategy.choose(repository, UUID.randomUUID(), "testType", entityQuery, 1)
+    val strategy =
+      EntityQueryStrategy.choose(repository, UUID.randomUUID(), "testType", entityQuery, 1, "metricsPrefix")
 
     strategy shouldBe a[FilterByColumnStrategy]
   }
@@ -68,7 +71,8 @@ class EntityQueryStrategySpec
   it should "choose the SearchStrategy when neither filterTerms nor columnFilter is defined" in {
     val repository = mock[CompactEntityRepository]
     val entityQuery = EntityQuery(0, 0, "", SortDirections.Ascending, None)
-    val strategy = EntityQueryStrategy.choose(repository, UUID.randomUUID(), "testType", entityQuery, 0)
+    val strategy =
+      EntityQueryStrategy.choose(repository, UUID.randomUUID(), "testType", entityQuery, 0, "metricsPrefix")
 
     strategy shouldBe a[AllEntitiesStrategy]
   }
@@ -77,6 +81,7 @@ class EntityQueryStrategySpec
 
   it should "return an empty source when count is 0" in {
     val strategy = new EntityQueryStrategy {
+      val workbenchMetricBaseName: String = "testMetricPrefix"
       override val repository: CompactEntityRepository = mock[CompactEntityRepository]
       override def getCountAndSource: Future[CountAndSource] =
         // the null will cause a NPE if streamQuery tries to use it which it shouldn't
@@ -92,6 +97,7 @@ class EntityQueryStrategySpec
     implicit val testCompactEntityGetter: GetResult[Entity] = GetResult(_ => testValue)
 
     val strategy = new EntityQueryStrategy {
+      val workbenchMetricBaseName: String = "testMetricPrefix"
       override val repository: CompactEntityRepository = mock[CompactEntityRepository]
       override def getCountAndSource: Future[CountAndSource] = {
         when(repository.dataSource).thenReturn(slickDataSource)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByColumnStrategySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByColumnStrategySpec.scala
@@ -33,7 +33,7 @@ class FilterByColumnStrategySpec
     val entityQuery = EntityQuery(0, 0, "", SortDirections.Ascending, None, columnFilter = Some(columnFilter))
     val workspaceId = UUID.randomUUID()
     val entityType = "testType"
-    val strategy = new FilterByColumnStrategy(mockRepository, workspaceId, entityType, entityQuery)
+    val strategy = new FilterByColumnStrategy(mockRepository, workspaceId, entityType, entityQuery, "testMetricPrefix")
 
     when(mockRepository.queries.countEntitiesWithColumnFilter(workspaceId, entityType, columnFilter))
       .thenReturn(DBIO.successful(10))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByNameStrategySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/FilterByNameStrategySpec.scala
@@ -32,7 +32,7 @@ class FilterByNameStrategySpec
     val entityQuery = EntityQuery(0, 0, "", SortDirections.Ascending, None, columnFilter = Some(columnFilter))
     val workspaceId = UUID.randomUUID()
     val entityType = "testType"
-    val strategy = new FilterByNameStrategy(mockRepository, workspaceId, entityType, entityQuery)
+    val strategy = new FilterByNameStrategy(mockRepository, workspaceId, entityType, entityQuery, "testMetricPrefix")
 
     when(mockRepository.queries.getEntity(workspaceId, entityType, entityName))
       .thenReturn(DBIO.successful(Some(testValue)))
@@ -57,7 +57,7 @@ class FilterByNameStrategySpec
     val entityQuery = EntityQuery(0, 0, "", SortDirections.Ascending, None, columnFilter = Some(columnFilter))
     val workspaceId = UUID.randomUUID()
     val entityType = "testType"
-    val strategy = new FilterByNameStrategy(mockRepository, workspaceId, entityType, entityQuery)
+    val strategy = new FilterByNameStrategy(mockRepository, workspaceId, entityType, entityQuery, "testMetricPrefix")
 
     when(mockRepository.queries.getEntity(workspaceId, entityType, entityName))
       .thenReturn(DBIO.successful(None))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/SearchStrategySpec.scala
@@ -32,7 +32,8 @@ class SearchStrategySpec
     val entityQuery = EntityQuery(0, 0, "", SortDirections.Ascending, Some("test"))
     val workspaceId = UUID.randomUUID()
     val entityType = "testType"
-    val strategy = new SearchStrategy(mockRepository, workspaceId, entityType, entityQuery, Seq("test"))
+    val strategy =
+      new SearchStrategy(mockRepository, workspaceId, entityType, entityQuery, Seq("test"), "testMetricPrefix")
 
     when(mockRepository.queries.countEntitiesWithFilterTerms(workspaceId, entityType, entityQuery, Seq("test")))
       .thenReturn(DBIO.successful(10))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
@@ -64,7 +64,7 @@ class CaseSensitivitySpec
 
   val testConf: Config = ConfigFactory.load()
 
-  private val providerBuilder = new CompactEntityProviderBuilder(slickDataSource)
+  private val providerBuilder = new CompactEntityProviderBuilder(slickDataSource, "testMetricPrefix")
 
   // ===================================================================================================================
   // exemplar data used in multiple tests


### PR DESCRIPTION
Ticket: CORE-708

This PR implements retries, with increasingly more memory allocated to `sort_buffer_size`, for specific SQL queries. This is implemented for:
* the `entityQuery` API
* the Quicksilver migration script

As these are the two places we have seen the dreaded "Out of sort memory" error.

The BIG drawback to these retries is that we lose result streaming for `entityQuery` and materialize the whole response. See comments inline explaining this.
