### PR TITLE
CORE-707: streamline logic to enable Quicksilver for new workspaces

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -213,26 +213,6 @@ class WorkspaceService(
           )
       }
 
-    /**
-     * Enable Quicksilver for a workspace by creating a CompactDataTables setting record.
-     * This bypasses WorkspaceSettingService and works directly with workspaceSettingsRepository to manipulate
-     * database rows. We do this because we don't want to trigger any of the Quicksilver migration logic
-     * when adding this setting.
-     *
-     * @param workspaceId UUID of workspace for which to enable Quicksilver
-     * @return number of settings applied; should always be 1.
-     */
-    def enableQuicksilver(workspaceId: UUID): Future[Int] = for {
-      _ <- workspaceSettingsRepository.createWorkspaceSettingsRecords(
-        workspaceId,
-        List(CompactDataTablesSetting(CompactDataTablesConfig(enabled = true, performMigration = Option(false)))),
-        parentContext.userInfo.userSubjectId
-      )
-      numApplied <- workspaceSettingsRepository.markWorkspaceSettingApplied(workspaceId,
-                                                                            WorkspaceSettingTypes.CompactDataTables
-      )
-    } yield numApplied
-
     for {
       _ <- traceFutureWithParent("withAttributeNamespaceCheck", parentContext)(_ =>
         withAttributeNamespaceCheck(workspaceRequest)(Future.successful())
@@ -276,15 +256,7 @@ class WorkspaceService(
         )
         throw t
       }
-      // enable quicksilver for new workspaces
-      _ <- traceFutureWithParent("enableQuicksilverForWorkspace", parentContext)(_ =>
-        enableQuicksilver(workspace.workspaceIdAsUUID) recover { case t: Throwable =>
-          logger.warn(
-            s"Error in createWorkspace.enableQuicksilver - workspace:'${workspaceRequest.name}' - UUID:${workspace.workspaceId}: ${t.getClass.getSimpleName}: ${t.getMessage}"
-          )
-          throw t
-        }
-      )
+
       _ <- traceFutureWithParent("FastPassService.setupFastPassNewWorkspace", parentContext)(childContext =>
         fastPassServiceConstructor(childContext)
           .syncFastPassesForUserInWorkspace(workspace) recover { case t: Throwable =>
@@ -2481,6 +2453,23 @@ class WorkspaceService(
           span
         )
       )
+
+      // enable quicksilver for new workspaces. This bypasses the logic in WorkspaceSettingRepository
+      // because we can be certain this is a brand-new workspace with no pre-existing settings, and
+      // we want to keep this operation as light as possible.
+      _ <- traceDBIOWithParent("enableQuicksilverForWorkspace", parentContext) { _ =>
+        val tsNow = java.sql.Timestamp.from(java.time.Instant.now())
+        val quicksilverRecord = WorkspaceSettingRecord(
+          "CompactDataTables",
+          savedWorkspace.workspaceIdAsUUID,
+          """{"enabled": true, "performMigration": false}""",
+          "Applied",
+          tsNow,
+          tsNow,
+          parentContext.userInfo.userSubjectId.value
+        )
+        dataAccess.workspaceSettingQuery += quicksilverRecord
+      }
 
       _ <- traceDBIOWithParent("updateServicePerimeter", parentContext)(_ =>
         maybeUpdateGoogleProjectsInPerimeter(billingProject, dataAccess)


### PR DESCRIPTION
Ticket: CORE-707

Some swatomation tests are flaky because workspace-creation fails with a lock-wait timeout creating the `CompactDataTables` workspace setting for that workspace.

This PR:
1. Moves creation of the `CompactDataTables` workspace setting inside the main database transaction for creating workspaces. This means that if creation of the setting fails, we will roll back the workspace creation. Previously, we would leave the workspace record in the db so when the test retried, it would fail on retry.
2. Significantly reduces the number and complexity of database queries required to save the setting, by passing the WorkspaceSettingRepository entirely. It now requires a single `INSERT` statement, where previously it was 4 queries (list pending settings, insert new setting, update applied settings to deleted, update pending settings to applied)

Analysis of the test failure (bottom is older, top is newer):
<img width="3334" height="1784" alt="Screenshot 15-10-2025 at 15 51" src="https://github.com/user-attachments/assets/eddca4dd-3717-47c6-934e-e93a79771b0d" />

