### PR TITLE
CORE-724: allow adding entity references to an empty list

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -47,6 +47,7 @@ import org.broadinstitute.dsde.rawls.model.{
 }
 import org.broadinstitute.dsde.rawls.util.TracingUtils._
 import org.broadinstitute.dsde.rawls.util.{
+  AttributeOperationListModes,
   AttributeSupport,
   AttributeUpdateOperationException,
   CollectionUtils,
@@ -557,12 +558,13 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
                 entityUpdates.map { entityUpdate =>
                   entityUpdate -> (entitiesByName.get((entityUpdate.entityType, entityUpdate.name)) match {
                     case Some(e) =>
-                      Try(applyOperationsToEntity(e, entityUpdate.operations))
+                      Try(applyOperationsToEntity(e, entityUpdate.operations, AttributeOperationListModes.Strict))
                     case None =>
                       if (upsert) {
                         Try(
                           applyOperationsToEntity(Entity(entityUpdate.name, entityUpdate.entityType, Map.empty),
-                                                  entityUpdate.operations
+                                                  entityUpdate.operations,
+                                                  AttributeOperationListModes.Strict
                           )
                         )
                       } else {
@@ -804,7 +806,7 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
       traceDBIOWithParent("withEntity", parentContext) { s =>
         withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
           val updateAction = Try {
-            val updatedEntity = applyOperationsToEntity(entity, operations)
+            val updatedEntity = applyOperationsToEntity(entity, operations, AttributeOperationListModes.Strict)
             traceDBIOWithParent("saveEntity", s)(_ => dataAccess.entityQuery.save(workspaceContext, updatedEntity))
           } match {
             case Success(result) => result

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/AttributeSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/AttributeSupport.scala
@@ -96,7 +96,11 @@ trait AttributeSupport {
                 case newMember: AttributeValue =>
                   startingAttributes + (attributeListName -> AttributeValueList(Seq(newMember)))
                 case newMember: AttributeEntityReference =>
-                  throw new AttributeUpdateOperationException("Cannot add non-value to list of values.")
+                  // When an entity has an attribute with a value of `[]`, Quicksilver cannot distinguish
+                  // if that value is a AttributeValueList or a AttributeEntityReferenceList, and by default
+                  // it deserializes it as AttributeValueList. So, here, we allow adding entity references
+                  // to an AttributeValueList, which converts it to a AttributeEntityReferenceList.
+                  startingAttributes + (attributeListName -> AttributeEntityReferenceList(Seq(newMember)))
                 case _ => throw new AttributeUpdateOperationException("Cannot create list with that type.")
               }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/AttributeSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/AttributeSupport.scala
@@ -26,6 +26,10 @@ import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
   MethodConfiguration
 }
+import org.broadinstitute.dsde.rawls.util.AttributeOperationListModes.{
+  AllowAddingReferencesToEmptyList,
+  AttributeOperationListMode
+}
 
 import scala.concurrent.Future
 
@@ -65,7 +69,8 @@ trait AttributeSupport {
   }
 
   def applyAttributeUpdateOperations(attributable: Attributable,
-                                     operations: Seq[AttributeUpdateOperation]
+                                     operations: Seq[AttributeUpdateOperation],
+                                     listMode: AttributeOperationListMode = AllowAddingReferencesToEmptyList
   ): AttributeMap =
     operations.foldLeft(attributable.attributes) { (startingAttributes, operation) =>
       operation match {
@@ -96,11 +101,17 @@ trait AttributeSupport {
                 case newMember: AttributeValue =>
                   startingAttributes + (attributeListName -> AttributeValueList(Seq(newMember)))
                 case newMember: AttributeEntityReference =>
-                  // When an entity has an attribute with a value of `[]`, Quicksilver cannot distinguish
-                  // if that value is a AttributeValueList or a AttributeEntityReferenceList, and by default
-                  // it deserializes it as AttributeValueList. So, here, we allow adding entity references
-                  // to an AttributeValueList, which converts it to a AttributeEntityReferenceList.
-                  startingAttributes + (attributeListName -> AttributeEntityReferenceList(Seq(newMember)))
+                  listMode match {
+                    case AttributeOperationListModes.Strict =>
+                      throw new AttributeUpdateOperationException("Cannot add non-value to list of values.")
+                    case AttributeOperationListModes.AllowAddingReferencesToEmptyList =>
+                      // When an entity has an attribute with a value of `[]`, Quicksilver cannot distinguish
+                      // if that value is a AttributeValueList or a AttributeEntityReferenceList, and by default
+                      // it deserializes it as AttributeValueList. So, here, we allow adding entity references
+                      // to an AttributeValueList, which converts it to a AttributeEntityReferenceList.
+                      startingAttributes + (attributeListName -> AttributeEntityReferenceList(Seq(newMember)))
+                  }
+
                 case _ => throw new AttributeUpdateOperationException("Cannot create list with that type.")
               }
 
@@ -179,8 +190,22 @@ trait AttributeSupport {
    * @throws AttributeUpdateOperationException when adding or removing from an attribute that is not a list
    * @return the updated entity
    */
-  def applyOperationsToEntity(entity: Entity, operations: Seq[AttributeUpdateOperation]): Entity =
-    entity.copy(attributes = applyAttributeUpdateOperations(entity, operations))
+  def applyOperationsToEntity(entity: Entity,
+                              operations: Seq[AttributeUpdateOperation],
+                              listMode: AttributeOperationListMode = AllowAddingReferencesToEmptyList
+  ): Entity =
+    entity.copy(attributes = applyAttributeUpdateOperations(entity, operations, listMode))
+}
+
+object AttributeOperationListModes extends Enumeration {
+  type AttributeOperationListMode = Value
+  /*
+   * AllowAddingReferencesToEmptyList: attempting to add an AttributeEntityReference as a list member to an
+   *  AttributeEmptyValueList is allowed and results in an AttributeEntityReferenceList
+   * Strict: attempting to add an AttributeEntityReference as a list member to an
+   *  AttributeEmptyValueList is not allowed and throws an exception.
+   */
+  val AllowAddingReferencesToEmptyList, Strict = Value
 }
 
 class AttributeUpdateOperationException(message: String) extends RawlsException(message)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -43,6 +43,7 @@ import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.TracingUtils._
 import org.broadinstitute.dsde.rawls.util.{
   AttributeNotFoundException,
+  AttributeOperationListModes,
   AttributeSupport,
   AttributeUpdateOperationException,
   BillingProjectSupport,
@@ -1654,7 +1655,9 @@ class WorkspaceService(
    * @return the updated entity
    */
   private def applyOperationsToWorkspace(workspace: Workspace, operations: Seq[AttributeUpdateOperation]): Workspace =
-    workspace.copy(attributes = applyAttributeUpdateOperations(workspace, operations))
+    workspace.copy(attributes =
+      applyAttributeUpdateOperations(workspace, operations, AttributeOperationListModes.Strict)
+    )
 
   private def getGoogleBucketPermissionsFromRoles(workspaceRoles: Set[SamResourceRole]): Future[Set[IamPermission]] = {
     val googleRole = if (workspaceRoles.intersect(SamWorkspaceRoles.rolesContainingWritePermissions).nonEmpty) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -1554,6 +1554,70 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
+  it should "allow adding references to a pre-existing empty list" in withTestDataApiServices { services =>
+    val entityName = "new-entity-empty-list"
+
+    // update 1: create an entity with an empty list
+    val update1 = EntityUpdateDefinition(
+      entityName,
+      testData.sample1.entityType,
+      Seq(AddUpdateAttribute(AttributeName.withDefaultNS("list"), AttributeValueEmptyList))
+    )
+    Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1))) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
+      check {
+        assertResult(StatusCodes.NoContent) {
+          status
+        }
+        assertResult(
+          Some(
+            Entity(
+              entityName,
+              testData.sample1.entityType,
+              Map(AttributeName.withDefaultNS("list") -> AttributeValueEmptyList)
+            )
+          )
+        ) {
+          runAndWait(
+            compactEntityRepository.queries.getEntity(testData.workspace.workspaceIdAsUUID,
+                                                      testData.sample1.entityType,
+                                                      entityName
+            )
+          ).map(_.toEntity)
+        }
+      }
+    // update 2: update that entity by adding a reference to the empty list
+    val ref = AttributeEntityReference(testData.sample1.entityType, testData.sample1.name)
+    val update2 = EntityUpdateDefinition(
+      entityName,
+      testData.sample1.entityType,
+      Seq(AddListMember(AttributeName.withDefaultNS("list"), ref))
+    )
+    Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update2))) ~>
+      sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
+      check {
+        assertResult(StatusCodes.NoContent) {
+          status
+        }
+        assertResult(
+          Some(
+            Entity(
+              entityName,
+              testData.sample1.entityType,
+              Map(AttributeName.withDefaultNS("list") -> AttributeEntityReferenceList(Seq(ref)))
+            )
+          )
+        ) {
+          runAndWait(
+            compactEntityRepository.queries.getEntity(testData.workspace.workspaceIdAsUUID,
+                                                      testData.sample1.entityType,
+                                                      entityName
+            )
+          ).map(_.toEntity)
+        }
+      }
+  }
+
   it should "return 200 on get entity" in withTestDataApiServices { services =>
     withStatsD {
       Get(testData.sample2.path(testData.workspace)) ~>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -1561,7 +1561,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val update1 = EntityUpdateDefinition(
       entityName,
       testData.sample1.entityType,
-      Seq(AddUpdateAttribute(AttributeName.withDefaultNS("list"), AttributeValueEmptyList))
+      Seq(CreateAttributeEntityReferenceList(AttributeName.withDefaultNS("samples")))
     )
     Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1))) ~>
       sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
@@ -1574,7 +1574,9 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             Entity(
               entityName,
               testData.sample1.entityType,
-              Map(AttributeName.withDefaultNS("list") -> AttributeValueEmptyList)
+              // note that even though update1 asked to create an empty reference list with CreateAttributeEntityReferenceList,
+              // what gets written to the db is `[]`, which Quicksilver interprets as AttributeValueEmptyList
+              Map(AttributeName.withDefaultNS("samples") -> AttributeValueEmptyList)
             )
           )
         ) {
@@ -1591,7 +1593,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val update2 = EntityUpdateDefinition(
       entityName,
       testData.sample1.entityType,
-      Seq(AddListMember(AttributeName.withDefaultNS("list"), ref))
+      Seq(AddListMember(AttributeName.withDefaultNS("samples"), ref))
     )
     Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update2))) ~>
       sealRoute(services.entityRoutes(userInfo = userInfo)) ~>
@@ -1604,7 +1606,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             Entity(
               entityName,
               testData.sample1.entityType,
-              Map(AttributeName.withDefaultNS("list") -> AttributeEntityReferenceList(Seq(ref)))
+              Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(ref)))
             )
           )
         ) {


### PR DESCRIPTION
Ticket: CORE-724

Quicksilver has incorrect behavior when a user uploads an entity TSV to create an empty set, followed by a membership TSV to add references to that set.

The TSV parsing happens in Orchestration and has not/should not change.

Assume the user has no pre-existing `sample_set` entities, but does have a `sample` entity named `sample1`.

The user uploads a simple entity TSV to create a new sample set. The TSV contains:
```tsv
membership:sample_set_id	sample
set1	sample1
```
which Orchestration converts to a payload for Rawls' batchUpsert API:
```json
[
  {
    "entityType": "sample_set",
    "name": "set1",
    "operations": [
      {
        "op": "CreateAttributeEntityReferenceList",
        "attributeListName": "samples"
      }
    ]
  }
]
```
Rawls accepts this payload and creates a `sample_set` entity. In Quicksilver, this is serialized to the database as:
```json
{"v": 2, "refs": [], "attrs": {"samples": []}}
```

Next, the user uploads a membership TSV:
```tsv
membership:sample_set_id	sample
set1	sample1
```
which Orchestration translates into a Rawls batchUpsert payload of:
```json
[
  {
    "entityType": "sample_set",
    "name": "set1",
    "operations": [
      {
        "op": "AddListMember",
        "attributeListName": "samples",
        "newMember": {
          "entityType": "sample",
          "entityName": "sample1"
        }
      }
    ]
  }
]
```

The problem occurs in this membership payload when Rawls attempts to apply the `AddListMember` operation to the existing entity. The `AddListMember` wants to add a new `AttributeEntityReference` to the existing empty list.

However, when Rawls/Quicksilver deserializes the existing entity from the db, it sees an attribute of `"samples": []`. It cannot distinguish from the `[]` whether the value should be a an empty list of _values_ (`AttributeValueEmptyList`) or an empty list of _references_ (`AttributeEntityReferenceEmptyList`). It deserializes to an `AttributeValueEmptyList`. This means it is trying to add an `AttributeEntityReference` to an `AttributeValueEmptyList`, which is illegal.

This PR changes the behavior - for Quicksilver only - to allow adding an `AttributeEntityReference` to an `AttributeValueEmptyList`, which results in a populated `AttributeEntityReferenceList`. This feels safe - since the list was empty in the first place, it should not cause any problems in the data.

