### PR TITLE
CORE-515: delete usages of all_attribute_values column

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -71,25 +71,14 @@ class EntityTable(tag: Tag) extends EntityTableBase[EntityRecord](tag) {
     (id, name, entityType, workspaceId, version, deleted, deletedDate) <> (EntityRecord.tupled, EntityRecord.unapply)
 }
 
-class EntityTableWithInlineAttributes(tag: Tag) extends EntityTableBase[EntityRecord](tag) {
-  def * = (id, name, entityType, workspaceId, version, deleted, deletedDate) <> (
-    EntityRecord.tupled,
-    EntityRecord.unapply
-  )
-}
-
 //noinspection TypeAnnotation
 trait EntityComponent {
   this: DriverComponent with WorkspaceComponent with AttributeComponent =>
 
-  object entityQueryWithInlineAttributes extends TableQuery(new EntityTable(_)) {
-    type EntityQueryWithInlineAttributes = Query[EntityTable, EntityRecord, Seq]
+  object entityQuery extends TableQuery(new EntityTable(_)) with LazyLogging {
 
-    // only used by tests
-    def findEntityByName(workspaceId: UUID, entityType: String, entityName: String): EntityQueryWithInlineAttributes =
-      filter(entRec =>
-        entRec.name === entityName && entRec.entityType === entityType && entRec.workspaceId === workspaceId
-      )
+    type EntityQuery = Query[EntityTable, EntityRecord, Seq]
+    type EntityAttributeQuery = Query[EntityAttributeTable, EntityAttributeRecord, Seq]
 
     def batchInsertEntities(workspaceContext: Workspace,
                             entities: TraversableOnce[Entity]
@@ -102,7 +91,7 @@ trait EntityComponent {
 
         workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID) andThen
           DBIO
-            .sequence(entityRecs.grouped(batchSize).map(entityQueryWithInlineAttributes ++= _))
+            .sequence(entityRecs.grouped(batchSize).map(entityQuery ++= _))
             .map(_.flatten.sum)
             .andThen(
               entityQuery.getEntityRecords(workspaceContext.workspaceIdAsUUID, entityRecs.map(_.toReference).toSet)
@@ -128,7 +117,7 @@ trait EntityComponent {
     def optimisticLockUpdate(entityRecs: Seq[EntityRecord],
                              entities: Traversable[Entity]
     ): ReadWriteAction[Seq[Int]] = {
-      def findEntityByIdAndVersion(id: Long, version: Long): EntityQueryWithInlineAttributes =
+      def findEntityByIdAndVersion(id: Long, version: Long): EntityQuery =
         filter(rec => rec.id === id && rec.version === version)
 
       def optimisticLockUpdateOne(originalRec: EntityRecord): ReadWriteAction[Int] =
@@ -144,12 +133,6 @@ trait EntityComponent {
 
       DBIO.sequence(entityRecs map optimisticLockUpdateOne)
     }
-  }
-
-  object entityQuery extends TableQuery(new EntityTable(_)) with LazyLogging {
-
-    type EntityQuery = Query[EntityTable, EntityRecord, Seq]
-    type EntityAttributeQuery = Query[EntityAttributeTable, EntityAttributeRecord, Seq]
 
     // Raw queries - used when querying for multiple AttributeEntityReferences
 
@@ -938,7 +921,7 @@ trait EntityComponent {
           getEntityRecords(workspaceContext.workspaceIdAsUUID, entities.map(_.toReference).toSet)
         )
         savingEntityRecs <- traceDBIOWithParent("insertNewEntities", parentContext)(_ =>
-          entityQueryWithInlineAttributes
+          entityQuery
             .insertNewEntities(workspaceContext, entities, preExistingEntityRecs.map(_.toReference))
             .map(_ ++ preExistingEntityRecs)
         )
@@ -972,7 +955,7 @@ trait EntityComponent {
         recsToUpdate = (actuallyUpdatedPreExistingEntityRecs ++ insertedRepeats).distinct
 
         _ <- traceDBIOWithParent("optimisticLockUpdate", parentContext)(_ =>
-          entityQueryWithInlineAttributes.optimisticLockUpdate(recsToUpdate, entities)
+          entityQuery.optimisticLockUpdate(recsToUpdate, entities)
         )
       } yield entities
     }
@@ -1323,8 +1306,6 @@ trait EntityComponent {
       }
 
     // Unmarshal methods
-
-    // NOTE: marshalNewEntity is in entityQueryWithInlineAttributes because it helps save the inline attributes to DB
 
     private def unmarshalEntity(entityRecord: EntityRecord, attributes: AttributeMap): Entity =
       Entity(entityRecord.name, entityRecord.entityType, attributes)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -31,16 +31,8 @@ sealed trait EntityRecordBase {
   val deletedDate: Option[Timestamp]
 
   def toReference = AttributeEntityReference(entityType, name)
-  def withoutAllAttributeValues = EntityRecord(id, name, entityType, workspaceId, recordVersion, deleted, deletedDate)
-  def withAllAttributeValues(allAttributeValues: Option[String]) = EntityRecordWithInlineAttributes(id,
-                                                                                                    name,
-                                                                                                    entityType,
-                                                                                                    workspaceId,
-                                                                                                    recordVersion,
-                                                                                                    allAttributeValues,
-                                                                                                    deleted,
-                                                                                                    deletedDate
-  )
+  def withAllAttributeValues =
+    EntityRecordWithInlineAttributes(id, name, entityType, workspaceId, recordVersion, deleted, deletedDate)
 }
 
 case class EntityRecord(id: Long,
@@ -57,7 +49,6 @@ case class EntityRecordWithInlineAttributes(id: Long,
                                             entityType: String,
                                             workspaceId: UUID,
                                             recordVersion: Long,
-                                            allAttributeValues: Option[String],
                                             deleted: Boolean,
                                             deletedDate: Option[Timestamp]
 ) extends EntityRecordBase
@@ -67,11 +58,6 @@ case class EntityAndAttributesResult(entityRecord: EntityRecord,
                                      attributeRecord: Option[EntityAttributeRecord],
                                      refEntityRecord: Option[EntityRecord]
 )
-
-object EntityComponent {
-  // the length of the all_attribute_values column, which is TEXT, minus a few bytes because i'm nervous
-  val allAttributeValuesColumnSize = 65532
-}
 
 import slick.jdbc.MySQLProfile.api._
 
@@ -95,9 +81,7 @@ class EntityTable(tag: Tag) extends EntityTableBase[EntityRecord](tag) {
 }
 
 class EntityTableWithInlineAttributes(tag: Tag) extends EntityTableBase[EntityRecordWithInlineAttributes](tag) {
-  def allAttributeValues = column[Option[String]]("all_attribute_values")
-
-  def * = (id, name, entityType, workspaceId, version, allAttributeValues, deleted, deletedDate) <> (
+  def * = (id, name, entityType, workspaceId, version, deleted, deletedDate) <> (
     EntityRecordWithInlineAttributes.tupled,
     EntityRecordWithInlineAttributes.unapply
   )
@@ -116,31 +100,6 @@ trait EntityComponent {
         entRec.name === entityName && entRec.entityType === entityType && entRec.workspaceId === workspaceId
       )
 
-    @tailrec
-    def collectAttributeStrings(toProcess: Iterable[Attribute], processed: List[String], charsRemaining: Int): String =
-      if (toProcess.isEmpty || charsRemaining <= 0)
-        processed.mkString(" ")
-      else {
-        val nextAttr = AttributeStringifier(toProcess.head)
-        collectAttributeStrings(toProcess.tail, processed :+ nextAttr, charsRemaining - nextAttr.length - 1)
-      }
-
-    private def createAllAttributesString(entity: Entity): Option[String] = {
-      // maxLength is the max number of *bytes* we want to insert into the db
-      val maxLength = EntityComponent.allAttributeValuesColumnSize
-      // generate the all_attribute_values string. This has {maxLength} *characters* in it; if it contains multi-byte
-      // characters then it will have > {maxLength} bytes in it
-      val raw =
-        s"${entity.name} ${collectAttributeStrings(entity.attributes.values.filterNot(_.isInstanceOf[AttributeList[_]]), List(), maxLength)}".toLowerCase
-      // take the first {maxLength} bytes from the all_attribute_values string
-      val bytes = raw.getBytes(StandardCharsets.UTF_8).take(maxLength)
-      // convert the bytes back into a string. If the last character was a multi-byte character and we truncated it,
-      // the last character will be corrupted, but we accept that possibility
-      val limited = new String(bytes, StandardCharsets.UTF_8)
-
-      Option(limited)
-    }
-
     def batchInsertEntities(workspaceContext: Workspace,
                             entities: TraversableOnce[Entity]
     ): ReadWriteAction[Seq[EntityRecord]] = {
@@ -150,7 +109,6 @@ trait EntityComponent {
                                          entity.entityType,
                                          workspaceId,
                                          0,
-                                         createAllAttributesString(entity),
                                          deleted = false,
                                          deletedDate = None
         )
@@ -187,22 +145,11 @@ trait EntityComponent {
                              entities: Traversable[Entity]
     ): ReadWriteAction[Seq[Int]] = {
       def populateAllAttributeValues(entityRecsFromDb: Seq[EntityRecord],
-                                     entitiesToSave: Traversable[Entity]
-      ): Seq[EntityRecordWithInlineAttributes] = {
-        // "entitiesToSave" may contain duplicate entities. Ensure that we merge attributes for any duplicates
-        // before grabbing their values.
-        val entitiesByRef = entitiesToSave
-          .foldLeft(Map.empty[AttributeEntityReference, Entity]) { (acc, e) =>
-            val ref = e.toReference
-            acc.get(ref) match {
-              case None          => acc + ((ref, e))
-              case Some(current) => acc.updated(ref, current.copy(attributes = current.attributes ++ e.attributes))
-            }
-          }
+                                     _entitiesToSave: Traversable[Entity]
+      ): Seq[EntityRecordWithInlineAttributes] =
         entityRecsFromDb map { rec =>
-          rec.withAllAttributeValues(createAllAttributesString(entitiesByRef(rec.toReference)))
+          rec.withAllAttributeValues
         }
-      }
 
       def findEntityByIdAndVersion(id: Long, version: Long): EntityQueryWithInlineAttributes =
         filter(rec => rec.id === id && rec.version === version)
@@ -417,23 +364,7 @@ trait EntityComponent {
       }
 
       // generate the clause to filter based on user search terms
-      def paginationFilterSql(prefix: String, alias: String, entityQuery: model.EntityQuery) = {
-        val filtersOption = entityQuery.filterTerms.map {
-          _.split(" ").toSeq.map { term =>
-            sql"concat(#$alias.name, ' ', #$alias.all_attribute_values) like ${'%' + term.toLowerCase + '%'}"
-          }
-        }
-
-        filtersOption match {
-          case None => sql""
-          case Some(filters) =>
-            concatSqlActions(
-              sql"#$prefix (",
-              reduceSqlActionsWithDelim(filters, sql" #${FilterOperators.toSql(entityQuery.filterOperator)} "),
-              sql") "
-            )
-        }
-      }
+      def paginationFilterSql(prefix: String, alias: String, entityQuery: model.EntityQuery) = sql""
 
       def activeActionForMetadata(workspaceContext: Workspace,
                                   entityType: String,
@@ -489,7 +420,7 @@ trait EntityComponent {
           Lots of conditionals in here, to achieve the optimal SQL query for any given request. Pseudocode:
 
           When sorting by name, and requesting no attributes:
-            select from ENTITY e order by e.name, with optional filter on e.all_attribute_values, limit, offset.
+            select from ENTITY e order by e.name, with optional limit, offset.
 
           All other requests:
             select from ENTITY e
@@ -498,7 +429,6 @@ trait EntityComponent {
               join (subquery of select attribute-being-sorted-on from ENTITY
                       left join ENTITY_ATTRIBUTE
                       left join ENTITY
-                      optional filter on e.all_attribute_values
                       sort by attribute, limit, offset) to get the proper pagination
          */
 
@@ -733,8 +663,8 @@ trait EntityComponent {
       ): WriteAction[Int] = {
 
         val baseInsert =
-          sql"""insert into ENTITY (name, entity_type, workspace_id, record_version, all_attribute_values, deleted, deleted_date)
-                select name, entity_type, $newWorkspaceId, record_version, all_attribute_values, 0, null from ENTITY e where workspace_id = $clonedWorkspaceId and deleted = 0
+          sql"""insert into ENTITY (name, entity_type, workspace_id, record_version, deleted, deleted_date)
+                select name, entity_type, $newWorkspaceId, record_version, 0, null from ENTITY e where workspace_id = $clonedWorkspaceId and deleted = 0
           """
         addEntitiesToWhereIfNeeded(entityRefs, baseInsert).head
       }
@@ -1053,8 +983,7 @@ trait EntityComponent {
         )
 
         // find any entities that were repeated in the input payload. These repeated entities
-        // may translate to one insert and one update; we need to make sure the extra updates
-        // properly calculate all_attribute_values in the call to optimisticLockUpdate below.
+        // may translate to one insert and one update.
         repeats = entities.groupBy(_.toReference).filter(_._2.size > 1).keySet
         // narrow the repeats to only those that triggered an insert (as opposed to repeats
         // being multiple updates)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -32,7 +32,7 @@ sealed trait EntityRecordBase {
 
   def toReference = AttributeEntityReference(entityType, name)
   def withAllAttributeValues =
-    EntityRecordWithInlineAttributes(id, name, entityType, workspaceId, recordVersion, deleted, deletedDate)
+    EntityRecord(id, name, entityType, workspaceId, recordVersion, deleted, deletedDate)
 }
 
 case class EntityRecord(id: Long,
@@ -42,15 +42,6 @@ case class EntityRecord(id: Long,
                         recordVersion: Long,
                         deleted: Boolean,
                         deletedDate: Option[Timestamp]
-) extends EntityRecordBase
-
-case class EntityRecordWithInlineAttributes(id: Long,
-                                            name: String,
-                                            entityType: String,
-                                            workspaceId: UUID,
-                                            recordVersion: Long,
-                                            deleted: Boolean,
-                                            deletedDate: Option[Timestamp]
 ) extends EntityRecordBase
 
 // result structure from entity and attribute list raw sql
@@ -80,10 +71,10 @@ class EntityTable(tag: Tag) extends EntityTableBase[EntityRecord](tag) {
     (id, name, entityType, workspaceId, version, deleted, deletedDate) <> (EntityRecord.tupled, EntityRecord.unapply)
 }
 
-class EntityTableWithInlineAttributes(tag: Tag) extends EntityTableBase[EntityRecordWithInlineAttributes](tag) {
+class EntityTableWithInlineAttributes(tag: Tag) extends EntityTableBase[EntityRecord](tag) {
   def * = (id, name, entityType, workspaceId, version, deleted, deletedDate) <> (
-    EntityRecordWithInlineAttributes.tupled,
-    EntityRecordWithInlineAttributes.unapply
+    EntityRecord.tupled,
+    EntityRecord.unapply
   )
 }
 
@@ -91,8 +82,8 @@ class EntityTableWithInlineAttributes(tag: Tag) extends EntityTableBase[EntityRe
 trait EntityComponent {
   this: DriverComponent with WorkspaceComponent with AttributeComponent =>
 
-  object entityQueryWithInlineAttributes extends TableQuery(new EntityTableWithInlineAttributes(_)) {
-    type EntityQueryWithInlineAttributes = Query[EntityTableWithInlineAttributes, EntityRecordWithInlineAttributes, Seq]
+  object entityQueryWithInlineAttributes extends TableQuery(new EntityTable(_)) {
+    type EntityQueryWithInlineAttributes = Query[EntityTable, EntityRecord, Seq]
 
     // only used by tests
     def findEntityByName(workspaceId: UUID, entityType: String, entityName: String): EntityQueryWithInlineAttributes =
@@ -103,15 +94,8 @@ trait EntityComponent {
     def batchInsertEntities(workspaceContext: Workspace,
                             entities: TraversableOnce[Entity]
     ): ReadWriteAction[Seq[EntityRecord]] = {
-      def marshalNewEntity(entity: Entity, workspaceId: UUID): EntityRecordWithInlineAttributes =
-        EntityRecordWithInlineAttributes(0,
-                                         entity.name,
-                                         entity.entityType,
-                                         workspaceId,
-                                         0,
-                                         deleted = false,
-                                         deletedDate = None
-        )
+      def marshalNewEntity(entity: Entity, workspaceId: UUID): EntityRecord =
+        EntityRecord(0, entity.name, entity.entityType, workspaceId, 0, deleted = false, deletedDate = None)
 
       if (entities.nonEmpty) {
         val entityRecs = entities.toSeq.map(e => marshalNewEntity(e, workspaceContext.workspaceIdAsUUID))
@@ -144,17 +128,10 @@ trait EntityComponent {
     def optimisticLockUpdate(entityRecs: Seq[EntityRecord],
                              entities: Traversable[Entity]
     ): ReadWriteAction[Seq[Int]] = {
-      def populateAllAttributeValues(entityRecsFromDb: Seq[EntityRecord],
-                                     _entitiesToSave: Traversable[Entity]
-      ): Seq[EntityRecordWithInlineAttributes] =
-        entityRecsFromDb map { rec =>
-          rec.withAllAttributeValues
-        }
-
       def findEntityByIdAndVersion(id: Long, version: Long): EntityQueryWithInlineAttributes =
         filter(rec => rec.id === id && rec.version === version)
 
-      def optimisticLockUpdateOne(originalRec: EntityRecordWithInlineAttributes): ReadWriteAction[Int] =
+      def optimisticLockUpdateOne(originalRec: EntityRecord): ReadWriteAction[Int] =
         findEntityByIdAndVersion(originalRec.id, originalRec.recordVersion) update originalRec.copy(recordVersion =
           originalRec.recordVersion + 1
         ) map {
@@ -165,7 +142,7 @@ trait EntityComponent {
           case success => success
         }
 
-      DBIO.sequence(populateAllAttributeValues(entityRecs, entities) map optimisticLockUpdateOne)
+      DBIO.sequence(entityRecs map optimisticLockUpdateOne)
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -506,7 +506,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
       // did we save the entity?
       val entityWithAllAttrs = runAndWait(
-        entityQueryWithInlineAttributes
+        entityQuery
           .findEntityByName(legacyTestData.workspace.workspaceIdAsUUID, "Sample", "some-sample")
           .result
       )
@@ -522,7 +522,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
       // did we update the record versions?
       val entityWithAllAttrs = runAndWait(
-        entityQueryWithInlineAttributes
+        entityQuery
           .findEntityByName(legacyTestData.workspace.workspaceIdAsUUID, "Sample", "some-sample")
           .result
       )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -332,48 +332,6 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   val testWorkspace = new EmptyWorkspace
 
-  it should "trim giant all_attribute_values strings so they don't overflow" in withCustomTestDatabase(testWorkspace) {
-    dataSource =>
-      /*
-       Create a long string composed of the recycle-symbol emoji. This string has 65534/4 characters in it, and we
-       will insert four copies of it into separate string attributes.
-
-       The recycle symbol used here is a triple-byte character. This means that each string is ~49151 bytes long.
-
-       Both the all_attributes_value and attribute_string columns in the db have a max byte length of 65535. We use
-       four separate attributes to ensure we will not overflow the attribute_string column ... but when concatenated
-       together, the value WOULD overflow all_attribute_values unless our trimming logic came into play.
-
-       This test verifies the all_attribute_values trimming logic.
-       */
-      val veryLongString = "♲" * (EntityComponent.allAttributeValuesColumnSize / 4)
-      val sample1 = Entity(
-        "sample1",
-        "Sample",
-        Map(
-          AttributeName.withDefaultNS("veryLongString1") -> AttributeString(veryLongString),
-          AttributeName.withDefaultNS("veryLongString2") -> AttributeString(veryLongString),
-          AttributeName.withDefaultNS("veryLongString3") -> AttributeString(veryLongString),
-          AttributeName.withDefaultNS("veryLongString4") -> AttributeString(veryLongString)
-        )
-      )
-      withWorkspaceContext(testWorkspace.workspace) { context =>
-        runAndWait(entityQuery.save(context, sample1))
-
-        val entityRec = runAndWait(
-          uniqueResult(
-            entityQueryWithInlineAttributes
-              .findEntityByName(UUID.fromString(testWorkspace.workspace.workspaceId), "Sample", "sample1")
-              .result
-          )
-        )
-        // measure the byte size of the actual value is exactly what we specified
-        assertResult(EntityComponent.allAttributeValuesColumnSize) {
-          entityRec.get.allAttributeValues.get.getBytes(StandardCharsets.UTF_8).length
-        }
-      }
-  }
-
   class BugTestData extends TestData {
     val wsName = WorkspaceName("myNamespace2", "myWorkspace2")
     val workspace = Workspace(wsName.namespace,
@@ -547,7 +505,6 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       runAndWait(entityQuery.save(context, makeEntity(0)))
 
       // did we save the entity?
-      // did we populate its all_attribute_values?
       val entityWithAllAttrs = runAndWait(
         entityQueryWithInlineAttributes
           .findEntityByName(legacyTestData.workspace.workspaceIdAsUUID, "Sample", "some-sample")
@@ -555,8 +512,6 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       )
       entityWithAllAttrs should have length 1
       entityWithAllAttrs.head.recordVersion shouldBe 0
-      entityWithAllAttrs.head.allAttributeValues should not be empty
-      entityWithAllAttrs.head.allAttributeValues.get should include("index-0")
     }
 
     withWorkspaceContext(legacyTestData.workspace) { context =>
@@ -565,7 +520,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         runAndWait(entityQuery.save(context, makeEntity(idx)))
       }
 
-      // did we update the record versions and populate its all_attribute_values?
+      // did we update the record versions?
       val entityWithAllAttrs = runAndWait(
         entityQueryWithInlineAttributes
           .findEntityByName(legacyTestData.workspace.workspaceIdAsUUID, "Sample", "some-sample")
@@ -573,11 +528,6 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       )
       entityWithAllAttrs should have length 1
       entityWithAllAttrs.head.recordVersion shouldBe count
-      entityWithAllAttrs.head.allAttributeValues should not be empty
-      entityWithAllAttrs.head.allAttributeValues.get should not be empty
-      entityWithAllAttrs.head.allAttributeValues.get should include(
-        "index-20"
-      ) // we should have updated to the newest value
     }
   }
 
@@ -1360,58 +1310,6 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     }
   }
 
-  it should "select the all_attribute_values column when using entityQueryWithInlineAttributes and not otherwise" in withLegacyDefaultTestDatabase {
-    withWorkspaceContext(legacyTestData.workspace) { context =>
-      val hasAttrs = Entity(
-        "entityWithAttrs",
-        "Pair",
-        Map(
-          AttributeName.withDefaultNS("attrOne") -> AttributeString("one"),
-          AttributeName.withDefaultNS("attrTwo") -> AttributeString("two"),
-          AttributeName.withDefaultNS("attrThree") -> AttributeString("three"),
-          AttributeName.withDefaultNS("attrFour") -> AttributeString("four")
-        )
-      )
-
-      runAndWait(entityQuery.save(context, hasAttrs))
-
-      val recWithAttrs = runAndWait(
-        entityQueryWithInlineAttributes
-          .filter(e => e.name === "entityWithAttrs" && e.entityType === "Pair")
-          .result
-          .headOption
-      )
-
-      assert(recWithAttrs.isDefined, "entityQuery should find the record")
-      withClue(
-        "entityQueryWithInlineAttributes should return an EntityRecordWithInlineAttributes, which has allAttributeValues"
-      ) {
-        recWithAttrs shouldBe an[Option[EntityRecordWithInlineAttributes]]
-      }
-      assertResult(Some(Some("entitywithattrs one two three four")), "entityQuery should return allAttributeValues") {
-        recWithAttrs.map(_.allAttributeValues)
-      }
-
-      val recWithoutAttrs = runAndWait(
-        entityQuery
-          .filter(e => e.name === "entityWithAttrs" && e.entityType === "Pair")
-          .result
-          .headOption
-      )
-
-      assert(recWithoutAttrs.isDefined, "entityQuery should find the record")
-      withClue("entityQuery should return an EntityRecord, which does not have allAttributeValues") {
-        recWithoutAttrs shouldBe an[Option[EntityRecord]]
-      }
-
-      assertResult(recWithoutAttrs,
-                   "entityQuery and entityQueryWithInlineAttributes should return the same record otherwise"
-      ) {
-        recWithAttrs.map(_.withoutAllAttributeValues)
-      }
-    }
-  }
-
   private def caseSensitivityFixtures(context: Workspace) = {
     val entitiesToSave = Seq(
       Entity("name-1",
@@ -1464,34 +1362,6 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
               runAndWait(entityQuery.loadEntityPageCounts(context, typeName, unfilteredQuery, testContext))
             pageResult._2 should be > 0
             pageResult._2 shouldBe pageResult._1
-          }
-        }
-      }
-    }
-  }
-
-  val filterFixtures = Map(
-    "mytype" -> Map("bar" -> 2, "value1" -> 1, "value" -> 3, "nonexistent" -> 0),
-    "anothertype" -> Map("value5" -> 1, "value" -> 2, "alsononexistent" -> 0)
-  )
-
-  filterFixtures foreach { typeFixtures =>
-    val typeName = typeFixtures._1
-    val typeTests = typeFixtures._2
-    typeTests foreach { test =>
-      val filterTerm = test._1
-      val expectedCount = test._2
-      List("name", "case", "CASE") foreach { sortKey =>
-        List(SortDirections.Ascending, SortDirections.Descending) foreach { sortDir =>
-          it should s"return expected count ($expectedCount) for type=[$typeName], sortKey=[$sortKey], sortDir=[$sortDir], term [$filterTerm]" in withCustomTestDatabase(
-            emptyWorkspace
-          ) { _ =>
-            withWorkspaceContext(emptyWorkspace.workspace) { context =>
-              caseSensitivityFixtures(context)
-              val filterQuery = EntityQuery(1, 1, sortKey, sortDir, Some(filterTerm))
-              val pageResult = runAndWait(entityQuery.loadEntityPageCounts(context, typeName, filterQuery, testContext))
-              pageResult._2 shouldBe expectedCount
-            }
           }
         }
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -99,16 +99,6 @@ class LocalEntityProviderSpec
                                                 AttributeName.withDefaultNS("two") -> AttributeString("222")
                                             )
         )
-
-        val withAllAttrs = runAndWait(
-          dataSource.dataAccess.entityQueryWithInlineAttributes
-            .findEntityByName(localEntityProviderTestData.workspace.workspaceIdAsUUID, "mytype", "myname")
-            .result
-        )
-
-        withAllAttrs.size shouldBe 1
-        val allAttrs = withAllAttrs.head.allAttributeValues.getOrElse("")
-        allAttrs shouldBe "myname 111 222"
     }
 
   }


### PR DESCRIPTION
Ticket: CORE-515

Delete all Scala code that references the `ENTITY.all_attribute_values` column. This is a prerequisite to dropping that column.

I have not tried to make this deletion very clean; it leaves behind some messy code. We will be deleting all/most of this code entirely once CORE-514 is complete, so I'm ok leaving it messy.