### PR TITLE
CORE-667: Quicksilver migration returns 204 if workspace is already migrated

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityModel.scala
@@ -97,3 +97,5 @@ case class QuicksilverMigrationResult(
   numEntitiesDeleted: Int,
   numAttributesDeleted: Int
 )
+
+class QuicksilverAlreadyMigratedException extends Exception

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.AttributeKey
 import org.apache.commons.lang3.time.StopWatch
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{
   DataAccess,
+  QuicksilverAlreadyMigratedException,
   QuicksilverMigrationResult,
   ReadAction,
   ReadWriteAction
@@ -634,11 +635,8 @@ class EntityService(protected val ctx: RawlsRequestContext,
             .asInstanceOf[Option[CompactDataTablesSetting]]
             .exists(_.config.enabled)
         ) {
-          throw new RawlsExceptionWithErrorReport(
-            ErrorReport(StatusCodes.Conflict,
-                        s"Quicksilver migration $workspaceId failed: Quicksilver already enabled for this workspace"
-            )
-          )
+          logger.info(s"Quicksilver migration $workspaceId skipped: Quicksilver already enabled for this workspace")
+          throw new QuicksilverAlreadyMigratedException
         }
 
         // Check if there are any pending compactDataTables settings for this workspace

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -635,7 +635,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
             .exists(_.config.enabled)
         ) {
           throw new RawlsExceptionWithErrorReport(
-            ErrorReport(s"Quicksilver migration $workspaceId failed: Quicksilver already enabled for this workspace")
+            ErrorReport(StatusCodes.Conflict,
+                        s"Quicksilver migration $workspaceId failed: Quicksilver already enabled for this workspace"
+            )
           )
         }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -10,7 +10,7 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import io.opentelemetry.context.Context
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
-import org.broadinstitute.dsde.rawls.dataaccess.slick.QuicksilverMigrationResult
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{QuicksilverAlreadyMigratedException, QuicksilverMigrationResult}
 import org.broadinstitute.dsde.rawls.entities.{EntityService, EntityStreamingUtils}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
   AttributeUpdateOperation,
@@ -364,6 +364,13 @@ trait EntityApiService extends UserInfoDirectives {
                                           cleanup = cleanup,
                                           sortBufferSize = sortBufferSize
                     )
+                    .map { result =>
+                      StatusCodes.OK -> Option(result)
+                    }
+                    .recover { case _: QuicksilverAlreadyMigratedException =>
+                      // this workspace was already Quicksilver-enabled. Treat this as a noop success.
+                      StatusCodes.NoContent -> None
+                    }
                 }
               }
             }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceCompactMigrationSpec.scala
@@ -8,7 +8,12 @@ import cats.effect.unsafe.implicits.global
 import com.typesafe.config.ConfigFactory
 import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{QuicksilverMigrationResult, RawSqlQuery, TestDriverComponent}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{
+  QuicksilverAlreadyMigratedException,
+  QuicksilverMigrationResult,
+  RawSqlQuery,
+  TestDriverComponent
+}
 import org.broadinstitute.dsde.rawls.dataaccess.{
   GoogleBigQueryServiceFactoryImpl,
   MockBigQueryServiceFactory,
@@ -449,6 +454,23 @@ class EntityServiceCompactMigrationSpec
     Await.result(repo.getWorkspaceSettingOfType(workspace.workspaceIdAsUUID, CompactDataTables),
                  Duration.Inf
     ) shouldBe empty
+
+  }
+
+  it should s"throw QuicksilverAlreadyMigratedException if the workspace has already been migrated" in withTestDataServices {
+    apiService =>
+      val workspace = legacyTestData.workspace // has some entities we can use to test references
+
+      // perform migration
+      val migrationResult =
+        Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName), atMost)
+
+      migrationResult shouldBe QuicksilverMigrationResult(18, 0, 0)
+
+      // perform migration again
+      intercept[QuicksilverAlreadyMigratedException] {
+        Await.result(apiService.entityService.quicksilverMigration(workspace.toWorkspaceName), atMost)
+      }
 
   }
 


### PR DESCRIPTION
Ticket: CORE-667

The Quicksilver migration API will now return a 204 instead of a 500 if the workspace is already Quicksilver-enabled.

This change:
* prevents any spurious exceptions to Sentry or alerts
* makes it easy for a batch-migration script to detect this condition