### PR TITLE
CORE-515: drop all_attribute_values column from db

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -151,4 +151,5 @@
     <include file="changesets/20251009_quicksilver_for_empty_workspaces.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20251015_entity_indexing.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20251023_truncate_entity_attributes.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20251029_drop_all_attribute_values.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20251029_drop_all_attribute_values.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20251029_drop_all_attribute_values.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+    <!--
+        The all_attribute_values column is not used by Quicksilver, and so can be dropped.
+        The entity_type_id was never used; it can also be dropped. It was added proactively during
+            a previous downtime (since adding a column can be slow), but was never used.
+     -->
+    <changeSet logicalFilePath="dummy" author="davidan" id="drop_all_attribute_values">
+        <dropColumn tableName="ENTITY">
+            <column name="all_attribute_values" />
+            <column name="entity_type_id" />
+        </dropColumn>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Ticket: CORE-515

#3515 removed all code usages of the `all_attribute_values` column. This PR drops the column from the database.

It also drops the `entity_type_id` column, which was never used.

On a clone of the prod db, this executes in 550.5 ms.

