### PR TITLE
CORE-717: more granularity, higher max for Quicksilver latency metrics

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderMetrics.scala
@@ -5,6 +5,7 @@ import io.opentelemetry.api.common.{AttributeKey, Attributes}
 import io.opentelemetry.api.metrics.{DoubleHistogram, LongCounter, LongHistogram}
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 
+import java.util.stream.DoubleStream
 import scala.jdk.CollectionConverters._
 
 trait EntityProviderMetrics extends RawlsInstrumented {
@@ -15,8 +16,32 @@ trait EntityProviderMetrics extends RawlsInstrumented {
   private val ProviderNameKey = AttributeKey.stringKey("providername")
   private val ErrorClassKey = AttributeKey.stringKey("errortype")
 
-  private val BucketBoundaries =
-    List[java.lang.Double](0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0).asJava
+  // every 10ms up to 100ms, then every 190ms up to 2s (190 ends neatly at 2s), then every 2s up to
+  // 10s, then every 20s up to 9m
+  private val BucketBoundaries: java.util.List[
+    java.lang.Double
+  ] = // does all the math in terms of milliseconds, then converts to seconds, otherwise the
+    // precision is wonky
+    DoubleStream
+      .iterate(10,
+               (d: Double) => d < 60000 * 9,
+               (d: Double) => {
+                 def foo(d: Double): Double =
+                   if (d < 100) {
+                     d + 10
+                   } else if (d < 2000) {
+                     d + 190
+                   } else if (d < 10000) {
+                     d + 2000
+                   } else
+                     d + 20000
+
+                 foo(d)
+               }
+      )
+      .map((d: Double) => d / 1000.0)
+      .boxed
+      .toList
 
   private def meter = GlobalOpenTelemetry.get().getMeter("RawlsMetrics")
 


### PR DESCRIPTION
Ticket: CORE-717

Quicksilver latency metrics now have more granularity and a higher upper limit. Before this PR, the available buckets did not give us the granularity necessary to properly visualize latencies; the graphs top out at 10 seconds and many of them show a "step function" as shown in the screenshot:

<img width="3334" height="1784" alt="Screenshot 07-10-2025 at 12 14" src="https://github.com/user-attachments/assets/645cc2cb-0471-41d7-b16f-e3edd19391d6" />


