### PR TITLE
CORE-726: listWorkflowEntities should return soft-deleted entities

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -200,7 +200,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         sql"""select id, name, entity_type, workspace_id, record_version, deleted, attributes
                from ENTITY
                where workspace_id = $workspaceId
-               and deleted = 0
                and id in ( """,
         inClause,
         sql""" );"""

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -265,6 +265,33 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     actual should contain theSameElementsAs selectedRecords
   }
 
+  it should "return soft-deleted entities" in withMinimalTestDatabase { dataSource =>
+    import driver.api._ // for Slick queries in this test
+
+    val entity1 = Entity("entityName1", "entityType", Map())
+    val entity2 = Entity("entityName2", "entityType", Map())
+    val entity3 = Entity("entityName3", "entityType", Map())
+
+    insertAndGetAll(Seq(entity1, entity2, entity3))
+
+    // soft-delete entity 2
+    val softDelete = runAndWait(dataSource.dataAccess.compactEntityQuery.batchHide(wsid, Seq(entity2.toPointer)))
+    softDelete shouldBe 1
+
+    // use the high-level Slick query object to get the actual rows saved to the database
+    val slickQuery: ReadAction[Seq[CompactEntityRecord]] = dataSource.dataAccess.compactEntitySlickQuery
+      .filter(e => e.workspaceId === wsid && e.entityType === entity1.entityType)
+      .result
+
+    val records: Seq[CompactEntityRecord] = runAndWait(slickQuery)
+
+    val ids = records.map(_.id)
+
+    val actual = runAndWait(q.getEntitiesByIds(wsid, ids))
+
+    actual should contain theSameElementsAs records
+  }
+
   behavior of "existsAll and countExisting"
 
   it should "find the entities" in withMinimalTestDatabase { _ =>


### PR DESCRIPTION
Ticket: CORE-726

Fixes a bug that causes a Cromwell submission to hang, if a user deletes one of the entities used as input to that submission.

The SubmissionMonitor retrieves the submission's entities by calling EntityService.listWorkflowEntities, which delegates to the listWorkflowEntities() method in either LocalEntityProvider or CompactEntityProvider. 

CompactEntityProvider has a where deleted = 0 clause in its sql for this method, whereas LocalEntityProvider does not; this is the root cause of the behavior difference.
