### PR TITLE
[CORE-721] Add start and end date query params to list submissions endpoint

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1079,6 +1079,20 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
+        - name: startDate
+          in: query
+          description: Optional start date to filter results (inclusive).
+          schema:
+            type: string
+            format: date
+            example: 2025-10-01
+        - name: endDate
+          in: query
+          description: Optional end date to filter results (inclusive).
+          schema:
+            type: string
+            format: date
+            example: 2025-10-31
       responses:
         200:
           description: Successful Request

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -746,6 +746,21 @@ paths:
       summary: list active submissions
       description: List all active submissions in all workspaces
       operationId: listAllActiveSubmissions
+      parameters:
+        - name: startDate
+          in: query
+          description: Optional start date to filter results (inclusive). Default value is 30 days ago.
+          schema:
+            type: string
+            format: date
+            example: 2025-10-31
+        - name: endDate
+          in: query
+          description: Optional end date to filter results (inclusive). Default value is the current date.
+          schema:
+            type: string
+            format: date
+            example: 2025-10-31
       responses:
         200:
           description: Successful Request

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -744,19 +744,19 @@ paths:
         - admin
         - submissions
       summary: list active submissions
-      description: List all active submissions in all workspaces
+      description: List all active submissions in all workspaces.
       operationId: listAllActiveSubmissions
       parameters:
         - name: startDate
           in: query
-          description: Optional start date to filter results (inclusive). Default value is 30 days ago.
+          description: Optional start date to filter results (inclusive).
           schema:
             type: string
             format: date
             example: 2025-10-01
         - name: endDate
           in: query
-          description: Optional end date to filter results (inclusive). Default value is the current date.
+          description: Optional end date to filter results (inclusive).
           schema:
             type: string
             format: date

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -753,7 +753,7 @@ paths:
           schema:
             type: string
             format: date
-            example: 2025-10-31
+            example: 2025-10-01
         - name: endDate
           in: query
           description: Optional end date to filter results (inclusive). Default value is the current date.

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -746,21 +746,6 @@ paths:
       summary: list active submissions
       description: List all active submissions in all workspaces.
       operationId: listAllActiveSubmissions
-      parameters:
-        - name: startDate
-          in: query
-          description: Optional start date to filter results (inclusive).
-          schema:
-            type: string
-            format: date
-            example: 2025-10-01
-        - name: endDate
-          in: query
-          description: Optional end date to filter results (inclusive).
-          schema:
-            type: string
-            format: date
-            example: 2025-10-31
       responses:
         200:
           description: Successful Request

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -152,14 +152,16 @@ trait SubmissionComponent {
       )
 
     def listWithSubmitter(workspaceContext: Workspace,
-                          startDate: Option[DateTime],
-                          endDate: Option[DateTime]
+                          startDateOpt: Option[DateTime],
+                          endDateOpt: Option[DateTime]
     ): ReadWriteAction[Seq[SubmissionListResponse]] = {
       val baseQuery = findByWorkspaceId(workspaceContext.workspaceIdAsUUID)
-      val filteredQuery = (startDate, endDate) match {
-        case (Some(start), Some(end)) =>
+      val filteredQuery = (startDateOpt, endDateOpt) match {
+        case (Some(startDate), Some(endDate)) =>
+          val start = new Timestamp(startDate.withTimeAtStartOfDay.getMillis)
+          val end = new Timestamp(endDate.plusDays(1).withTimeAtStartOfDay.getMillis - 1)
           baseQuery.filter(sub =>
-            sub.submissionDate >= new Timestamp(start.getMillis) && sub.submissionDate <= new Timestamp(end.getMillis)
+            sub.submissionDate >= start && sub.submissionDate <= end
           )
         case _ =>
           baseQuery

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -160,10 +160,14 @@ trait SubmissionComponent {
         case (Some(startDate), Some(endDate)) =>
           val start = new Timestamp(startDate.withTimeAtStartOfDay.getMillis)
           val end = new Timestamp(endDate.plusDays(1).withTimeAtStartOfDay.getMillis - 1)
-          baseQuery.filter(sub =>
-            sub.submissionDate >= start && sub.submissionDate <= end
-          )
-        case _ =>
+          baseQuery.filter(sub => sub.submissionDate >= start && sub.submissionDate <= end)
+        case (Some(startDate), None) =>
+          val start = new Timestamp(startDate.withTimeAtStartOfDay.getMillis)
+          baseQuery.filter(sub => sub.submissionDate >= start)
+        case (None, Some(endDate)) =>
+          val end = new Timestamp(endDate.plusDays(1).withTimeAtStartOfDay.getMillis - 1)
+          baseQuery.filter(sub => sub.submissionDate <= end)
+        case (None, None) =>
           baseQuery
       }
       val query = for {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -152,14 +152,22 @@ trait SubmissionComponent {
       )
 
     def listWithSubmitter(workspaceContext: Workspace,
-                          startDate: DateTime,
-                          endDate: DateTime): ReadWriteAction[Seq[SubmissionListResponse]] = {
-      val start = new Timestamp(startDate.getMillis)
-      val end = new Timestamp(endDate.getMillis)
+                          startDate: Option[DateTime],
+                          endDate: Option[DateTime]
+    ): ReadWriteAction[Seq[SubmissionListResponse]] = {
+      val baseQuery = findByWorkspaceId(workspaceContext.workspaceIdAsUUID)
+      val filteredQuery = (startDate, endDate) match {
+        case (Some(start), Some(end)) =>
+          baseQuery.filter(sub =>
+            sub.submissionDate >= new Timestamp(start.getMillis) && sub.submissionDate <= new Timestamp(end.getMillis)
+          )
+        case _ =>
+          baseQuery
+      }
       val query = for {
-        (submissionRec, entityRec) <- findByWorkspaceId(workspaceContext.workspaceIdAsUUID)
-          .filter(sub => sub.submissionDate >= start && sub.submissionDate <= end)
-          .joinLeft(entityQuery).on(_.submissionEntityId === _.id)
+        (submissionRec, entityRec) <- filteredQuery
+          .joinLeft(entityQuery)
+          .on(_.submissionEntityId === _.id)
         methodConfigRec <- methodConfigurationQuery if submissionRec.methodConfigurationId === methodConfigRec.id
       } yield (submissionRec, methodConfigRec, entityRec)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -151,11 +151,15 @@ trait SubmissionComponent {
         })
       )
 
-    def listWithSubmitter(workspaceContext: Workspace): ReadWriteAction[Seq[SubmissionListResponse]] = {
+    def listWithSubmitter(workspaceContext: Workspace,
+                          startDate: DateTime,
+                          endDate: DateTime): ReadWriteAction[Seq[SubmissionListResponse]] = {
+      val start = new Timestamp(startDate.getMillis)
+      val end = new Timestamp(endDate.getMillis)
       val query = for {
-        (submissionRec, entityRec) <- findByWorkspaceId(
-          workspaceContext.workspaceIdAsUUID
-        ) joinLeft entityQuery on (_.submissionEntityId === _.id)
+        (submissionRec, entityRec) <- findByWorkspaceId(workspaceContext.workspaceIdAsUUID)
+          .filter(sub => sub.submissionDate >= start && sub.submissionDate <= end)
+          .joinLeft(entityQuery).on(_.submissionEntityId === _.id)
         methodConfigRec <- methodConfigurationQuery if submissionRec.methodConfigurationId === methodConfigRec.id
       } yield (submissionRec, methodConfigRec, entityRec)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/openam/UserInfoDirectives.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/openam/UserInfoDirectives.scala
@@ -1,13 +1,17 @@
 package org.broadinstitute.dsde.rawls.openam
 
 import akka.http.scaladsl.server.Directive1
-import io.opencensus.trace.Span
+import akka.http.scaladsl.unmarshalling.Unmarshaller
 import io.opentelemetry.context.Context
 import org.broadinstitute.dsde.rawls.model.UserInfo
+import org.joda.time.DateTime
 
 /**
  * Directives to get user information.
  */
 trait UserInfoDirectives {
   def requireUserInfo(otelContext: Option[Context] = None): Directive1[UserInfo]
+
+  implicit def dateTimeUnmarshaller: Unmarshaller[String, DateTime] = Unmarshaller.strict(DateTime.parse)
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -8,7 +8,16 @@ import org.apache.commons.lang3.StringUtils
 import org.broadinstitute.dsde.rawls.config.WorkspaceServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction, WorkflowRecord}
 import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, StringValidationUtils}
-import org.broadinstitute.dsde.rawls.dataaccess.{ExecutionServiceCluster, ExecutionServiceDAO, ExecutionServiceId, GoogleServicesDAO, MethodRepoDAO, SamDAO, SlickDataSource, SubmissionCostService}
+import org.broadinstitute.dsde.rawls.dataaccess.{
+  ExecutionServiceCluster,
+  ExecutionServiceDAO,
+  ExecutionServiceId,
+  GoogleServicesDAO,
+  MethodRepoDAO,
+  SamDAO,
+  SlickDataSource,
+  SubmissionCostService
+}
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.LookupExpression
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityRequestArguments, EntityService}
 import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, ExpressionEvaluationContext}
@@ -20,7 +29,49 @@ import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.OutputType
 import org.broadinstitute.dsde.rawls.model.WorkflowFailureModes.WorkflowFailureMode
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
-import org.broadinstitute.dsde.rawls.model.{ActiveSubmission, AttributeEntityReference, AttributeString, AttributeValue, ErrorReport, ErrorReportSource, ExecutionServiceLogs, ExecutionServiceOutputs, ExternalEntityInfo, MetadataParams, MethodConfiguration, PreparedSubmission, RawlsBillingProject, RawlsBillingProjectName, RawlsRequestContext, RawlsUserEmail, RetriedSubmissionReport, SamWorkspaceActions, SeparateSubmissionFinalOutputsSetting, Submission, SubmissionListResponse, SubmissionReport, SubmissionRequest, SubmissionRetry, SubmissionStatuses, SubmissionValidationEntityInputs, SubmissionValidationHeader, SubmissionValidationInput, SubmissionValidationReport, TaskOutput, UserCommentUpdateOperation, Workflow, WorkflowCost, WorkflowCostTypes, WorkflowFailureModes, WorkflowOutputs, WorkflowQueueStatusByUserResponse, WorkflowStatuses, Workspace, WorkspaceAttributeSpecs, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model.{
+  ActiveSubmission,
+  AttributeEntityReference,
+  AttributeString,
+  AttributeValue,
+  ErrorReport,
+  ErrorReportSource,
+  ExecutionServiceLogs,
+  ExecutionServiceOutputs,
+  ExternalEntityInfo,
+  MetadataParams,
+  MethodConfiguration,
+  PreparedSubmission,
+  RawlsBillingProject,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RetriedSubmissionReport,
+  SamWorkspaceActions,
+  SeparateSubmissionFinalOutputsSetting,
+  Submission,
+  SubmissionListResponse,
+  SubmissionReport,
+  SubmissionRequest,
+  SubmissionRetry,
+  SubmissionStatuses,
+  SubmissionValidationEntityInputs,
+  SubmissionValidationHeader,
+  SubmissionValidationInput,
+  SubmissionValidationReport,
+  TaskOutput,
+  UserCommentUpdateOperation,
+  Workflow,
+  WorkflowCost,
+  WorkflowCostTypes,
+  WorkflowFailureModes,
+  WorkflowOutputs,
+  WorkflowQueueStatusByUserResponse,
+  WorkflowStatuses,
+  Workspace,
+  WorkspaceAttributeSpecs,
+  WorkspaceName
+}
 import org.broadinstitute.dsde.rawls.submissions.SubmissionsService.getTerminalStatusDate
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, RoleSupport, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
@@ -277,9 +328,9 @@ class SubmissionsService(
   }
 
   def listWithSubmitterForWorkspace(workspaceName: WorkspaceName,
-                                               startDate: DateTime,
-                                               endDate: DateTime
-                                             ): Future[Seq[SubmissionListResponse]] = {
+                                    startDate: Option[DateTime],
+                                    endDate: Option[DateTime]
+  ): Future[Seq[SubmissionListResponse]] =
     getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         dataAccess.submissionQuery.listWithSubmitter(
@@ -289,20 +340,19 @@ class SubmissionsService(
         )
       }
     }
-  }
 
   def listSubmissions(workspaceName: WorkspaceName,
                       parentContext: RawlsRequestContext,
                       startDateOpt: Option[DateTime],
                       endDateOpt: Option[DateTime]
   ): Future[Seq[SubmissionListResponse]] = {
-    val startDate = startDateOpt.getOrElse(DateTime.now().minusDays(30))
-    val endDate = endDateOpt.getOrElse(DateTime.now())
-    if (endDate.isBefore(startDate)) {
-      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "End date must occur after start date."))
+    if (startDateOpt.isDefined && endDateOpt.isDefined && endDateOpt.get.isBefore(startDateOpt.get)) {
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.BadRequest, "End date must occur after start date.")
+      )
     }
 
-    val costlessSubmissionsFuture = listWithSubmitterForWorkspace(workspaceName, startDate, endDate)
+    val costlessSubmissionsFuture = listWithSubmitterForWorkspace(workspaceName, startDateOpt, endDateOpt)
 
     // TODO David An 2018-05-30: temporarily disabling cost calculations for submission list due to potential performance hit
     // val costMapFuture = costlessSubmissionsFuture flatMap { submissions =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -3,20 +3,12 @@ package org.broadinstitute.dsde.rawls.submissions
 import akka.http.scaladsl.model.StatusCodes
 import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
+import jakarta.ws.rs.BadRequestException
 import org.apache.commons.lang3.StringUtils
 import org.broadinstitute.dsde.rawls.config.WorkspaceServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction, WorkflowRecord}
 import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, StringValidationUtils}
-import org.broadinstitute.dsde.rawls.dataaccess.{
-  ExecutionServiceCluster,
-  ExecutionServiceDAO,
-  ExecutionServiceId,
-  GoogleServicesDAO,
-  MethodRepoDAO,
-  SamDAO,
-  SlickDataSource,
-  SubmissionCostService
-}
+import org.broadinstitute.dsde.rawls.dataaccess.{ExecutionServiceCluster, ExecutionServiceDAO, ExecutionServiceId, GoogleServicesDAO, MethodRepoDAO, SamDAO, SlickDataSource, SubmissionCostService}
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.LookupExpression
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityRequestArguments, EntityService}
 import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, ExpressionEvaluationContext}
@@ -28,59 +20,20 @@ import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.OutputType
 import org.broadinstitute.dsde.rawls.model.WorkflowFailureModes.WorkflowFailureMode
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
-import org.broadinstitute.dsde.rawls.model.{
-  ActiveSubmission,
-  AttributeEntityReference,
-  AttributeString,
-  AttributeValue,
-  ErrorReport,
-  ErrorReportSource,
-  ExecutionServiceLogs,
-  ExecutionServiceOutputs,
-  ExternalEntityInfo,
-  MetadataParams,
-  MethodConfiguration,
-  PreparedSubmission,
-  RawlsBillingProject,
-  RawlsBillingProjectName,
-  RawlsRequestContext,
-  RawlsUserEmail,
-  RetriedSubmissionReport,
-  SamWorkspaceActions,
-  SeparateSubmissionFinalOutputsSetting,
-  Submission,
-  SubmissionListResponse,
-  SubmissionReport,
-  SubmissionRequest,
-  SubmissionRetry,
-  SubmissionStatuses,
-  SubmissionValidationEntityInputs,
-  SubmissionValidationHeader,
-  SubmissionValidationInput,
-  SubmissionValidationReport,
-  TaskOutput,
-  UserCommentUpdateOperation,
-  Workflow,
-  WorkflowCost,
-  WorkflowCostTypes,
-  WorkflowFailureModes,
-  WorkflowOutputs,
-  WorkflowQueueStatusByUserResponse,
-  WorkflowStatuses,
-  Workspace,
-  WorkspaceAttributeSpecs,
-  WorkspaceName
-}
+import org.broadinstitute.dsde.rawls.model.{ActiveSubmission, AttributeEntityReference, AttributeString, AttributeValue, ErrorReport, ErrorReportSource, ExecutionServiceLogs, ExecutionServiceOutputs, ExternalEntityInfo, MetadataParams, MethodConfiguration, PreparedSubmission, RawlsBillingProject, RawlsBillingProjectName, RawlsRequestContext, RawlsUserEmail, RetriedSubmissionReport, SamWorkspaceActions, SeparateSubmissionFinalOutputsSetting, Submission, SubmissionListResponse, SubmissionReport, SubmissionRequest, SubmissionRetry, SubmissionStatuses, SubmissionValidationEntityInputs, SubmissionValidationHeader, SubmissionValidationInput, SubmissionValidationReport, TaskOutput, UserCommentUpdateOperation, Workflow, WorkflowCost, WorkflowCostTypes, WorkflowFailureModes, WorkflowOutputs, WorkflowQueueStatusByUserResponse, WorkflowStatuses, Workspace, WorkspaceAttributeSpecs, WorkspaceName}
 import org.broadinstitute.dsde.rawls.submissions.SubmissionsService.getTerminalStatusDate
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, RoleSupport, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
 import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceSettingRepository}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+import org.springframework.web.client.HttpClientErrorException.BadRequest
 import slick.jdbc.TransactionIsolation
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsObject
 
+import java.sql.Timestamp
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -323,15 +276,33 @@ class SubmissionsService(
     } yield WorkflowCost(workflowId, costs.get(workflowId))
   }
 
-  def listSubmissions(workspaceName: WorkspaceName,
-                      parentContext: RawlsRequestContext
-  ): Future[Seq[SubmissionListResponse]] = {
-    val costlessSubmissionsFuture =
-      getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
-        dataSource.inTransaction { dataAccess =>
-          dataAccess.submissionQuery.listWithSubmitter(workspaceContext)
-        }
+  def listWithSubmitterForWorkspace(workspaceName: WorkspaceName,
+                                               startDate: DateTime,
+                                               endDate: DateTime
+                                             ): Future[Seq[SubmissionListResponse]] = {
+    getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
+      dataSource.inTransaction { dataAccess =>
+        dataAccess.submissionQuery.listWithSubmitter(
+          workspaceContext,
+          startDate,
+          endDate
+        )
       }
+    }
+  }
+
+  def listSubmissions(workspaceName: WorkspaceName,
+                      parentContext: RawlsRequestContext,
+                      startDateOpt: Option[DateTime],
+                      endDateOpt: Option[DateTime]
+  ): Future[Seq[SubmissionListResponse]] = {
+    val startDate = startDateOpt.getOrElse(DateTime.now().minusDays(30))
+    val endDate = endDateOpt.getOrElse(DateTime.now())
+    if (endDate.isBefore(startDate)) {
+      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "End date must occur after start date."))
+    }
+
+    val costlessSubmissionsFuture = listWithSubmitterForWorkspace(workspaceName, startDate, endDate)
 
     // TODO David An 2018-05-30: temporarily disabling cost calculations for submission list due to potential performance hit
     // val costMapFuture = costlessSubmissionsFuture flatMap { submissions =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -352,6 +352,12 @@ class SubmissionsService(
       )
     }
 
+    if (endDateOpt.isDefined && endDateOpt.get.isAfter(DateTime.now())) {
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.BadRequest, "Date filters cannot be in the future.")
+      )
+    }
+
     val costlessSubmissionsFuture = listWithSubmitterForWorkspace(workspaceName, startDateOpt, endDateOpt)
 
     // TODO David An 2018-05-30: temporarily disabling cost calculations for submission list due to potential performance hit

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -51,8 +51,6 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
       }
     }
 
-  implicit def dateTimeUnmarshaller: Unmarshaller[String, DateTime] = Unmarshaller.strict(DateTime.parse)
-
   def billingRoutesV2(otelContext: Context = Context.root(), userInfo: UserInfo): server.Route = {
     val ctx = RawlsRequestContext(userInfo, Option(otelContext))
     pathPrefix("billing" / "v2") {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.ErrorReportForma
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
 import org.broadinstitute.dsde.rawls.submissions.SubmissionsService
+import org.joda.time.DateTime
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsString, PrettyPrinter}
 
@@ -30,8 +31,14 @@ trait SubmissionApiService extends UserInfoDirectives {
     val ctx = RawlsRequestContext(userInfo, Option(otelContext))
     path("workspaces" / Segment / Segment / "submissions") { (workspaceNamespace, workspaceName) =>
       get {
-        complete {
-          submissionsServiceConstructor(ctx).listSubmissions(WorkspaceName(workspaceNamespace, workspaceName), ctx)
+        parameters("startDate".as[DateTime].?, "endDate".as[DateTime].?) { (startDateOpt, endDateOpt) =>
+          complete {
+            submissionsServiceConstructor(ctx).listSubmissions(
+              WorkspaceName(workspaceNamespace, workspaceName),
+              ctx,
+              startDateOpt,
+              endDateOpt)
+          }
         }
       }
     } ~

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponentSpec.scala
@@ -30,7 +30,7 @@ class DriverComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     val queryArecords = runAndWait(queryA.as[WorkflowRecord])
 
     // first check that we're not just comparing empty seqs
-    assertResult(22)(queryArecords.length)
+    assertResult(23)(queryArecords.length)
 
     assertResult(queryArecords) {
       runAndWait(concatSqlActions(Seq(select, where): _*).as[WorkflowRecord])
@@ -43,7 +43,7 @@ class DriverComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     val queryBrecords = runAndWait(queryB.as[WorkflowRecord])
 
     // first check that we're not just comparing empty seqs
-    assertResult(22)(queryBrecords.length)
+    assertResult(23)(queryBrecords.length)
 
     assertResult(queryBrecords) {
       runAndWait(concatSqlActions(Seq(select, where1, sql",", where2): _*).as[WorkflowRecord])

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponentSpec.scala
@@ -73,7 +73,7 @@ class DriverComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     val queryRecords = runAndWait(query.as[WorkflowRecord])
 
     // first check that we're not just comparing empty seqs
-    assertResult(33)(queryRecords.length)
+    assertResult(34)(queryRecords.length)
 
     assertResult(queryRecords) {
       runAndWait(concatSqlActions(select, where1, reduceSqlActionsWithDelim(statuses), where2).as[WorkflowRecord])

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
@@ -277,7 +277,7 @@ class SubmissionComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers
   it should "count submissions by their statuses" in withDefaultTestDatabase {
     val workspaceContext = testData.workspace
 
-    // test data contains 5 submissions, all in "Submitted" state
+    // test data contains 7 submissions, all in "Submitted" state
     // update one of the submissions to "Done"
     runAndWait(
       submissionQuery.updateStatus(UUID.fromString(testData.submission1.submissionId), SubmissionStatuses.Done)
@@ -294,10 +294,10 @@ class SubmissionComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers
       runAndWait(submissionQuery.get(workspaceContext, testData.submission2.submissionId))
     }
 
-    // should return {"Submitted" : 6, "Done" : 1, "Aborted" : 1}
+    // should return {"Submitted" : 7, "Done" : 1, "Aborted" : 1}
     assert(3 == runAndWait(submissionQuery.countByStatus(workspaceContext)).size)
     assert(
-      Option(6) == runAndWait(submissionQuery.countByStatus(workspaceContext))
+      Option(7) == runAndWait(submissionQuery.countByStatus(workspaceContext))
         .get(SubmissionStatuses.Submitted.toString)
     )
     assert(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -1640,13 +1640,13 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       workflows = Seq(
         Workflow(
           workflowId = Option("workflowSubmission20250915"),
-          status = WorkflowStatuses.Succeeded,
+          status = WorkflowStatuses.Submitted,
           statusLastChangedDate = testDate,
           workflowEntity = Option(sample1.toReference),
           inputResolutions = inputResolutions
         )
       ),
-      status = SubmissionStatuses.Done,
+      status = SubmissionStatuses.Submitted,
       useCallCache = false,
       deleteIntermediateOutputFiles = false
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -86,7 +86,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   )
   val testContext = RawlsRequestContext(userInfo)
 
-  // NOTE: we previously truncated millis here for DB compatibility reasons, but this is is no longer necessary.
+  // NOTE: we previously truncated millis here for DB compatibility reasons, but this is no longer necessary.
   // now only serves to encapsulate a Java-ism
   def currentTime() = new DateTime()
   val testDate = currentTime()
@@ -160,8 +160,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
                            workflowFailureMode: Option[WorkflowFailureMode] = None,
                            individualWorkflowCost: Option[Float] = None,
                            externalEntityInfo: Option[ExternalEntityInfo] = None,
-                           ignoreEmptyOutputs: Boolean = false,
-                           testDate: DateTime = currentTime()
+                           ignoreEmptyOutputs: Boolean = false
   ): Submission = {
 
     val workflows = workflowEntities map { ref =>
@@ -1630,16 +1629,26 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
     )
 
     // a submission from 30 days ago, to test filtering submissions by date
-    val submission20250915 = createTestSubmission(
-      workspace,
-      agoraMethodConfig,
-      indiv1,
-      WorkbenchEmail(userOwner.userEmail.value),
-      Seq(sample1, sample2, sample3),
-      Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
-      Seq(sample4, sample5, sample6),
-      Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2),
-      testDate = new DateTime(2025, 9, 15, 0, 0, 0, 0)
+    val submission20250915 = Submission(
+      submissionId = UUID.randomUUID().toString,
+      submissionDate = new DateTime(2025, 9, 15, 0, 0, 0, 0),
+      submitter = WorkbenchEmail(userOwner.userEmail.value),
+      methodConfigurationNamespace = agoraMethodConfig.namespace,
+      methodConfigurationName = agoraMethodConfig.name,
+      submissionEntity = Option(indiv1.toReference),
+      submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
+      workflows = Seq(
+        Workflow(
+          workflowId = Option("workflowSubmission20250915"),
+          status = WorkflowStatuses.Succeeded,
+          statusLastChangedDate = testDate,
+          workflowEntity = Option(sample1.toReference),
+          inputResolutions = inputResolutions
+        )
+      ),
+      status = SubmissionStatuses.Done,
+      useCallCache = false,
+      deleteIntermediateOutputFiles = false
     )
 
     val allWorkspaces = Seq(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -160,7 +160,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
                            workflowFailureMode: Option[WorkflowFailureMode] = None,
                            individualWorkflowCost: Option[Float] = None,
                            externalEntityInfo: Option[ExternalEntityInfo] = None,
-                           ignoreEmptyOutputs: Boolean = false
+                           ignoreEmptyOutputs: Boolean = false,
+                           testDate: DateTime = currentTime()
   ): Submission = {
 
     val workflows = workflowEntities map { ref =>
@@ -1200,6 +1201,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       Seq(sample4, sample5, sample6),
       Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2)
     )
+
     val regionalSubmission = createTestSubmission(
       regionalWorkspace,
       agoraMethodConfig,
@@ -1627,6 +1629,19 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       workflowFailureMode = Option(WorkflowFailureModes.ContinueWhilePossible)
     )
 
+    // a submission from 30 days ago, to test filtering submissions by date
+    val submission20250915 = createTestSubmission(
+      workspace,
+      agoraMethodConfig,
+      indiv1,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq(sample1, sample2, sample3),
+      Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
+      Seq(sample4, sample5, sample6),
+      Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2),
+      testDate = new DateTime(2025, 9, 15, 0, 0, 0, 0)
+    )
+
     val allWorkspaces = Seq(
       workspace,
       workspaceLocked,
@@ -1748,6 +1763,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
             submissionQuery.create(context, submission2),
             submissionQuery.create(context, submissionUpdateEntity),
             submissionQuery.create(context, submissionUpdateWorkspace),
+            submissionQuery.create(context, submission20250915),
 
             // update exec key for all test data workflows that have been started.
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -938,7 +938,7 @@ class SubmissionSpec(_system: ActorSystem)
       val submissionData = checkSubmissionStatus(submissionsService, newSubmissionReport.submissionId)
       assert(submissionData.workflows.size == 1)
 
-      val subList = Await.result(submissionsService.listSubmissions(testData.wsName, testContext), Duration.Inf)
+      val subList = Await.result(submissionsService.listSubmissions(testData.wsName, testContext, Option.empty, Option.empty), Duration.Inf)
 
       val oneSub = subList.filter(s => s.submissionId == newSubmissionReport.submissionId)
       assert(oneSub.nonEmpty)
@@ -1289,7 +1289,7 @@ class SubmissionSpec(_system: ActorSystem)
     val submissionData = checkSubmissionStatus(submissionsService, newSubmissionReport.submissionId)
     assert(submissionData.workflows.size == 1)
 
-    val subList = Await.result(submissionsService.listSubmissions(testData.wsName, testContext), Duration.Inf)
+    val subList = Await.result(submissionsService.listSubmissions(testData.wsName, testContext, Option.empty, Option.empty), Duration.Inf)
 
     val oneSub = subList.filter(s => s.submissionId == newSubmissionReport.submissionId)
     assert(oneSub.nonEmpty)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
@@ -29,18 +29,13 @@ import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterServiceImp
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice._
-import org.broadinstitute.dsde.rawls.workspace.{
-  RawlsWorkspaceAclManager,
-  WorkspaceRepository,
-  WorkspaceService,
-  WorkspaceSettingRepository,
-  WorkspaceSettingService
-}
+import org.broadinstitute.dsde.rawls.workspace.{RawlsWorkspaceAclManager, WorkspaceRepository, WorkspaceService, WorkspaceSettingRepository, WorkspaceSettingService}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, RawlsTestUtils}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.google.{BigQueryDatasetName, BigQueryTableName, GoogleProject}
 import org.joda.time.DateTime
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
@@ -49,6 +44,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{BeforeAndAfterAll, OptionValues}
 
+import java.time.LocalDate
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
@@ -286,26 +282,48 @@ class SubmissionsServiceSpec
         workspaceRepository,
         workbenchMetricBaseName
       ) _
+    override val submissionsServiceConstructor: RawlsRequestContext => SubmissionsService = { ctx =>
+      spy(
+        SubmissionsService.constructor(
+          slickDataSource,
+          entityManager,
+          methodRepoDAO,
+          new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName),
+          executionServiceCluster,
+          methodConfigResolver,
+          gcsDAO,
+          samDAO,
+          maxActiveWorkflowsTotal,
+          maxActiveWorkflowsPerUser,
+          workbenchMetricBaseName,
+          submissionCostService,
+          workspaceServiceConfig,
+          workspaceRepository,
+          workspaceSettingRepository,
+          entityServiceConstructor
+        )(ctx)
+      )
+    }
 
-    override val submissionsServiceConstructor: RawlsRequestContext => SubmissionsService =
-      SubmissionsService.constructor(
-        slickDataSource,
-        entityManager,
-        methodRepoDAO,
-        new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName),
-        executionServiceCluster,
-        methodConfigResolver,
-        gcsDAO,
-        samDAO,
-        maxActiveWorkflowsTotal,
-        maxActiveWorkflowsPerUser,
-        workbenchMetricBaseName,
-        submissionCostService,
-        workspaceServiceConfig,
-        workspaceRepository,
-        workspaceSettingRepository,
-        entityServiceConstructor
-      ) _
+//    override val submissionsServiceConstructor: RawlsRequestContext => SubmissionsService =
+//      SubmissionsService.constructor(
+//        slickDataSource,
+//        entityManager,
+//        methodRepoDAO,
+//        new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName),
+//        executionServiceCluster,
+//        methodConfigResolver,
+//        gcsDAO,
+//        samDAO,
+//        maxActiveWorkflowsTotal,
+//        maxActiveWorkflowsPerUser,
+//        workbenchMetricBaseName,
+//        submissionCostService,
+//        workspaceServiceConfig,
+//        workspaceRepository,
+//        workspaceSettingRepository,
+//        entityServiceConstructor
+//      ) _
 
     def cleanupSupervisor =
       submissionSupervisor ! PoisonPill
@@ -726,6 +744,37 @@ class SubmissionsServiceSpec
       actual should contain theSameElementsAs Seq("old success")
     }
 
+  }
+
+  behavior of "listSubmissions"
+
+  it should "error if end date before start date" in withTestDataServices { services =>
+    val workspaceName = testData.workspaceSuccessfulSubmission.toWorkspaceName
+    val start = currentTime()
+    val end = start.minusHours(1)
+
+    val actual = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(services.submissionsService.listSubmissions(workspaceName, testContext, Option(start), Option(end)),
+                   Duration.Inf
+      )
+    }
+    actual.errorReport.statusCode should contain(StatusCodes.BadRequest)
+    actual.errorReport.message shouldBe "End date must occur after start date."
+  }
+
+  it should "use default start and end dates if not specified" in withTestDataServices { services =>
+    val workspaceName = testData.workspaceSuccessfulSubmission.toWorkspaceName
+    Await.result(services.submissionsService.listSubmissions(workspaceName, testContext, None, None), Duration.Inf)
+
+    val workspaceCaptor = ArgumentCaptor.forClass(classOf[WorkspaceName])
+    val startCaptor = ArgumentCaptor.forClass(classOf[DateTime])
+    val endCaptor = ArgumentCaptor.forClass(classOf[DateTime])
+
+    verify(services.submissionsService)
+      .listWithSubmitterForWorkspace(workspaceCaptor.capture(), startCaptor.capture(), endCaptor.capture())
+    workspaceCaptor.getValue shouldBe workspaceName
+    startCaptor.getValue shouldBe DateTime.now().minusDays(30).toDate
+    endCaptor.getValue shouldBe DateTime.now().toDate
   }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
@@ -752,26 +752,18 @@ class SubmissionsServiceSpec
     actual.errorReport.message shouldBe "End date must occur after start date."
   }
 
-  it should "use default start and end dates if not specified" in withTestDataServices { services =>
+  it should "Do not filter submissions when no start and end dates are specified" in withTestDataServices { services =>
     val workspaceName = testData.workspaceSuccessfulSubmission.toWorkspaceName
     Await.result(services.submissionsService.listSubmissions(workspaceName, testContext, None, None), Duration.Inf)
 
     val workspaceCaptor = ArgumentCaptor.forClass(classOf[WorkspaceName])
-    val startCaptor = ArgumentCaptor.forClass(classOf[DateTime])
-    val endCaptor = ArgumentCaptor.forClass(classOf[DateTime])
+    val startCaptor = ArgumentCaptor.forClass(classOf[Option[DateTime]])
+    val endCaptor = ArgumentCaptor.forClass(classOf[Option[DateTime]])
 
     verify(services.submissionsService)
       .listWithSubmitterForWorkspace(workspaceCaptor.capture(), startCaptor.capture(), endCaptor.capture())
     workspaceCaptor.getValue shouldBe workspaceName
-
-    val startDate = startCaptor.getValue
-    val expectedStartDate = DateTime.now().minusDays(30)
-    (startDate.getYear, startDate.getMonthOfYear, startDate.getDayOfMonth) shouldBe
-      (expectedStartDate.getYear, expectedStartDate.getMonthOfYear, expectedStartDate.getDayOfMonth)
-
-    val endDate = endCaptor.getValue
-    val expectedEndDate = DateTime.now()
-    (endDate.getYear, endDate.getMonthOfYear, endDate.getDayOfMonth) shouldBe
-      (expectedEndDate.getYear, expectedEndDate.getMonthOfYear, expectedEndDate.getDayOfMonth)
+    startCaptor.getValue shouldBe Option.empty
+    endCaptor.getValue shouldBe Option.empty
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
@@ -311,26 +311,6 @@ class SubmissionsServiceSpec
       )
     }
 
-//    override val submissionsServiceConstructor: RawlsRequestContext => SubmissionsService =
-//      SubmissionsService.constructor(
-//        slickDataSource,
-//        entityManager,
-//        methodRepoDAO,
-//        new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName),
-//        executionServiceCluster,
-//        methodConfigResolver,
-//        gcsDAO,
-//        samDAO,
-//        maxActiveWorkflowsTotal,
-//        maxActiveWorkflowsPerUser,
-//        workbenchMetricBaseName,
-//        submissionCostService,
-//        workspaceServiceConfig,
-//        workspaceRepository,
-//        workspaceSettingRepository,
-//        entityServiceConstructor
-//      ) _
-
     def cleanupSupervisor =
       submissionSupervisor ! PoisonPill
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
@@ -763,8 +763,15 @@ class SubmissionsServiceSpec
     verify(services.submissionsService)
       .listWithSubmitterForWorkspace(workspaceCaptor.capture(), startCaptor.capture(), endCaptor.capture())
     workspaceCaptor.getValue shouldBe workspaceName
-    startCaptor.getValue shouldBe DateTime.now().minusDays(30).toDate
-    endCaptor.getValue shouldBe DateTime.now().toDate
-  }
 
+    val startDate = startCaptor.getValue
+    val expectedStartDate = DateTime.now().minusDays(30)
+    (startDate.getYear, startDate.getMonthOfYear, startDate.getDayOfMonth) shouldBe
+      (expectedStartDate.getYear, expectedStartDate.getMonthOfYear, expectedStartDate.getDayOfMonth)
+
+    val endDate = endCaptor.getValue
+    val expectedEndDate = DateTime.now()
+    (endDate.getYear, endDate.getMonthOfYear, endDate.getDayOfMonth) shouldBe
+      (expectedEndDate.getYear, expectedEndDate.getMonthOfYear, expectedEndDate.getDayOfMonth)
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
@@ -29,7 +29,13 @@ import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterServiceImp
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice._
-import org.broadinstitute.dsde.rawls.workspace.{RawlsWorkspaceAclManager, WorkspaceRepository, WorkspaceService, WorkspaceSettingRepository, WorkspaceSettingService}
+import org.broadinstitute.dsde.rawls.workspace.{
+  RawlsWorkspaceAclManager,
+  WorkspaceRepository,
+  WorkspaceService,
+  WorkspaceSettingRepository,
+  WorkspaceSettingService
+}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, RawlsTestUtils}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
@@ -506,7 +512,11 @@ class SubmissionsServiceSpec
       )
 
       val firstSubmission =
-        Await.result(services.submissionsService.listSubmissions(workspaceName, testContext, Option.empty, Option.empty), Duration.Inf).head
+        Await
+          .result(services.submissionsService.listSubmissions(workspaceName, testContext, Option.empty, Option.empty),
+                  Duration.Inf
+          )
+          .head
 
       val result = Await.result(
         services.submissionsService.getSubmissionMethodConfiguration(workspaceName, firstSubmission.submissionId),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
@@ -488,7 +488,7 @@ class SubmissionsServiceSpec
       )
 
       val firstSubmission =
-        Await.result(services.submissionsService.listSubmissions(workspaceName, testContext), Duration.Inf).head
+        Await.result(services.submissionsService.listSubmissions(workspaceName, testContext, Option.empty, Option.empty), Duration.Inf).head
 
       val result = Await.result(
         services.submissionsService.getSubmissionMethodConfiguration(workspaceName, firstSubmission.submissionId),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -670,18 +670,20 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
 
     SubmissionListResponse(sub, None, statuses, false).copy(cost = runCost)
   }
-  val expectedSubmissions = Set(
-    expectedResponse(testData.submissionTerminateTest),
-    expectedResponse(testData.submissionNoWorkflows),
-    expectedResponse(testData.submission1),
-    expectedResponse(testData.costedSubmission1),
-    expectedResponse(testData.submission2),
-    expectedResponse(testData.submissionUpdateEntity),
-    expectedResponse(testData.regionalSubmission),
-    expectedResponse(testData.submissionUpdateWorkspace)
-  )
 
   it should "return 200 when listing submissions" in withTestDataApiServices { services =>
+    val expectedSubmissions = Set(
+      expectedResponse(testData.submissionTerminateTest),
+      expectedResponse(testData.submissionNoWorkflows),
+      expectedResponse(testData.submission1),
+      expectedResponse(testData.costedSubmission1),
+      expectedResponse(testData.submission2),
+      expectedResponse(testData.submissionUpdateEntity),
+      expectedResponse(testData.regionalSubmission),
+      expectedResponse(testData.submissionUpdateWorkspace),
+      expectedResponse(testData.submission20250915)
+    )
+
     Get(s"${testData.wsName.path}/submissions") ~>
       sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
@@ -692,12 +694,12 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
       }
   }
 
-  it should "return 200 when listing submissions with date filter" in withTestDataApiServices { services =>
-    Get(s"${testData.wsName.path}/submissions?startDate=2025-10-01") ~>
+  it should "return 200 listing submissions within date range" in withTestDataApiServices { services =>
+    Get(s"${testData.wsName.path}/submissions?startDate=2025-09-01&endDate=2025-10-01") ~>
       sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
-        assertResult(expectedSubmissions) {
+        assertResult(Set(expectedResponse(testData.submission20250915))) {
           responseAs[Seq[SubmissionListResponse]].toSet
         }
       }
@@ -730,7 +732,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
           assertResult(StatusCodes.OK) {
             status
           }
-          assertResult(Map("Submitted" -> 8)) {
+          assertResult(Map("Submitted" -> 9)) {
             responseAs[Map[String, Int]]
           }
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -693,7 +693,6 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
   }
 
   it should "return 200 when listing submissions with date filter" in withTestDataApiServices { services =>
-
     Get(s"${testData.wsName.path}/submissions?startDate=2025-10-01") ~>
       sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
@@ -704,24 +703,25 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
       }
   }
 
-   it should "return 200 with no matching submissions" in withTestDataApiServices { services =>
-     Get(s"${testData.wsName.path}/submissions?startDate=2025-01-01&endDate=2025-06-01") ~>
-       sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
-       check {
-         assertResult(StatusCodes.OK)(status)
-         assertResult(Set.empty) {
-           responseAs[Seq[SubmissionListResponse]].toSet
-         }
-       }
-   }
+  it should "return 200 with no matching submissions" in withTestDataApiServices { services =>
+    Get(s"${testData.wsName.path}/submissions?startDate=2025-01-01&endDate=2025-06-01") ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
+      check {
+        assertResult(StatusCodes.OK)(status)
+        assertResult(Set.empty) {
+          responseAs[Seq[SubmissionListResponse]].toSet
+        }
+      }
+  }
 
-   it should "return 400 error listing submissions with incorrect start and end date format" in withTestDataApiServices { services =>
-     Get(s"${testData.wsName.path}/submissions?startDate=foo&endDate=bar") ~>
-       sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
-       check {
-         assertResult(StatusCodes.BadRequest)(status)
-       }
-   }
+  it should "return 400 error listing submissions with incorrect start and end date format" in withTestDataApiServices {
+    services =>
+      Get(s"${testData.wsName.path}/submissions?startDate=foo&endDate=bar") ~>
+        sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
+        check {
+          assertResult(StatusCodes.BadRequest)(status)
+        }
+  }
 
   it should "return 200 when counting submissions" in withTestDataApiServices { services =>
     withStatsD {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -661,37 +661,67 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
       }
   }
 
+  def expectedResponse(sub: Submission): SubmissionListResponse = {
+    val wfCount = sub.workflows.length
+    val statuses: Map[String, Int] = if (wfCount > 0) Map("Submitted" -> wfCount) else Map.empty
+    // TODO David An 2018-05-30: temporarily disabling cost calculations for submission list due to potential performance hit
+    // val runCost = if (wfCount == 0) None else Some(wfCount * 1.23f)  // mockSubmissionCostService.fixedCost
+    val runCost = None
+
+    SubmissionListResponse(sub, None, statuses, false).copy(cost = runCost)
+  }
+  val expectedSubmissions = Set(
+    expectedResponse(testData.submissionTerminateTest),
+    expectedResponse(testData.submissionNoWorkflows),
+    expectedResponse(testData.submission1),
+    expectedResponse(testData.costedSubmission1),
+    expectedResponse(testData.submission2),
+    expectedResponse(testData.submissionUpdateEntity),
+    expectedResponse(testData.regionalSubmission),
+    expectedResponse(testData.submissionUpdateWorkspace)
+  )
+
   it should "return 200 when listing submissions" in withTestDataApiServices { services =>
-    def expectedResponse(sub: Submission): SubmissionListResponse = {
-      val wfCount = sub.workflows.length
-      val statuses: Map[String, Int] = if (wfCount > 0) Map("Submitted" -> wfCount) else Map.empty
-      // TODO David An 2018-05-30: temporarily disabling cost calculations for submission list due to potential performance hit
-      // val runCost = if (wfCount == 0) None else Some(wfCount * 1.23f)  // mockSubmissionCostService.fixedCost
-      val runCost = None
-
-      SubmissionListResponse(sub, None, statuses, false).copy(cost = runCost)
-    }
-
     Get(s"${testData.wsName.path}/submissions") ~>
       sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
-        assertResult(
-          Set(
-            expectedResponse(testData.submissionTerminateTest),
-            expectedResponse(testData.submissionNoWorkflows),
-            expectedResponse(testData.submission1),
-            expectedResponse(testData.costedSubmission1),
-            expectedResponse(testData.submission2),
-            expectedResponse(testData.submissionUpdateEntity),
-            expectedResponse(testData.regionalSubmission),
-            expectedResponse(testData.submissionUpdateWorkspace)
-          )
-        ) {
+        assertResult(expectedSubmissions) {
           responseAs[Seq[SubmissionListResponse]].toSet
         }
       }
   }
+
+  it should "return 200 when listing submissions with date filter" in withTestDataApiServices { services =>
+
+    Get(s"${testData.wsName.path}/submissions?startDate=2025-10-01") ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
+      check {
+        assertResult(StatusCodes.OK)(status)
+        assertResult(expectedSubmissions) {
+          responseAs[Seq[SubmissionListResponse]].toSet
+        }
+      }
+  }
+
+   it should "return 200 with no matching submissions" in withTestDataApiServices { services =>
+     Get(s"${testData.wsName.path}/submissions?startDate=2025-01-01&endDate=2025-06-01") ~>
+       sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
+       check {
+         assertResult(StatusCodes.OK)(status)
+         assertResult(Set.empty) {
+           responseAs[Seq[SubmissionListResponse]].toSet
+         }
+       }
+   }
+
+   it should "return 400 error listing submissions with incorrect start and end date format" in withTestDataApiServices { services =>
+     Get(s"${testData.wsName.path}/submissions?startDate=foo&endDate=bar") ~>
+       sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
+       check {
+         assertResult(StatusCodes.BadRequest)(status)
+       }
+   }
 
   it should "return 200 when counting submissions" in withTestDataApiServices { services =>
     withStatsD {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -671,24 +671,46 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
     SubmissionListResponse(sub, None, statuses, false).copy(cost = runCost)
   }
 
-  it should "return 200 when listing submissions" in withTestDataApiServices { services =>
-    val expectedSubmissions = Set(
-      expectedResponse(testData.submissionTerminateTest),
-      expectedResponse(testData.submissionNoWorkflows),
-      expectedResponse(testData.submission1),
-      expectedResponse(testData.costedSubmission1),
-      expectedResponse(testData.submission2),
-      expectedResponse(testData.submissionUpdateEntity),
-      expectedResponse(testData.regionalSubmission),
-      expectedResponse(testData.submissionUpdateWorkspace),
-      expectedResponse(testData.submission20250915)
-    )
+  val expectedSubmissions = Set(
+    expectedResponse(testData.submissionTerminateTest),
+    expectedResponse(testData.submissionNoWorkflows),
+    expectedResponse(testData.submission1),
+    expectedResponse(testData.costedSubmission1),
+    expectedResponse(testData.submission2),
+    expectedResponse(testData.submissionUpdateEntity),
+    expectedResponse(testData.regionalSubmission),
+    expectedResponse(testData.submissionUpdateWorkspace),
+    expectedResponse(testData.submission20250915)
+  )
 
+  it should "return 200 when listing submissions" in withTestDataApiServices { services =>
     Get(s"${testData.wsName.path}/submissions") ~>
       sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
       check {
         assertResult(StatusCodes.OK)(status)
         assertResult(expectedSubmissions) {
+          responseAs[Seq[SubmissionListResponse]].toSet
+        }
+      }
+  }
+
+  it should "use current date when no end date is specified" in withTestDataApiServices { services =>
+    Get(s"${testData.wsName.path}/submissions?startDate=2025-09-01") ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
+      check {
+        assertResult(StatusCodes.OK)(status)
+        assertResult(expectedSubmissions) {
+          responseAs[Seq[SubmissionListResponse]].toSet
+        }
+      }
+  }
+
+  it should "return all results up to end date when no start date is specified" in withTestDataApiServices { services =>
+    Get(s"${testData.wsName.path}/submissions?endDate=2025-09-30") ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
+      check {
+        assertResult(StatusCodes.OK)(status)
+        assertResult(Set(expectedResponse(testData.submission20250915))) {
           responseAs[Seq[SubmissionListResponse]].toSet
         }
       }
@@ -713,6 +735,14 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
         assertResult(Set.empty) {
           responseAs[Seq[SubmissionListResponse]].toSet
         }
+      }
+  }
+
+  it should "return 400 error with start and end dates in the future" in withTestDataApiServices { services =>
+    Get(s"${testData.wsName.path}/submissions?startDate=2050-10-15&endDate=2050-10-30") ~>
+      sealRoute(services.submissionRoutes(userInfo = userInfo)) ~>
+      check {
+        assertResult(StatusCodes.BadRequest)(status)
       }
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-721

Update listSubmissions endpoint to take in optional `startDate` and `endDate` query parameters:
- If no query params are specified, default to the existing behavior which is to list all submissions. 
- If a start and date are specified, return results within that date range
- If only a start date is specified, return all results after (and including) that date
- If only an end date is specified, return all results before (and including) that date  

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [x] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
