### PR TITLE
[CORE-711] Log workspace delete events

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -364,6 +364,12 @@ object Boot extends IOApp with LazyLogging {
         Some(workspaceSettingRepository)
       )
 
+      val bardService = new BardService(
+        appConfigManager.conf.getBoolean("bard.enabled"),
+        appConfigManager.conf.getString("bard.bardUrl"),
+        appConfigManager.conf.getInt("bard.connectionPoolSize")
+      )
+
       lazy val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService =
         (ctx: RawlsRequestContext) =>
           new WorkspaceSettingService(ctx,
@@ -403,7 +409,8 @@ object Boot extends IOApp with LazyLogging {
         fastPassServiceConstructor,
         policyService,
         workspaceSettingServiceConstructor,
-        entityServiceConstructor
+        entityServiceConstructor,
+        bardService
       )
 
       val workspaceAdminServiceConstructor: RawlsRequestContext => WorkspaceAdminService =
@@ -526,12 +533,6 @@ object Boot extends IOApp with LazyLogging {
 
       if (appConfigManager.conf.getBooleanOption("backRawls").getOrElse(false)) {
         logger.info("This instance has been marked as BACK. Booting monitors...")
-
-        val bardService = new BardService(
-          appConfigManager.conf.getBoolean("bard.enabled"),
-          appConfigManager.conf.getString("bard.bardUrl"),
-          appConfigManager.conf.getInt("bard.connectionPoolSize")
-        )
 
         BootMonitors.bootMonitors(
           system,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/logEvents/WorkspaceDeleteEvent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/logEvents/WorkspaceDeleteEvent.scala
@@ -1,0 +1,22 @@
+package org.broadinstitute.dsde.rawls.metrics.logEvents
+
+import java.util
+
+case class WorkspaceDeleteEvent(workspaceId: String,
+                                workspaceNamespace: String,
+                                workspaceName: String,
+                                userSubjectId: String
+) extends BardEvent {
+
+  override def eventName: String = "workspace:delete"
+
+  override def getProperties: util.Map[String, Any] =
+    this.transformMap(
+      Map(
+        "workspaceId" -> workspaceId,
+        "workspaceNamespace" -> workspaceNamespace,
+        "workspaceName" -> workspaceName,
+        "userSubjectId" -> userSubjectId
+      )
+    )
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -23,7 +23,8 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.entities.EntityService
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.LookupExpression
 import org.broadinstitute.dsde.rawls.fastpass.FastPassService
-import org.broadinstitute.dsde.rawls.metrics.{MetricsHelper, RawlsInstrumented}
+import org.broadinstitute.dsde.rawls.metrics.{BardService, MetricsHelper, RawlsInstrumented}
+import org.broadinstitute.dsde.rawls.metrics.logEvents.WorkspaceDeleteEvent
 import org.broadinstitute.dsde.rawls.model.Attributable.{workspaceIdAttribute, AttributeMap}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
@@ -95,7 +96,8 @@ object WorkspaceService {
                   fastPassServiceConstructor: (RawlsRequestContext, SlickDataSource) => FastPassService,
                   policyService: PolicyService,
                   workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService,
-                  entityServiceConstructor: RawlsRequestContext => EntityService
+                  entityServiceConstructor: RawlsRequestContext => EntityService,
+                  bardService: BardService
   )(
     ctx: RawlsRequestContext
   )(implicit materializer: Materializer, executionContext: ExecutionContext): WorkspaceService =
@@ -127,7 +129,8 @@ object WorkspaceService {
       new WorkspaceSettingRepository(dataSource),
       policyService,
       (context: RawlsRequestContext) => workspaceSettingServiceConstructor(context),
-      (context: RawlsRequestContext) => entityServiceConstructor(context)
+      (context: RawlsRequestContext) => entityServiceConstructor(context),
+      bardService: BardService
     )
 
   val SECURITY_LABEL_KEY: String = "security"
@@ -177,7 +180,8 @@ class WorkspaceService(
   val workspaceSettingsRepository: WorkspaceSettingRepository,
   policyService: PolicyService,
   workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService,
-  entityServiceConstructor: RawlsRequestContext => EntityService
+  entityServiceConstructor: RawlsRequestContext => EntityService,
+  bardService: BardService
 )(implicit protected val executionContext: ExecutionContext)
     extends LazyLogging
     with UserWiths
@@ -653,6 +657,13 @@ class WorkspaceService(
         logger.info(s"failure aborting workflows while deleting workspace ${workspace.toWorkspaceName}", t)
       case _ => /* ok */
     }
+    val workspaceDeleteEvent = WorkspaceDeleteEvent(
+      workspaceId = workspace.workspaceId,
+      workspaceNamespace = workspace.namespace,
+      workspaceName = workspace.name,
+      userSubjectId = ctx.userInfo.userSubjectId.value
+    )
+    bardService.sendEvent(workspaceDeleteEvent, ctx.userInfo)
     WorkspaceDeletionResult.fromGcpBucketName(workspace.bucketName)
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, TestDriverCom
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.google.MockGoogleAccessContextManagerDAO
 import org.broadinstitute.dsde.rawls.jobexec.{SubmissionMonitorConfig, SubmissionSupervisor}
-import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
+import org.broadinstitute.dsde.rawls.metrics.{BardService, RawlsStatsDTestUtils}
 import org.broadinstitute.dsde.rawls.mock._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
@@ -242,6 +242,8 @@ class FastPassMonitorSpec
 
     val entityServiceConstructor: RawlsRequestContext => EntityService = _ => mock[EntityService](RETURNS_SMART_NULLS)
 
+    val bardService: BardService = new MockBardService()
+
     val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,
       executionServiceCluster,
@@ -265,7 +267,8 @@ class FastPassMonitorSpec
       fastPassServiceConstructor,
       policyService,
       workspaceSettingServiceConstructor,
-      entityServiceConstructor
+      entityServiceConstructor,
+      bardService
     ) _
 
     def cleanupSupervisor =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -282,6 +282,8 @@ class FastPassServiceSpec
     )
     val entityServiceConstructor: RawlsRequestContext => EntityService = _ => entityService
 
+    val bardService = new MockBardService();
+
     val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,
       executionServiceCluster,
@@ -305,7 +307,8 @@ class FastPassServiceSpec
       fastPassServiceConstructor,
       policyService,
       workspaceSettingServiceConstructor,
-      entityServiceConstructor
+      entityServiceConstructor,
+      bardService
     ) _
 
     def cleanupSupervisor =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
@@ -242,6 +242,7 @@ class SubmissionsServiceSpec
     val workspaceSettingRepository = new WorkspaceSettingRepository(slickDataSource)
     val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService = _ =>
       mock[WorkspaceSettingService](RETURNS_SMART_NULLS)
+    val bardService = new MockBardService();
     val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,
       executionServiceCluster,
@@ -265,7 +266,8 @@ class SubmissionsServiceSpec
       fastPassServiceConstructor,
       policyService,
       workspaceSettingServiceConstructor,
-      entityServiceConstructor
+      entityServiceConstructor,
+      bardService
     ) _
 
     val methodRepoDAO = new HttpMethodRepoDAO(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -318,6 +318,7 @@ trait ApiServiceSpec
       terraBucketWriterRole = "fakeTerraBucketWriterRole"
     ) _
 
+    val bardService = new MockBardService();
     override val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,
       executionServiceCluster,
@@ -341,7 +342,8 @@ trait ApiServiceSpec
       fastPassServiceConstructor,
       policyService,
       workspaceSettingServiceConstructor,
-      entityServiceConstructor
+      entityServiceConstructor,
+      bardService
     ) _
 
     override val workspaceAdminServiceConstructor: RawlsRequestContext => WorkspaceAdminService =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -49,7 +49,12 @@ import org.broadinstitute.dsde.rawls.submissions.SubmissionsService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice._
-import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, RawlsTestUtils, TestExecutionContext}
+import org.broadinstitute.dsde.rawls.{
+  NoSuchWorkspaceException,
+  RawlsExceptionWithErrorReport,
+  RawlsTestUtils,
+  TestExecutionContext
+}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.google.iam.IamMemberTypes
@@ -1372,16 +1377,16 @@ class WorkspaceServiceSpec
   }
 
   it should "log to bard when deleting workspace" in withTestDataServices { services =>
-      // delete the workspace
-      Await.result(services.workspaceService.deleteWorkspace(testData.wsName3), Duration.Inf)
+    // delete the workspace
+    Await.result(services.workspaceService.deleteWorkspace(testData.wsName3), Duration.Inf)
 
-      val deleteEvent = WorkspaceDeleteEvent(
-        testData.workspaceNoSubmissions.workspaceId,
-        testData.workspaceNoSubmissions.namespace,
-        testData.workspaceNoSubmissions.name,
-        testContext.userInfo.userSubjectId.value
-      )
-      verify(services.bardService).sendEvent(deleteEvent, testContext.userInfo)
+    val deleteEvent = WorkspaceDeleteEvent(
+      testData.workspaceNoSubmissions.workspaceId,
+      testData.workspaceNoSubmissions.namespace,
+      testData.workspaceNoSubmissions.name,
+      services.ctx1.userInfo.userSubjectId.value
+    )
+    verify(services.bardService).sendEvent(deleteEvent, services.ctx1.userInfo)
   }
 
   behavior of "getTags"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -317,6 +317,7 @@ class WorkspaceServiceSpec
                                 Option(mockWorkspaceSettingRepository)
       ) _
 
+    val bardService = new MockBardService();
     val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,
       executionServiceCluster,
@@ -340,7 +341,8 @@ class WorkspaceServiceSpec
       fastPassServiceConstructor,
       policyService,
       workspaceSettingServiceConstructor,
-      entityServiceConstructor
+      entityServiceConstructor,
+      bardService
     ) _
 
     val methodRepoDAO = new HttpMethodRepoDAO(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -32,7 +32,8 @@ import org.broadinstitute.dsde.rawls.fastpass.{FastPassServiceImpl, MockFastPass
 import org.broadinstitute.dsde.rawls.google.MockGoogleAccessContextManagerDAO
 import org.broadinstitute.dsde.rawls.jobexec.{SubmissionMonitorConfig, SubmissionSupervisor}
 import org.broadinstitute.dsde.rawls.methods.MethodConfigurationService
-import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
+import org.broadinstitute.dsde.rawls.metrics.{BardService, RawlsStatsDTestUtils}
+import org.broadinstitute.dsde.rawls.metrics.logEvents.WorkspaceDeleteEvent
 import org.broadinstitute.dsde.rawls.mock._
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.ProjectPoolType.ProjectPoolType
@@ -48,12 +49,7 @@ import org.broadinstitute.dsde.rawls.submissions.SubmissionsService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice._
-import org.broadinstitute.dsde.rawls.{
-  NoSuchWorkspaceException,
-  RawlsExceptionWithErrorReport,
-  RawlsTestUtils,
-  TestExecutionContext
-}
+import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, RawlsTestUtils, TestExecutionContext}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.google.iam.IamMemberTypes
@@ -317,7 +313,7 @@ class WorkspaceServiceSpec
                                 Option(mockWorkspaceSettingRepository)
       ) _
 
-    val bardService = new MockBardService();
+    val bardService = mock[BardService](RETURNS_SMART_NULLS)
     val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,
       executionServiceCluster,
@@ -1373,6 +1369,19 @@ class WorkspaceServiceSpec
     assertResult(Some(StatusCodes.BadRequest)) {
       error.errorReport.statusCode
     }
+  }
+
+  it should "log to bard when deleting workspace" in withTestDataServices { services =>
+      // delete the workspace
+      Await.result(services.workspaceService.deleteWorkspace(testData.wsName3), Duration.Inf)
+
+      val deleteEvent = WorkspaceDeleteEvent(
+        testData.workspaceNoSubmissions.workspaceId,
+        testData.workspaceNoSubmissions.namespace,
+        testData.workspaceNoSubmissions.name,
+        testContext.userInfo.userSubjectId.value
+      )
+      verify(services.bardService).sendEvent(deleteEvent, testContext.userInfo)
   }
 
   behavior of "getTags"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -9,6 +9,8 @@ import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.entities.EntityService
 import org.broadinstitute.dsde.rawls.fastpass.FastPassService
+import org.broadinstitute.dsde.rawls.metrics.BardService
+import org.broadinstitute.dsde.rawls.mock.MockBardService
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.GcpBucketRequesterPaysConfig
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.GcpBucketRequesterPays
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.WorkspaceType
@@ -108,7 +110,8 @@ class WorkspaceServiceUnitTests
     policyService: PolicyService = mock[PolicyService](RETURNS_SMART_NULLS),
     workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService = _ =>
       mock[WorkspaceSettingService](RETURNS_SMART_NULLS),
-    entityServiceConstructor: RawlsRequestContext => EntityService = _ => mock[EntityService](RETURNS_SMART_NULLS)
+    entityServiceConstructor: RawlsRequestContext => EntityService = _ => mock[EntityService](RETURNS_SMART_NULLS),
+    bardService: BardService = new MockBardService()
   ): RawlsRequestContext => WorkspaceService = info =>
     new WorkspaceService(
       info,
@@ -138,7 +141,8 @@ class WorkspaceServiceUnitTests
       workspaceSettingRepository,
       policyService,
       workspaceSettingServiceConstructor,
-      entityServiceConstructor
+      entityServiceConstructor,
+      bardService
     )(scala.concurrent.ExecutionContext.global)
 
   behavior of "getWorkspaceById"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUpdateAclSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUpdateAclSpec.scala
@@ -9,6 +9,8 @@ import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.entities.EntityService
 import org.broadinstitute.dsde.rawls.fastpass.FastPassService
+import org.broadinstitute.dsde.rawls.metrics.BardService
+import org.broadinstitute.dsde.rawls.mock.MockBardService
 import org.broadinstitute.dsde.rawls.model.{
   RawlsRequestContext,
   RawlsUserEmail,
@@ -103,7 +105,8 @@ class WorkspaceServiceUpdateAclSpec extends AnyFlatSpecLike with MockitoSugar wi
     policyService: PolicyService = mock[PolicyService](RETURNS_SMART_NULLS),
     workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService = _ =>
       mock[WorkspaceSettingService](RETURNS_SMART_NULLS),
-    entityServiceConstructor: RawlsRequestContext => EntityService = _ => mock[EntityService](RETURNS_SMART_NULLS)
+    entityServiceConstructor: RawlsRequestContext => EntityService = _ => mock[EntityService](RETURNS_SMART_NULLS),
+    bardService: BardService = new MockBardService()
   ): RawlsRequestContext => WorkspaceService = info =>
     new WorkspaceService(
       info,
@@ -133,7 +136,8 @@ class WorkspaceServiceUpdateAclSpec extends AnyFlatSpecLike with MockitoSugar wi
       workspaceSettingRepository,
       policyService,
       workspaceSettingServiceConstructor,
-      entityServiceConstructor
+      entityServiceConstructor,
+      bardService
     )(scala.concurrent.ExecutionContext.global)
 
   // Return mocks with reasonable defaults for basic usage. Override mocked behavior as needed.


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-711

Add a Bard event for when Rawls deletes a workspace. Because the Bard logs may get sent to MixPanel in addition to the BigQuery data warehouse, this just includes the user's terra id and not their email address. In order to identify the user, we can join to the warehouse email table. Note that table does not include deleted Terra users, but perhaps we can change this behavior as part of another ticket.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
