### PR TITLE
CORE-723: sort by array column respects sort direction

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -1320,7 +1320,7 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           // the order of the columns here is also the sort precedence, list length first, then scalar value
           // Sorting on a list column should sort by the list size and sorting on a scalar column sorts on the column value.
           // If the column is a mixed type then all scalars will group together sorted by value then all the lists will follow sorted by size.
-          sql" JSON_LENGTH(e.attributes -> ${slickAttributePath(attr)}), e.attributes -> ${slickAttributePath(attr)}"
+          sql" JSON_LENGTH(e.attributes -> ${slickAttributePath(attr)}) #${SortDirections.toSql(entityQuery.sortDirection)}, e.attributes -> ${slickAttributePath(attr)}"
       },
       sql" #${SortDirections.toSql(entityQuery.sortDirection)}, name #${SortDirections.toSql(entityQuery.sortDirection)}"
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -2465,6 +2465,62 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
     actual should contain theSameElementsInOrderAs List(entity4, entity2, entity1, entity3)
   }
 
+  it should "sort by attribute list size descending" in withMinimalTestDatabase { _ =>
+    val entityType1 = "entityType1"
+    val testAttrName = AttributeName.withDefaultNS("foo")
+    val sortAttrName = AttributeName.withDefaultNS("sortMe")
+    val entity1 =
+      Entity(
+        UUID.randomUUID().toString,
+        entityType1,
+        Map(testAttrName -> AttributeString("foo"),
+            sortAttrName -> AttributeValueList(List.fill(7)(AttributeNumber(Random.nextInt())))
+        )
+      )
+    val entity2 =
+      Entity(
+        UUID.randomUUID().toString,
+        entityType1,
+        Map(testAttrName -> AttributeString("foo"),
+            sortAttrName -> AttributeValueList(List.fill(3)(AttributeNumber(Random.nextInt())))
+        )
+      )
+    val entity3 =
+      Entity(
+        UUID.randomUUID().toString,
+        entityType1,
+        Map(testAttrName -> AttributeString("foo"),
+            sortAttrName -> AttributeValueList(List.fill(9)(AttributeNumber(Random.nextInt())))
+        )
+      )
+    val entity4 =
+      Entity(UUID.randomUUID().toString,
+             entityType1,
+             Map(testAttrName -> AttributeString("foo"), sortAttrName -> AttributeNumber(Random.nextInt()))
+      )
+    insertAndGet(entity1)
+    insertAndGet(entity2)
+    insertAndGet(entity3)
+    insertAndGet(entity4) // this one does not have a list so should have a sort value of 1
+
+    val columnFilter = EntityColumnFilter(testAttrName, "foo")
+    val actual = runAndWait(
+      q.queryEntitiesWithColumnFilter(
+        wsid,
+        entityType1,
+        EntityQuery(1,
+                    10,
+                    toDelimitedName(sortAttrName),
+                    SortDirections.Descending,
+                    None,
+                    columnFilter = Some(columnFilter)
+        ),
+        columnFilter
+      )
+    )
+    actual should contain theSameElementsInOrderAs List(entity3, entity1, entity2, entity4)
+  }
+
   it should "respect desired fields" in withMinimalTestDatabase { _ =>
     val columnFilter = EntityColumnFilter(AttributeName.withDefaultNS("foo"), "foo")
     testDesiredFields(None, Some(columnFilter)) { (entityType, entityQuery) =>


### PR DESCRIPTION
Ticket: CORE-723

When sorting a Quicksilver data table by the length of an array column, we were not respecting the sort direction (asc/desc).