### PR TITLE
CORE-515: local-entity code cleanup

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -124,7 +124,6 @@ trait AttributeComponent {
 
   abstract class AttributeTable[OWNER_ID: TypedType, RECORD <: AttributeRecord[OWNER_ID]](tag: Tag, tableName: String)
       extends Table[RECORD](tag, tableName) {
-    final type OwnerIdType = OWNER_ID
 
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
     def ownerId = column[OWNER_ID]("owner_id")
@@ -162,11 +161,6 @@ trait AttributeComponent {
              deleted,
              deletedDate
     ) <> (EntityAttributeRecord.tupled, EntityAttributeRecord.unapply)
-
-    def uniqueIdx = index("UNQ_ENTITY_ATTRIBUTE", (ownerId, namespace, name, listIndex), unique = true)
-
-    def entityRef = foreignKey(s"FK_ENT_ATTRIBUTE_ENTITY_REF_$shard", valueEntityRef, entityQuery)(_.id.?)
-    def parentEntity = foreignKey(s"FK_ATTRIBUTE_PARENT_ENTITY_$shard", ownerId, entityQuery)(_.id)
   }
 
   class WorkspaceAttributeTable(tag: Tag)
@@ -185,11 +179,6 @@ trait AttributeComponent {
              deleted,
              deletedDate
     ) <> (WorkspaceAttributeRecord.tupled, WorkspaceAttributeRecord.unapply)
-
-    def uniqueIdx = index("UNQ_WORKSPACE_ATTRIBUTE", (ownerId, namespace, name, listIndex), unique = true)
-
-    def entityRef = foreignKey("FK_WS_ATTRIBUTE_ENTITY_REF", valueEntityRef, entityQuery)(_.id.?)
-    def workspace = foreignKey("FK_ATTRIBUTE_PARENT_WORKSPACE", ownerId, workspaceQuery)(_.id)
   }
 
   class SubmissionAttributeTable(tag: Tag)
@@ -208,12 +197,6 @@ trait AttributeComponent {
              deleted,
              deletedDate
     ) <> (SubmissionAttributeRecord.tupled, SubmissionAttributeRecord.unapply)
-
-    def uniqueIdx = index("UNQ_SUBMISSION_ATTRIBUTE", (ownerId, namespace, name, listIndex), unique = true)
-
-    def entityRef = foreignKey("FK_SUB_ATTRIBUTE_ENTITY_REF", valueEntityRef, entityQuery)(_.id.?)
-    def submissionValidation =
-      foreignKey("FK_ATTRIBUTE_PARENT_SUB_VALIDATION", ownerId, submissionValidationQuery)(_.id)
   }
 
   class EntityAttributeTempTable(tag: Tag)
@@ -506,7 +489,7 @@ trait AttributeComponent {
     def findByOwnerQuery(ownerIds: Seq[OWNER_ID]) =
       filter(_.ownerId inSetBind ownerIds)
 
-    val caseSensitiveCollate = SimpleExpression.unary[Option[String], Option[String]] { (value, qb) =>
+    private val caseSensitiveCollate = SimpleExpression.unary[Option[String], Option[String]] { (value, qb) =>
       qb.expr(value)
       qb.sqlBuilder += " collate utf8_bin"
     }
@@ -568,15 +551,19 @@ trait AttributeComponent {
     // but we only want to use a subset of the fields: the primary key.
     // AttributeRecordPrimaryKey encapsulates only those fields.
 
-    case class AttributeRecordPrimaryKey(ownerId: OWNER_ID, namespace: String, name: String, listIndex: Option[Int])
+    private case class AttributeRecordPrimaryKey(ownerId: OWNER_ID,
+                                                 namespace: String,
+                                                 name: String,
+                                                 listIndex: Option[Int]
+    )
 
     // a map of PK -> Record allows us to perform set operations on the PKs but return the Records as results
-    def toPrimaryKeyMap(recs: Traversable[RECORD]) =
+    private def toPrimaryKeyMap(recs: Iterable[RECORD]) =
       recs.map(rec => (AttributeRecordPrimaryKey(rec.ownerId, rec.namespace, rec.name, rec.listIndex), rec)).toMap
 
-    def patchAttributesAction(inserts: Traversable[RECORD],
-                              updates: Traversable[RECORD],
-                              deleteIds: Traversable[Long],
+    def patchAttributesAction(inserts: Iterable[RECORD],
+                              updates: Iterable[RECORD],
+                              deleteIds: Iterable[Long],
                               insertFunction: Seq[RECORD] => () => WriteAction[Int],
                               tracingContext: RawlsTracingContext
     ) =
@@ -622,7 +609,7 @@ trait AttributeComponent {
         _ <- workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID)
       } yield numRowsRenamed
 
-    object DeleteAttributeColumnQueries extends RawSqlQuery {
+    private object DeleteAttributeColumnQueries extends RawSqlQuery {
       val driver: JdbcProfile = AttributeComponent.this.driver
 
       def deleteAttributeColumn(workspaceContext: Workspace, entityType: String, attributeNames: Set[AttributeName]) = {
@@ -635,14 +622,14 @@ trait AttributeComponent {
         val deleteQueryBase = sql"""delete ea from ENTITY_ATTRIBUTE_#$shardId ea
                                     join ENTITY e on e.id = ea.owner_id
                                     where e.workspace_id = ${workspaceContext.workspaceIdAsUUID}
-                                      and e.entity_type = ${entityType}
+                                      and e.entity_type = $entityType
                                       and (ea.namespace, ea.name) in """
 
         concatSqlActions(deleteQueryBase, sql"(", attributeNamesSql, sql")").as[Int]
       }
     }
 
-    object AttributeColumnQueries extends RawSqlQuery {
+    private object AttributeColumnQueries extends RawSqlQuery {
       val driver: JdbcProfile = AttributeComponent.this.driver
 
       def renameAttribute(workspaceContext: Workspace,
@@ -683,8 +670,8 @@ trait AttributeComponent {
      * @param insertFunction function to use when writing attributes to the db (allows rewriteAttrsAction to be generic)
      * @return the ids of the parent (entity|workspace) objects that had attribute inserts/updates/deletes
      */
-    def rewriteAttrsAction(attributesToSave: Traversable[RECORD],
-                           existingAttributes: Traversable[RECORD],
+    def rewriteAttrsAction(attributesToSave: Iterable[RECORD],
+                           existingAttributes: Iterable[RECORD],
                            insertFunction: Seq[RECORD] => () => WriteAction[Int],
                            parentContext: RawlsTracingContext = RawlsTracingContext()
     ): ReadWriteAction[Set[OWNER_ID]] =
@@ -734,10 +721,10 @@ trait AttributeComponent {
         val existingKeys = existingAttrMap.keySet
 
         // insert attributes which are in save but not exists
-        val attributesToInsert = toSaveAttrMap.filterKeys(!existingKeys.contains(_))
+        val attributesToInsert = toSaveAttrMap.view.filterKeys(!existingKeys.contains(_))
 
         // delete attributes which are in exists but not save
-        val attributesToDelete = existingAttrMap.filterKeys(!toSaveAttrMap.keySet.contains(_))
+        val attributesToDelete = existingAttrMap.view.filterKeys(!toSaveAttrMap.keySet.contains(_))
 
         val attributesToUpdate = toSaveAttrMap.filter { case (k, v) =>
           existingKeys.contains(k) && // if the attribute doesn't already exist, don't attempt to update it
@@ -763,7 +750,7 @@ trait AttributeComponent {
       }
 
     // noinspection SqlDialectInspection
-    object AlterAttributesUsingScratchTableQueries extends RawSqlQuery {
+    private object AlterAttributesUsingScratchTableQueries extends RawSqlQuery {
       val driver: JdbcProfile = AttributeComponent.this.driver
 
       // MySQL seems to handle null safe operators inefficiently. the solution to this
@@ -773,12 +760,12 @@ trait AttributeComponent {
       // attributes.
 
       // updateInMasterAction: updates any row in *_ATTRIBUTE that also exists in *_ATTRIBUTE_SCRATCH
-      def updateInMasterAction() = {
+      private def updateInMasterAction() = {
         val joinTableName = getTempOrScratchTableName(baseTableRow.tableName)
 
         sql"""
           update #${baseTableRow.tableName} a
-              join #${joinTableName} ta
+              join #$joinTableName ta
               on (a.namespace, a.name, a.owner_id, ifnull(a.list_index, 0)) =
                  (ta.namespace, ta.name, ta.owner_id, ifnull(ta.list_index, 0))
           set a.value_string=ta.value_string,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -14,10 +14,9 @@ import slick.dbio.Effect.Read
 import slick.jdbc.{GetResult, JdbcProfile, SQLActionBuilder}
 import slick.sql.SqlStreamingAction
 
-import java.nio.charset.StandardCharsets
 import java.sql.Timestamp
 import java.util.{Date, UUID}
-import scala.annotation.tailrec
+import scala.annotation.unused
 import scala.language.postfixOps
 
 //noinspection TypeAnnotation
@@ -31,8 +30,6 @@ sealed trait EntityRecordBase {
   val deletedDate: Option[Timestamp]
 
   def toReference = AttributeEntityReference(entityType, name)
-  def withAllAttributeValues =
-    EntityRecord(id, name, entityType, workspaceId, recordVersion, deleted, deletedDate)
 }
 
 case class EntityRecord(id: Long,
@@ -61,9 +58,6 @@ sealed abstract class EntityTableBase[RECORD_TYPE <: EntityRecordBase](tag: Tag)
   def version = column[Long]("record_version")
   def deleted = column[Boolean]("deleted")
   def deletedDate = column[Option[Timestamp]]("deleted_date")
-
-//  def workspace = foreignKey("FK_ENTITY_WORKSPACE", workspaceId, workspaceQuery)(_.id)
-  def uniqueTypeName = index("idx_entity_type_name", (workspaceId, entityType, name), unique = true)
 }
 
 class EntityTable(tag: Tag) extends EntityTableBase[EntityRecord](tag) {
@@ -78,16 +72,16 @@ trait EntityComponent {
   object entityQuery extends TableQuery(new EntityTable(_)) with LazyLogging {
 
     type EntityQuery = Query[EntityTable, EntityRecord, Seq]
-    type EntityAttributeQuery = Query[EntityAttributeTable, EntityAttributeRecord, Seq]
+    private type EntityAttributeQuery = Query[EntityAttributeTable, EntityAttributeRecord, Seq]
 
-    def batchInsertEntities(workspaceContext: Workspace,
-                            entities: TraversableOnce[Entity]
+    private def batchInsertEntities(workspaceContext: Workspace,
+                                    entities: IterableOnce[Entity]
     ): ReadWriteAction[Seq[EntityRecord]] = {
       def marshalNewEntity(entity: Entity, workspaceId: UUID): EntityRecord =
         EntityRecord(0, entity.name, entity.entityType, workspaceId, 0, deleted = false, deletedDate = None)
 
-      if (entities.nonEmpty) {
-        val entityRecs = entities.toSeq.map(e => marshalNewEntity(e, workspaceContext.workspaceIdAsUUID))
+      if (entities.iterator.nonEmpty) {
+        val entityRecs = entities.iterator.toSeq.map(e => marshalNewEntity(e, workspaceContext.workspaceIdAsUUID))
 
         workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID) andThen
           DBIO
@@ -101,9 +95,9 @@ trait EntityComponent {
       }
     }
 
-    def insertNewEntities(workspaceContext: Workspace,
-                          entities: Traversable[Entity],
-                          existingEntityRefs: Seq[AttributeEntityReference]
+    private def insertNewEntities(workspaceContext: Workspace,
+                                  entities: Iterable[Entity],
+                                  existingEntityRefs: Seq[AttributeEntityReference]
     ): ReadWriteAction[Seq[EntityRecord]] = {
       val newEntities = entities.filterNot(e => existingEntityRefs.contains(e.toReference))
       // only insert the first instance of each entity, if the input contains duplicates.
@@ -114,9 +108,7 @@ trait EntityComponent {
       batchInsertEntities(workspaceContext, insertableEntities)
     }
 
-    def optimisticLockUpdate(entityRecs: Seq[EntityRecord],
-                             entities: Traversable[Entity]
-    ): ReadWriteAction[Seq[Int]] = {
+    def optimisticLockUpdate(entityRecs: Seq[EntityRecord]): ReadWriteAction[Seq[Int]] = {
       def findEntityByIdAndVersion(id: Long, version: Long): EntityQuery =
         filter(rec => rec.id === id && rec.version === version)
 
@@ -324,7 +316,11 @@ trait EntityComponent {
       }
 
       // generate the clause to filter based on user search terms
-      def paginationFilterSql(prefix: String, alias: String, entityQuery: model.EntityQuery) = sql""
+      private def paginationFilterSql(@unused prefix: String,
+                                      @unused alias: String,
+                                      @unused entityQuery: model.EntityQuery
+      ) =
+        sql""
 
       def activeActionForMetadata(workspaceContext: Workspace,
                                   entityType: String,
@@ -693,18 +689,16 @@ trait EntityComponent {
 
       val driver: JdbcProfile = EntityComponent.this.driver
 
-      def listActiveEntitiesOfType(workspaceContext: Workspace,
-                                   entityType: String
-      ): ReadAction[TraversableOnce[Entity]] =
+      def listActiveEntitiesOfType(workspaceContext: Workspace, entityType: String): ReadAction[IterableOnce[Entity]] =
         sql"""#${EntityAndAttributesRawSqlQuery.baseEntityAndAttributeSql(workspaceContext)}
         where e.deleted = false
-        and e.entity_type = ${entityType}
+        and e.entity_type = $entityType
         and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}"""
           .as[EntityAndAttributesResult](EntityAndAttributesRawSqlQuery.getEntityAndAttributesResult)
           .map(query => unmarshalEntities(query))
 
       // includes "deleted" hidden entities
-      def listEntities(workspaceContext: Workspace): ReadAction[TraversableOnce[Entity]] =
+      def listEntities(workspaceContext: Workspace): ReadAction[IterableOnce[Entity]] =
         sql"""#${EntityAndAttributesRawSqlQuery.baseEntityAndAttributeSql(
             workspaceContext
           )} where e.workspace_id = ${workspaceContext.workspaceIdAsUUID}"""
@@ -764,7 +758,7 @@ trait EntityComponent {
         query => unmarshalEntities(query)
       ) map (_.headOption)
 
-    def getEntities(workspaceId: UUID, entityIds: Traversable[Long]): ReadAction[Seq[(Long, Entity)]] =
+    def getEntities(workspaceId: UUID, entityIds: Iterable[Long]): ReadAction[Seq[(Long, Entity)]] =
       EntityAndAttributesRawSqlQuery.actionForIds(workspaceId, entityIds.toSet) map (query =>
         unmarshalEntitiesWithIds(query)
       )
@@ -780,15 +774,15 @@ trait EntityComponent {
     }
 
     def getActiveEntities(workspaceContext: Workspace,
-                          entityRefs: Traversable[AttributeEntityReference]
-    ): ReadAction[TraversableOnce[Entity]] =
+                          entityRefs: Iterable[AttributeEntityReference]
+    ): ReadAction[IterableOnce[Entity]] =
       EntityAndAttributesRawSqlQuery.activeActionForRefs(workspaceContext, entityRefs.toSet) map (query =>
         unmarshalEntities(query)
       )
 
     // list all entities or those in a category
 
-    def listActiveEntities(workspaceContext: Workspace): ReadAction[TraversableOnce[Entity]] =
+    def listActiveEntities(workspaceContext: Workspace): ReadAction[IterableOnce[Entity]] =
       EntityAndAttributesRawSqlQuery.activeActionForWorkspace(workspaceContext) map (query => unmarshalEntities(query))
 
     // almost the same as "listActiveEntitiesOfType" except 1) does not unmarshal entities; 2) returns a stream
@@ -908,9 +902,9 @@ trait EntityComponent {
       save(workspaceContext, Seq(entity)).map(_.head)
 
     def save(workspaceContext: Workspace,
-             entities: Traversable[Entity],
+             entities: Iterable[Entity],
              parentContext: RawlsTracingContext = RawlsTracingContext()
-    ): ReadWriteAction[Traversable[Entity]] = {
+    ): ReadWriteAction[Iterable[Entity]] = {
       entities.foreach(EntityUtils.validateEntity)
 
       for {
@@ -955,13 +949,13 @@ trait EntityComponent {
         recsToUpdate = (actuallyUpdatedPreExistingEntityRecs ++ insertedRepeats).distinct
 
         _ <- traceDBIOWithParent("optimisticLockUpdate", parentContext)(_ =>
-          entityQuery.optimisticLockUpdate(recsToUpdate, entities)
+          entityQuery.optimisticLockUpdate(recsToUpdate)
         )
       } yield entities
     }
 
     private def lookupNotYetLoadedReferences(workspaceContext: Workspace,
-                                             entities: Traversable[Entity],
+                                             entities: Iterable[Entity],
                                              alreadyLoadedEntityRefs: Seq[AttributeEntityReference]
     ): ReadAction[Seq[EntityRecord]] = {
       val allRefAttributes = (for {
@@ -1002,7 +996,7 @@ trait EntityComponent {
     }
 
     private def rewriteAttributes(workspaceId: UUID,
-                                  entitiesToSave: Traversable[Entity],
+                                  entitiesToSave: Iterable[Entity],
                                   entityIds: Seq[Long],
                                   entityIdsByRef: Map[AttributeEntityReference, Long],
                                   parentContext: RawlsTracingContext = RawlsTracingContext()
@@ -1112,7 +1106,7 @@ trait EntityComponent {
 
       def getSoftConflicts(paths: Seq[EntityPath]) =
         getCopyConflicts(destWorkspaceContext, paths.map(_.path.last)).map { conflicts =>
-          val conflictsAsRefs = conflicts.toSeq.map(_.toReference)
+          val conflictsAsRefs = conflicts.iterator.toSeq.map(_.toReference)
           paths.filter(p => conflictsAsRefs.contains(p.path.last))
         }
 
@@ -1207,9 +1201,9 @@ trait EntityComponent {
     // return the entities already present in the destination workspace
 
     private[slick] def getCopyConflicts(destWorkspaceContext: Workspace,
-                                        entitiesToCopy: TraversableOnce[AttributeEntityReference]
-    ): ReadAction[TraversableOnce[EntityRecord]] =
-      getEntityRecords(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopy.toSet)
+                                        entitiesToCopy: IterableOnce[AttributeEntityReference]
+    ): ReadAction[IterableOnce[EntityRecord]] =
+      getEntityRecords(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopy.iterator.toSet)
 
     // the opposite of getEntitySubtrees: traverse the graph to retrieve all entities which ultimately refer to these
 
@@ -1227,9 +1221,9 @@ trait EntityComponent {
         entityAction map { _.toSet map { e: Entity => e.toReference } }
       }
 
-    sealed trait RecursionDirection
-    case object Up extends RecursionDirection
-    case object Down extends RecursionDirection
+    sealed private trait RecursionDirection
+    private case object Up extends RecursionDirection
+    private case object Down extends RecursionDirection
 
     /**
       * Starting with entities specified by entityIds, recursively walk references accumulating all the ids
@@ -1286,25 +1280,6 @@ trait EntityComponent {
       }
     }
 
-    // Utility methods
-
-    def generateEntityMetadataMap(typesAndCountsQ: ReadAction[Map[String, Int]],
-                                  typesAndAttrsQ: ReadAction[Map[String, Seq[AttributeName]]]
-    ) =
-      typesAndCountsQ flatMap { typesAndCounts =>
-        typesAndAttrsQ map { typesAndAttrs =>
-          (typesAndCounts.keySet ++ typesAndAttrs.keySet) map { entityType =>
-            (entityType,
-             EntityTypeMetadata(
-               typesAndCounts.getOrElse(entityType, 0),
-               entityType + Attributable.entityIdAttributeSuffix,
-               typesAndAttrs.getOrElse(entityType, Seq()).map(AttributeName.toDelimitedName).sortBy(_.toLowerCase)
-             )
-            )
-          } toMap
-        }
-      }
-
     // Unmarshal methods
 
     private def unmarshalEntity(entityRecord: EntityRecord, attributes: AttributeMap): Entity =
@@ -1315,7 +1290,7 @@ trait EntityComponent {
     ): Seq[Entity] =
       unmarshalEntitiesWithIds(entityAttributeRecords).map { case (_, entity) => entity }
 
-    def unmarshalEntitiesWithIds(
+    private def unmarshalEntitiesWithIds(
       entityAttributeRecords: Seq[EntityAndAttributesResult]
     ): Seq[(Long, Entity)] = {
       val allEntityRecords = entityAttributeRecords.map(_.entityRecord).distinct

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/ExpressionEvaluationSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/ExpressionEvaluationSupport.scala
@@ -32,12 +32,6 @@ object ExpressionEvaluationSupport {
 }
 
 trait ExpressionEvaluationSupport {
-  protected def createSubmissionValidationEntityInputs(
-    valuesByEntity: Map[EntityName, Seq[SubmissionValidationValue]]
-  ): LazyList[SubmissionValidationEntityInputs] =
-    LazyList.from(valuesByEntity.map { case (entityName, values) =>
-      SubmissionValidationEntityInputs(entityName, values.toSet)
-    })
 
   protected def isStringInputType(input: MethodInput): Boolean = {
     val valuetype = input.workflowInput.getValueType

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -390,7 +390,7 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
                   entityUpdates.map(eu => AttributeEntityReference(eu.entityType, eu.name))
                 )
               ) map { entities =>
-                val entitiesByName = entities.map(e => (e.entityType, e.name) -> e).toMap
+                val entitiesByName = entities.iterator.map(e => (e.entityType, e.name) -> e).toMap
                 entityUpdates.map { entityUpdate =>
                   entityUpdate -> (entitiesByName.get((entityUpdate.entityType, entityUpdate.name)) match {
                     case Some(e) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/AttributeSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/AttributeSupport.scala
@@ -36,7 +36,7 @@ import scala.concurrent.Future
 trait AttributeSupport {
 
   // note: success is indicated by  Map.empty
-  def attributeNamespaceCheck(attributeNames: Iterable[AttributeName]): Map[String, String] = {
+  private def attributeNamespaceCheck(attributeNames: Iterable[AttributeName]): Map[String, String] = {
     val namespaces = attributeNames.map(_.namespace).toSet
 
     // no one can modify attributes with invalid namespaces
@@ -121,7 +121,7 @@ trait AttributeSupport {
                   startingAttributes
                 case newMember: AttributeEntityReference =>
                   startingAttributes + (attributeListName -> AttributeEntityReferenceList(Seq(newMember)))
-                case newMember: AttributeValue =>
+                case _: AttributeValue =>
                   throw new AttributeUpdateOperationException("Cannot add non-reference to list of references.")
                 case _ => throw new AttributeUpdateOperationException("Cannot create list with that type.")
               }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/EntitySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/EntitySupport.scala
@@ -25,7 +25,7 @@ trait EntitySupport {
                            dataAccess: DataAccess,
                            entities: Seq[AttributeEntityReference],
                            context: RawlsRequestContext
-  )(op: (Seq[AttributeEntityReference]) => ReadWriteAction[T]): ReadWriteAction[T] =
+  )(op: Seq[AttributeEntityReference] => ReadWriteAction[T]): ReadWriteAction[T] =
     // query the db to see which of the specified entity refs exist in the workspace and are active
     traceDBIOWithParent("withAllEntityRefs.getActiveRefs", context)(_ =>
       dataAccess.entityQuery.getActiveRefs(workspaceContext.workspaceIdAsUUID, entities.toSet)
@@ -48,16 +48,15 @@ trait EntitySupport {
     }
 
   def withEntity[T](workspaceContext: Workspace, entityType: String, entityName: String, dataAccess: DataAccess)(
-    op: (Entity) => ReadWriteAction[T]
+    op: Entity => ReadWriteAction[T]
   ): ReadWriteAction[T] =
     dataAccess.entityQuery.get(workspaceContext, entityType, entityName) flatMap {
       case None =>
         DBIO.failed(
           new RawlsExceptionWithErrorReport(
-            errorReport =
-              ErrorReport(StatusCodes.NotFound,
-                          s"${entityType} ${entityName} does not exist in ${workspaceContext.toWorkspaceName}"
-              )
+            errorReport = ErrorReport(StatusCodes.NotFound,
+                                      s"$entityType $entityName does not exist in ${workspaceContext.toWorkspaceName}"
+            )
           )
         )
       case Some(entity) => op(entity)


### PR DESCRIPTION
Ticket: CORE-515

This is a prefactoring for some files in the `LocalEntityProvider` hierarchy. It eliminates most of the warnings that IntelliJ shows on these files.

The next step in CORE-515 is to delete implementations in `LocalEntityProvider`, which will leave some of the methods in these files unused. I would like to use IntelliJ to identify which methods are unused ... so, cleaning up the list of warnings will help in that process.

