### PR TITLE
[CORE-545] Improve entityQuery performance when specifying fields

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -1273,20 +1273,47 @@ class CompactEntityQuery(driverComponent: DriverComponent)
         // For each field, create a JSON_OBJECT that contains the field if it exists;
         // else create an empty JSON_OBJECT. These objects are all merged together below;
         // this ensures that if a field is missing in the db, it will not be present in the result.
+        val refsFilter = fields.map(f => s"'$f'").mkString(",")
+        val refsJsonArray =
+          sql"""(
+          SELECT IFNULL(
+            JSON_ARRAYAGG(
+              JSON_OBJECT(
+                'a', jt.a,
+                't', jt.t,
+                'n', jt.n
+              )
+            ),
+            JSON_ARRAY()
+          )
+          FROM JSON_TABLE(
+            e.attributes, '$$.refs[*]'
+            COLUMNS (
+              a VARCHAR(254) PATH '$$.a',
+              t VARCHAR(254) PATH '$$.t',
+              n VARCHAR(254) PATH '$$.n'
+            )
+          ) jt
+          WHERE jt.a IN (#$refsFilter)
+        )"""
+
         val fieldObjects = fields.map { field =>
           sql"IF(JSON_CONTAINS_PATH(e.attributes, 'one', ${slickAttributePath(field)}), JSON_OBJECT($field, e.attributes -> ${slickAttributePath(field)}), JSON_OBJECT())"
         }
         concatSqlActions(
           sql"""JSON_OBJECT(
-               '#${CompactEntitySerialization.VERSION_KEY}', e.attributes -> '$$.#${CompactEntitySerialization.VERSION_KEY}',
-               '#${CompactEntitySerialization.REFS_KEY}', e.attributes -> '$$.#${CompactEntitySerialization.REFS_KEY}',
-               '#${CompactEntitySerialization.ATTRS_KEY}', JSON_MERGE_PATCH(
-                  JSON_OBJECT(),""",
+             '#${CompactEntitySerialization.VERSION_KEY}', e.attributes -> '$$.#${CompactEntitySerialization.VERSION_KEY}',
+             '#${CompactEntitySerialization.REFS_KEY}', """,
+          refsJsonArray,
+          sql""",
+             '#${CompactEntitySerialization.ATTRS_KEY}', JSON_MERGE_PATCH(
+                JSON_OBJECT(),""",
           reduceSqlActionsWithDelim(fieldObjects.toSeq, sql","),
           sql"))"
         )
       case _ => sql"attributes"
     }
+
 
   private def fromActiveEntitiesOfTypeInWorkspace(workspaceId: UUID, entityType: String) =
     sql" from ENTITY e where e.workspace_id = $workspaceId and e.entity_type = $entityType and e.deleted = 0"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -1314,7 +1314,6 @@ class CompactEntityQuery(driverComponent: DriverComponent)
       case _ => sql"attributes"
     }
 
-
   private def fromActiveEntitiesOfTypeInWorkspace(workspaceId: UUID, entityType: String) =
     sql" from ENTITY e where e.workspace_id = $workspaceId and e.entity_type = $entityType and e.deleted = 0"
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -1289,9 +1289,9 @@ class CompactEntityQuery(driverComponent: DriverComponent)
           FROM JSON_TABLE(
             e.attributes, '$$.refs[*]'
             COLUMNS (
-              a VARCHAR(254) PATH '$$.a',
-              t VARCHAR(254) PATH '$$.t',
-              n VARCHAR(254) PATH '$$.n'
+              a varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.a',
+              t varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin PATH '$$.t',
+              n varchar(254) PATH '$$.n'
             )
           ) jt
           WHERE jt.a IN (#$refsFilter)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-545

Benchmarking (in a dev workspace):

Original query: 
```
SELECT name, entity_type,
JSON_OBJECT(
'v', e.attributes -> '$.v',
'refs', e.attributes -> '$.refs',
'attrs', JSON_MERGE_PATCH(
JSON_OBJECT(),
IF(JSON_CONTAINS_PATH(e.attributes, 'one', '$.attrs."bam"'),
JSON_OBJECT('bam', e.attributes -> '$.attrs."bam"'),
JSON_OBJECT())
)
)
FROM ENTITY e
WHERE e.workspace_id=0x66A6F97BA0344459B858162501EAA690
AND e.entity_type='sample'
AND e.deleted = 0
ORDER BY name ASC
LIMIT 10 OFFSET 1;
```

Mysql explain analyze:
```
-> Limit/Offset: 10/1 row(s)  (cost=1848 rows=10) (actual time=0.0575..0.153 rows=10 loops=1)
    -> Filter: (e.deleted = 0)  (cost=1848 rows=1008) (actual time=0.048..0.151 rows=11 loops=1)
        -> Index lookup on e using idx_entity_type_name (workspace_id=0x66a6f97ba0344459b858162501eaa690, entity_type='sample'), with index condition: (e.workspace_id = 0x66a6f97ba0344459b858162501eaa690)  (cost=1848 rows=2015) (actual time=0.0467..0.148 rows=11 loops=1)
```

Updated query to only include refs for fields being filtered. Note: this was generated using Copilot, so there may be a better way to write this. I tested the behavior through the Rawls API and in the MySQL db to verify the expected results are returned:
```
SELECT name, entity_type,
JSON_OBJECT(
  'v', e.attributes -> '$.v',
  'refs', (
    SELECT IFNULL(
      JSON_ARRAYAGG(
        JSON_OBJECT(
          'a', jt.a,
          't', jt.t,
          'n', jt.n
        )
      ),
      JSON_ARRAY()
    )
    FROM JSON_TABLE(
      e.attributes, '$.refs[*]'
      COLUMNS (
        a VARCHAR(254) PATH '$.a',
        t VARCHAR(254) PATH '$.t',
        n VARCHAR(254) PATH '$.n'
      )
    ) jt
    WHERE jt.a IN (‘bam’)
  ),
  'attrs', JSON_MERGE_PATCH(
    JSON_OBJECT(),
    IF(JSON_CONTAINS_PATH(e.attributes, 'one', '$.attrs.bam'),
       JSON_OBJECT('bam', e.attributes -> '$.attrs.bam'),
       JSON_OBJECT())
  )
)
FROM ENTITY e
WHERE e.workspace_id=0x66A6F97BA0344459B858162501EAA690
  AND e.entity_type='sample'
  AND e.deleted=0
ORDER BY name ASC
LIMIT 10 OFFSET 1;
```

MySQL explain analyze:
```
| -> Limit/Offset: 10/1 row(s)  (cost=1848 rows=10) (actual time=0.0466..0.0978 rows=10 loops=1)
    -> Filter: (e.deleted = 0)  (cost=1848 rows=1008) (actual time=0.0373..0.0957 rows=11 loops=1)
        -> Index lookup on e using idx_entity_type_name (workspace_id=0x66a6f97ba0344459b858162501eaa690, entity_type='sample'), with index condition: (e.workspace_id = 0x66a6f97ba0344459b858162501eaa690)  (cost=1848 rows=2015) (actual time=0.0358..0.0926 rows=11 loops=1)
-> Select #2 (subquery in projection; dependent)
    -> Aggregate: json_arrayagg(json_object('a',jt.a,'t',jt.t,'n',jt.n))  (cost=0 rows=1) (actual time=0.00561..0.00567 rows=1 loops=10)
        -> Materialize table function  (actual time=0.0051..0.0051 rows=0 loops=10)
```

| Metric | First Query | Second Query | Improvement |
|--------|-------------|--------------|-------------|
| **Total time** | 0.153 ms | 0.0978 ms | **36% faster** |
| **Filter time** | 0.151 ms | 0.0957 ms | **37% faster** |
| **Index lookup time** | 0.148 ms | 0.0926 ms | **37% faster** |
| **Initial lookup time** | 0.0467 ms | 0.0358 ms | **23% faster** |

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
