### PR TITLE
CORE-727: fix improper casting for the ENTITY.deleted column

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -422,7 +422,7 @@ trait EntityComponent {
         concatSqlActions(
           sql"""select e.id, e.name #$sortColumns from ENTITY e """,
           sortJoin,
-          sql""" where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = $workspaceId """
+          sql""" where e.deleted = b'0' and e.entity_type = $entityType and e.workspace_id = $workspaceId """
         )
       }
 
@@ -594,7 +594,7 @@ trait EntityComponent {
             concatSqlActions(
               sql"""select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date, null
                              from ENTITY e
-                             where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} """,
+                             where e.deleted = b'0' and e.entity_type = $entityType and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} """,
               paginationFilterSql("and", "e", entityQuery),
               order("e"),
               sql" limit #${entityQuery.pageSize} offset #${(entityQuery.page - 1) * entityQuery.pageSize}"
@@ -602,7 +602,7 @@ trait EntityComponent {
           } else {
             // user is sorting by an attribute value, so we need the largest number of joins
             // this query is very similar to baseEntityAndAttributeSql
-            /* TODO: include "where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = $workspaceId"
+            /* TODO: include "where e.deleted = b'0' and e.entity_type = $entityType and e.workspace_id = $workspaceId"
                 in the top-level select, to reduce what MySQL needs to look at? Does this actually help?
              */
             /* TODO: it's inefficient to return all columns of e_ref; we only really need the id and the name. We turn it into an


### PR DESCRIPTION
Ticket: CORE-727

Fixes improper datatype casting on a couple queries using the `ENTITY.deleted` column.

Both the before and after in this PR are functional _unless the ENTITY.deleted column is indexed_. When it is not indexed, MySQL handles the implicit casting of `'false'` to `b'0'`. However, if we add an index on ENTITY.deleted - which CORE-727 intends to do - the index only contains the correct `b'0'` datatype, and queries that use `deleted = 'false'` fail.

So, this is a prerequisite to adding an index on ENTITY.deleted.

Of note: the LocalEntityProviderSpec "accept multiple update operations for the same entity in batchUpsert" unit test verifies the behavior in this PR. When we have an index on ENTITY.deleted, that unit test fails on this PR's "before" code, but passes on its "after" code. Check out #3500 to see that unit test fail.