### PR TITLE
CORE-734: avoid scientific notation when de/serializing Quicksilver numbers

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
@@ -95,7 +95,8 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
     "1.10" -> "1.1",
     "10" -> "10",
     "50" -> "50",
-    "99999.0000" -> "99999"
+    "99999.0000" -> "99999",
+    "-123456.7890" -> "-123456.789"
   )
 
   // note this is serialization of an entity via `AttributeFormat`, not via `CompactEntitySerialization`
@@ -220,7 +221,8 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
     "10" -> "10",
     "50" -> "50",
     "5E+1" -> "50",
-    "99999.0000" -> "99999"
+    "99999.0000" -> "99999",
+    "-123456.7890" -> "-123456.789"
   )
 
   trailingZeroDeserializationCases foreach { case (inputVal, expectedVal) =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
@@ -95,6 +95,7 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
     "1.10" -> "1.1",
     "10" -> "10",
     "50" -> "50",
+    "5E+1" -> "50",
     "99999.0000" -> "99999",
     "-123456.7890" -> "-123456.789"
   )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntitySerializationSpec.scala
@@ -93,6 +93,8 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
     "1.0" -> "1",
     "1.1" -> "1.1",
     "1.10" -> "1.1",
+    "10" -> "10",
+    "50" -> "50",
     "99999.0000" -> "99999"
   )
 
@@ -215,6 +217,9 @@ class CompactEntitySerializationSpec extends AnyFlatSpec with Matchers with Comp
     "1.0" -> "1",
     "1.1" -> "1.1",
     "1.10" -> "1.1",
+    "10" -> "10",
+    "50" -> "50",
+    "5E+1" -> "50",
     "99999.0000" -> "99999"
   )
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
@@ -122,9 +122,11 @@ trait AttributeFormat extends RootJsonFormat[Attribute] with AttributeListSerial
   override def write(obj: Attribute): JsValue = writeAttribute(obj)
   def writeAttribute(obj: Attribute): JsValue = obj match {
     // vals
-    case AttributeNull            => JsNull
-    case AttributeBoolean(b)      => JsBoolean(b)
-    case AttributeNumber(n)       => JsNumber(n.bigDecimal.stripTrailingZeros()) // remove any trailing zeros
+    case AttributeNull       => JsNull
+    case AttributeBoolean(b) => JsBoolean(b)
+    // remove any trailing zeros and avoid scientific notation
+    case AttributeNumber(n) =>
+      JsNumber(BigDecimal(n.bigDecimal.stripTrailingZeros().toPlainString))
     case AttributeString(s)       => JsString(s)
     case AttributeValueRawJson(j) => j
     // ref
@@ -144,7 +146,8 @@ trait AttributeFormat extends RootJsonFormat[Attribute] with AttributeListSerial
     case JsNull       => AttributeNull
     case JsString(s)  => AttributeString(s)
     case JsBoolean(b) => AttributeBoolean(b)
-    case JsNumber(n)  => AttributeNumber(n.bigDecimal.stripTrailingZeros()) // remove any trailing zeros
+    // remove any trailing zeros and avoid scientific notation
+    case JsNumber(n) => AttributeNumber(BigDecimal(n.bigDecimal.stripTrailingZeros().toPlainString))
     // NOTE: we handle AttributeValueRawJson in readComplexType below
 
     case JsObject(members) if ENTITY_OBJECT_KEYS subsetOf members.keySet =>


### PR DESCRIPTION
Ticket: CORE-734

When serializing or deserializing Quicksilver entities, if that entity contained a "round" number like `50`, we could serialize that number in scientific notation: `5E+1`. This caused problems with some clients.

This PR tweaks the serialization/deserialization to avoid scientific notation.

### Before
<img width="1375" height="917" alt="Screenshot 2025-10-28 at 12 41 00 PM" src="https://github.com/user-attachments/assets/a67213f4-2977-438f-aeee-ea21db29e678" />

### After
<img width="1088" height="946" alt="Screenshot 2025-10-28 at 12 41 10 PM" src="https://github.com/user-attachments/assets/de57af58-97e9-4a99-8ad3-bd6fe5173bba" />

