### PR TITLE
CORE-727: add index on workspaceid, entitytype, deleted to ENTITY table

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -149,4 +149,5 @@
     <include file="changesets/20250821_remove_all_gcpbatch_workspace_settings_again.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250912_workflow_actual_cost.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20251009_quicksilver_for_empty_workspaces.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20251015_entity_indexing.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20251015_entity_indexing.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20251015_entity_indexing.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+    <!-- In production, this index requires ~1 hour to create. We will manually add the index to the db using
+     ALGORITHM=INPLACE, LOCK=NONE. This changeset reflects that manual operation, and thus uses
+     failOnError="false" because we expect the index to already exist in prod when it runs. -->
+    <changeSet logicalFilePath="dummy" author="davidan" id="entity_indexing" failOnError="false">
+        <createIndex tableName="ENTITY" indexName="idx_ws_type_deleted">
+            <column name="workspace_id" />
+            <column name="entity_type" />
+            <column name="deleted" />
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -422,7 +422,7 @@ trait EntityComponent {
         concatSqlActions(
           sql"""select e.id, e.name #$sortColumns from ENTITY e """,
           sortJoin,
-          sql""" where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = $workspaceId """
+          sql""" where e.deleted = b'0' and e.entity_type = $entityType and e.workspace_id = $workspaceId """
         )
       }
 
@@ -594,7 +594,7 @@ trait EntityComponent {
             concatSqlActions(
               sql"""select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date, null
                              from ENTITY e
-                             where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} """,
+                             where e.deleted = b'0' and e.entity_type = $entityType and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} """,
               paginationFilterSql("and", "e", entityQuery),
               order("e"),
               sql" limit #${entityQuery.pageSize} offset #${(entityQuery.page - 1) * entityQuery.pageSize}"
@@ -602,7 +602,7 @@ trait EntityComponent {
           } else {
             // user is sorting by an attribute value, so we need the largest number of joins
             // this query is very similar to baseEntityAndAttributeSql
-            /* TODO: include "where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = $workspaceId"
+            /* TODO: include "where e.deleted = b'0' and e.entity_type = $entityType and e.workspace_id = $workspaceId"
                 in the top-level select, to reduce what MySQL needs to look at? Does this actually help?
              */
             /* TODO: it's inefficient to return all columns of e_ref; we only really need the id and the name. We turn it into an

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -422,7 +422,7 @@ trait EntityComponent {
         concatSqlActions(
           sql"""select e.id, e.name #$sortColumns from ENTITY e """,
           sortJoin,
-          sql""" where e.deleted = b'0' and e.entity_type = $entityType and e.workspace_id = $workspaceId """
+          sql""" where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = $workspaceId """
         )
       }
 
@@ -594,7 +594,7 @@ trait EntityComponent {
             concatSqlActions(
               sql"""select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date, null
                              from ENTITY e
-                             where e.deleted = b'0' and e.entity_type = $entityType and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} """,
+                             where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} """,
               paginationFilterSql("and", "e", entityQuery),
               order("e"),
               sql" limit #${entityQuery.pageSize} offset #${(entityQuery.page - 1) * entityQuery.pageSize}"
@@ -602,7 +602,7 @@ trait EntityComponent {
           } else {
             // user is sorting by an attribute value, so we need the largest number of joins
             // this query is very similar to baseEntityAndAttributeSql
-            /* TODO: include "where e.deleted = b'0' and e.entity_type = $entityType and e.workspace_id = $workspaceId"
+            /* TODO: include "where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = $workspaceId"
                 in the top-level select, to reduce what MySQL needs to look at? Does this actually help?
              */
             /* TODO: it's inefficient to return all columns of e_ref; we only really need the id and the name. We turn it into an


### PR DESCRIPTION
Ticket: CORE-727

Liquibase changeset to add the `idx_ws_type_deleted (workspace_id, entity_type, deleted)` index on the `ENTITY` table.

POC has shown this index helps measurably with query latency such as the entity type metadata table counts. I expect it will also help with any queries which target a single workspace & entity type and only work with active entities - such as `entityQuery`.

