### PR TITLE
CORE-731: apply the out-of-sort-memory workaround to queries that sort by entity name

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategy.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/entityQuery/EntityQueryStrategy.scala
@@ -49,16 +49,9 @@ trait EntityQueryStrategy extends SortMemoryRetry {
   )(op: => ReadWriteAction[T])(implicit
     executionContext: ExecutionContext
   ): Future[T] =
-    // is this a sort by name/id? If so, no need to retry with extra sort memory.
-    entityQuery.sortField match {
-      case Attributable.nameReservedAttribute =>
-        repository.dataSource.inTransaction(isolationLevel)(_ => op)
-      case _ =>
-        retryWithSortMemory[T](repository.dataSource, functionName, isolationLevel = isolationLevel) {
-          op
-        }
+    retryWithSortMemory[T](repository.dataSource, functionName, isolationLevel = isolationLevel) {
+      op
     }
-
 }
 
 object EntityQueryStrategy {


### PR DESCRIPTION
Ticket: CORE-731

Quicksilver implemented a workaround for MySQL's 'Out of sort memory' bug for the entityQuery API. From the evidence we gathered, Quicksilver assumed that this workaround was only necessary when sorting the result set by a user-defined attribute - that is, the workaround was not necessary when sorting by the entity name.

We have now seen a userliaison issue that provides evidence that the 'Out of sort memory' error can happen when sorting by name.

This PR applies the workaround to the sort-by-name case as well.
