### PR TITLE
CORE-734: remove trailing zeros from numbers in entities

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
@@ -3,7 +3,17 @@ package org.broadinstitute.dsde.rawls.entities.compact
 import org.broadinstitute.dsde.rawls.dataaccess.slick.CompactEntityAttributeListSerializer
 import org.broadinstitute.dsde.rawls.entities.exceptions.CompactEntityDeserializationException
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
-import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeEntityReference, AttributeEntityReferenceList, AttributeFormat, AttributeName, AttributeNumber, AttributeString, AttributeValueList, Entity}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeBoolean,
+  AttributeEntityReference,
+  AttributeEntityReferenceList,
+  AttributeFormat,
+  AttributeName,
+  AttributeNumber,
+  AttributeString,
+  AttributeValueList,
+  Entity
+}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import spray.json.{JsNumber, JsObject}
@@ -90,8 +100,8 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
   trailingZeroSerializationCases foreach { case (input, expected) =>
     it should s"strip trailing zeros from $input" in {
       import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.AttributeNameFormat
-        import spray.json.DefaultJsonProtocol._
-        import spray.json._
+      import spray.json.DefaultJsonProtocol._
+      import spray.json._
 
       implicit val attributeFormat: AttributeFormat = new AttributeFormat with CompactEntityAttributeListSerializer
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
@@ -1,19 +1,12 @@
 package org.broadinstitute.dsde.rawls.entities.compact
 
+import org.broadinstitute.dsde.rawls.dataaccess.slick.CompactEntityAttributeListSerializer
 import org.broadinstitute.dsde.rawls.entities.exceptions.CompactEntityDeserializationException
-import org.broadinstitute.dsde.rawls.model.{
-  AttributeBoolean,
-  AttributeEntityReference,
-  AttributeEntityReferenceList,
-  AttributeName,
-  AttributeNumber,
-  AttributeString,
-  AttributeValueList,
-  Entity
-}
+import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
+import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeEntityReference, AttributeEntityReferenceList, AttributeFormat, AttributeName, AttributeNumber, AttributeString, AttributeValueList, Entity}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import spray.json.{JsArray, JsNumber, JsObject}
+import spray.json.{JsNumber, JsObject}
 
 class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with CompactEntitySerialization {
 
@@ -81,6 +74,33 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
     actual.attrs(singleref) shouldBe AttributeString("targetName1")
     actual.attrs.keys should contain(reflist)
     actual.attrs(reflist) shouldBe AttributeNumber(2)
+  }
+
+  behavior of "AttributeFormat serialization"
+
+  val trailingZeroSerializationCases = Map(
+    "1" -> "1",
+    "1.0" -> "1",
+    "1.1" -> "1.1",
+    "1.10" -> "1.1",
+    "99999.0000" -> "99999"
+  )
+
+  // note this is serialization of an entity via `AttributeFormat`, not via `CompactEntitySerialization`
+  trailingZeroSerializationCases foreach { case (input, expected) =>
+    it should s"strip trailing zeros from $input" in {
+      import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.AttributeNameFormat
+        import spray.json.DefaultJsonProtocol._
+        import spray.json._
+
+      implicit val attributeFormat: AttributeFormat = new AttributeFormat with CompactEntityAttributeListSerializer
+
+      val attrs: AttributeMap = Map(
+        AttributeName.withDefaultNS("foo") -> AttributeNumber(BigDecimal(input))
+      )
+      val serialized = attrs.toJson.compactPrint
+      serialized shouldBe s"""{"foo":$expected}"""
+    }
   }
 
   behavior of "Attribute deserialization"
@@ -178,6 +198,37 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
 
     val actual = fromSql(Option(input))
     actual shouldBe expected
+  }
+
+  val trailingZeroDeserializationCases = Map(
+    "1" -> "1",
+    "1.0" -> "1",
+    "1.1" -> "1.1",
+    "1.10" -> "1.1",
+    "99999.0000" -> "99999"
+  )
+
+  trailingZeroDeserializationCases foreach { case (inputVal, expectedVal) =>
+    it should s"strip trailing zeros when deserializing $inputVal" in {
+      val input =
+        s"""{ "v": 2,
+         "attrs": {"hello": "world", "mynum": $inputVal, "somelist": [true, false] },
+         "refs": []
+       }"""
+
+      val expected = Map(
+        AttributeName.fromDelimitedName("hello") -> AttributeString("world"),
+        AttributeName.fromDelimitedName("mynum") -> AttributeNumber(
+          BigDecimal(expectedVal).bigDecimal.stripTrailingZeros()
+        ),
+        AttributeName.fromDelimitedName("somelist") -> AttributeValueList(
+          Seq(AttributeBoolean(true), AttributeBoolean(false))
+        )
+      )
+
+      val actual = fromSql(Option(input))
+      actual shouldBe expected
+    }
   }
 
   it should "throw if the attributes sub-object is missing" in {

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
@@ -124,7 +124,7 @@ trait AttributeFormat extends RootJsonFormat[Attribute] with AttributeListSerial
     // vals
     case AttributeNull            => JsNull
     case AttributeBoolean(b)      => JsBoolean(b)
-    case AttributeNumber(n)       => JsNumber(n)
+    case AttributeNumber(n)       => JsNumber(n.bigDecimal.stripTrailingZeros()) // remove any trailing zeros
     case AttributeString(s)       => JsString(s)
     case AttributeValueRawJson(j) => j
     // ref

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
@@ -144,7 +144,7 @@ trait AttributeFormat extends RootJsonFormat[Attribute] with AttributeListSerial
     case JsNull       => AttributeNull
     case JsString(s)  => AttributeString(s)
     case JsBoolean(b) => AttributeBoolean(b)
-    case JsNumber(n)  => AttributeNumber(n)
+    case JsNumber(n)  => AttributeNumber(n.bigDecimal.stripTrailingZeros()) // remove any trailing zeros
     // NOTE: we handle AttributeValueRawJson in readComplexType below
 
     case JsObject(members) if ENTITY_OBJECT_KEYS subsetOf members.keySet =>


### PR DESCRIPTION
Ticket: CORE-734

We now strip trailing zeros from numbers in data tables in two places:
1. When serializing an entity to JSON, such as when delivering an API response payload or when storing in the db
2. When deserializing an entity from MySQL

This should effectively remove trailing zeros from all numbers in almost every situation.

Note this does NOT fix CORE-735, which deals with column filtering on these values.




