### PR TITLE
CORE-735: column filters understand numerics

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -29,11 +29,11 @@ import slick.jdbc._
 import slick.sql.SqlStreamingAction
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.model.ErrorReport
-
 import spray.json._
 
 import scala.concurrent.ExecutionContext
 import scala.language.postfixOps
+import scala.util.{Failure, Success, Try}
 
 trait CompactEntityComponent extends LazyLogging {
   this: DriverComponent =>
@@ -1333,8 +1333,24 @@ class CompactEntityQuery(driverComponent: DriverComponent)
   }
 
   private def columnFilterCondition(columnFilter: EntityColumnFilter) =
-    // CAST, JSON_UNQUOTE and JSON_EXTRACT are used to handle strings and numbers and do a case insensitive comparison
-    sql" and CAST(e.attributes ->> ${slickAttributePath(columnFilter.attributeName)} AS CHAR) = ${columnFilter.term}"
+    // Can the filter term be parsed as a number?
+    Try(columnFilter.term.toDouble) match {
+      case Failure(_) =>
+        sql" and CAST(e.attributes ->> ${slickAttributePath(columnFilter.attributeName)} AS CHAR) = ${columnFilter.term}"
+      case Success(dbl) =>
+        // The user-supplied filter term is a number. If the attribute in the database is also a number, compare
+        // number-to-number in the WHERE clause. If the attribute in the database is anything else, treat both the
+        // attribute and the filter term as strings and compare those.
+        sql""" and (
+          (
+            JSON_TYPE(e.attributes -> ${slickAttributePath(columnFilter.attributeName)}) in ('INTEGER', 'DOUBLE')
+            AND
+            e.attributes -> ${slickAttributePath(columnFilter.attributeName)} = $dbl
+          )
+          OR
+          CAST(e.attributes ->> ${slickAttributePath(columnFilter.attributeName)} AS CHAR) = ${columnFilter.term}
+        )"""
+    }
 
   private def orderBy(entityQuery: EntityQuery): SQLActionBuilder =
     concatSqlActions(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponentSpec.scala
@@ -2298,7 +2298,7 @@ class CompactEntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatch
   }
 
   private val columnFilterCases = List(
-    (AttributeNumber(42), "42"),
+    (AttributeNumber(42), "42.0"),
     (AttributeString("foo"), "foo"),
     (AttributeString("fOo"), "foO"), // case sensitivity check
     (AttributeBoolean(true), "TRUE")


### PR DESCRIPTION
Ticket: CORE-735

When filtering a data table for exact-match on a specific column, we previously always cast numerics to strings. This means that if the database contains `8.0` and you search on `8` ... or if the database contains `7` and you search on `7.0`, rows will not be found.

This PR changes the SQL such that if the search term and the database both contain numbers, we don't cast them to strings.