### PR TITLE
[CORE-512] Do not allow locking workspaces with paused cloud environments

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/leonardo/LeonardoService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/leonardo/LeonardoService.scala
@@ -50,7 +50,13 @@ class LeonardoService(leonardoDAO: LeonardoDAO)(implicit
     ec: ExecutionContext
   ): Future[Seq[ListAppResponse]] =
     getAllApps(workspace, ctx).map { allApps =>
-      val statuses = Set(AppStatus.RUNNING, AppStatus.PROVISIONING, AppStatus.STARTING, AppStatus.DELETING);
+      val statuses = Set(AppStatus.RUNNING,
+                         AppStatus.PROVISIONING,
+                         AppStatus.STARTING,
+                         AppStatus.STOPPED,
+                         AppStatus.STOPPING,
+                         AppStatus.DELETING
+      );
       allApps.filter(app => statuses.contains(app.getStatus));
     }
 
@@ -69,12 +75,14 @@ class LeonardoService(leonardoDAO: LeonardoDAO)(implicit
     ec: ExecutionContext
   ): Future[Seq[ListRuntimeResponse]] =
     getAllRuntimes(workspace, ctx).map { allRuntimes =>
-      val statuses = Set(ClusterStatus.RUNNING,
-                         ClusterStatus.STARTING,
-                         ClusterStatus.STOPPING,
-                         ClusterStatus.CREATING,
-                         ClusterStatus.UPDATING,
-                         ClusterStatus.DELETING
+      val statuses = Set(
+        ClusterStatus.RUNNING,
+        ClusterStatus.STARTING,
+        ClusterStatus.STOPPING,
+        ClusterStatus.STOPPED,
+        ClusterStatus.CREATING,
+        ClusterStatus.UPDATING,
+        ClusterStatus.DELETING
       );
       allRuntimes.filter(runtime => statuses.contains(runtime.getStatus));
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/leonardo/LeonardoServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/leonardo/LeonardoServiceSpec.scala
@@ -126,6 +126,7 @@ class LeonardoServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers wi
           new ListAppResponse().status(AppStatus.PROVISIONING),
           new ListAppResponse().status(AppStatus.STARTING),
           new ListAppResponse().status(AppStatus.RUNNING),
+          new ListAppResponse().status(AppStatus.STOPPED),
           new ListAppResponse().status(AppStatus.DELETING),
           new ListAppResponse().status(AppStatus.DELETED)
         )
@@ -133,10 +134,11 @@ class LeonardoServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers wi
 
     val action = new LeonardoService(leoDAO)
     val result = Await.result(action.listRunningApps(googleWorkspace, ctx), Duration.Inf)
-    result.size shouldBe 4
+    result.size shouldBe 5
     result.map(_.getStatus) shouldBe Seq(AppStatus.PROVISIONING,
                                          AppStatus.STARTING,
                                          AppStatus.RUNNING,
+                                         AppStatus.STOPPED,
                                          AppStatus.DELETING
     )
     verify(leoDAO).listApps(anyString(), ArgumentMatchers.eq(googleWorkspace.googleProjectId))
@@ -144,12 +146,11 @@ class LeonardoServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers wi
 
   it should "not list stopped or deleted apps" in {
     val runningAppResponse = new ListAppResponse().status(AppStatus.DELETED)
-    val stoppedAppResponse = new ListAppResponse().status(AppStatus.STOPPED)
     val statusUnspecifiedAppResponse = new ListAppResponse().status(AppStatus.STATUS_UNSPECIFIED)
     val errorAppResponse = new ListAppResponse().status(AppStatus.ERROR)
     val leoDAO: MockLeonardoDAO = Mockito.spy(new MockLeonardoDAO() {
       override def listApps(token: String, googleProjectId: GoogleProjectId): Seq[ListAppResponse] =
-        Seq(runningAppResponse, stoppedAppResponse, statusUnspecifiedAppResponse, errorAppResponse)
+        Seq(runningAppResponse, statusUnspecifiedAppResponse, errorAppResponse)
     })
 
     val action = new LeonardoService(leoDAO)
@@ -169,6 +170,7 @@ class LeonardoServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers wi
           ClusterStatus.UPDATING,
           ClusterStatus.STARTING,
           ClusterStatus.STOPPING,
+          ClusterStatus.STOPPED,
           ClusterStatus.DELETING,
           ClusterStatus.DELETED
         )
@@ -182,13 +184,15 @@ class LeonardoServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers wi
 
     val action = new LeonardoService(leoDAO)
     val result = Await.result(action.listRunningRuntimes(googleWorkspace, ctx), Duration.Inf)
-    result.size shouldBe 6
-    result.map(_.getStatus) shouldBe Seq(ClusterStatus.CREATING,
-                                         ClusterStatus.RUNNING,
-                                         ClusterStatus.UPDATING,
-                                         ClusterStatus.STARTING,
-                                         ClusterStatus.STOPPING,
-                                         ClusterStatus.DELETING
+    result.size shouldBe 7
+    result.map(_.getStatus) shouldBe Seq(
+      ClusterStatus.CREATING,
+      ClusterStatus.RUNNING,
+      ClusterStatus.UPDATING,
+      ClusterStatus.STARTING,
+      ClusterStatus.STOPPING,
+      ClusterStatus.STOPPED,
+      ClusterStatus.DELETING
     )
     verify(leoDAO).listRuntimes(anyString(), ArgumentMatchers.eq(googleWorkspace.googleProjectId))
   }
@@ -196,7 +200,7 @@ class LeonardoServiceSpec extends AnyFlatSpec with MockitoSugar with Matchers wi
   it should "not list stopped or deleted runtimes" in {
     val leoDAO: MockLeonardoDAO = Mockito.spy(new MockLeonardoDAO() {
       override def listRuntimes(token: String, googleProjectId: GoogleProjectId): Seq[ListRuntimeResponse] = {
-        val statuses = Seq(ClusterStatus.ERROR, ClusterStatus.STOPPED, ClusterStatus.DELETED, ClusterStatus.UNKNOWN)
+        val statuses = Seq(ClusterStatus.ERROR, ClusterStatus.DELETED, ClusterStatus.UNKNOWN)
         statuses.map { status =>
           new ListRuntimeResponse()
             .status(status)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-512

When a cloud environment is paused/stopped, it still incurs charges so we actually do not want to allow the user to lock the workspace. Notebooks are stored in the workspace bucket and will remain read-only even when the Jupyter cloud environment is deleted so users will not loose any work in that case.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
