### PR TITLE
CORE-725: mass migrate zero-entity workspaces to Quicksilver

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -148,4 +148,5 @@
     <include file="changesets/20250807_drop_entity_keys.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250821_remove_all_gcpbatch_workspace_settings_again.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250912_workflow_actual_cost.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20251009_quicksilver_for_empty_workspaces.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20251009_quicksilver_for_empty_workspaces.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20251009_quicksilver_for_empty_workspaces.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
+    <changeSet logicalFilePath="dummy" author="davidan" id="quicksilver_for_empty_workspaces.xml">
+        <sql>
+        <!-- Insert a CompactDataTables workspace setting for all v2 workspaces which have zero entities.
+                If a workspace has no entities, it does not need any complicated migration to Quicksilver;
+                it just needs the appropriate workspace setting.
+         -->
+            insert into WORKSPACE_SETTINGS(
+                WORKSPACE_ID, SETTING_TYPE, CONFIG, STATUS, USER_ID)
+            select w.id, 'CompactDataTables', '{"enabled": true, "performMigration": false}', 'Applied', 'quicksilver-migration'
+            from WORKSPACE w
+            where w.WORKSPACE_VERSION = 'v2'
+              and (w.ID not in (
+                select s.WORKSPACE_ID
+                from WORKSPACE_SETTINGS s
+                where s.SETTING_TYPE = 'CompactDataTables'
+            ))
+              and not exists (
+                SELECT 1
+                FROM ENTITY e
+                WHERE e.workspace_id = w.id
+            );
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Ticket: CORE-725

Migrates ~36,000 workspaces to Quicksilver. Specifically, this PR migrates all workspaces which:
* have zero data entities, and thus don't need a complicated migration
* do not already have a Quicksilver setting

On a clone of the production db, the insert statement ran in just under one second.