### PR TITLE
CORE-69: scala to 2.13.17; sbt to 1.11.7; scoverage to 2.4.1

### DIFF
--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -328,7 +328,7 @@ jobs:
                           -e POSTGRES_READ_URL=localhost:5432 \
                           -e POSTGRES_USERNAME=rawls-test \
                           -e POSTGRES_PASSWORD=rawls-test \
-                          sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.6_2.13.16 \
+                          sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.7_2.13.17 \
                           bash -c "git config --global --add safe.directory /working && sbt -J-Xmx2g -J-XX:+UseG1GC \"project pact4s\" clean coverage \"testOnly org.broadinstitute.dsde.rawls.provider.*\"  coverageReport"
 
   can-i-deploy: # The can-i-deploy job will run as a result of a Rawls PR. It reports the pact verification statuses on all deployed environments.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: Replace build script with multi-stage Dockerfile that builds its own JAR
-# FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.3_2.13.16 as jar-builder
+# FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.7_2.13.17 as jar-builder
 # ...build JAR...
 # FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 # COPY --from=jar-builder ./rawls*.jar /rawls

--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.3_2.13.16
+FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.7_2.13.17
 
 COPY src /app/src
 COPY test.sh /app

--- a/automation/project/Settings.scala
+++ b/automation/project/Settings.scala
@@ -38,7 +38,7 @@ object Settings {
   val commonSettings =
     commonBuildSettings ++ testSettings ++ List(
     organization  := "org.broadinstitute.dsde.firecloud",
-    scalaVersion  := "2.13.16",
+    scalaVersion  := "2.13.17",
     resolvers ++= commonResolvers,
     scalacOptions ++= commonCompilerSettings,
       dependencyOverrides ++= transitiveDependencyOverrides

--- a/automation/project/build.properties
+++ b/automation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.11.6
+sbt.version = 1.11.7

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -94,7 +94,7 @@ function make_jar()
     # TODO: DOCKER_TAG hack until JAR build migrates to Dockerfile. Tell SBT to name the JAR
     # `rawls-assembly-local-SNAP.jar` instead of including the commit hash. Otherwise we get
     # an explosion of JARs that all get copied to the image; and which one runs is undefined.
-    DOCKER_RUN="$DOCKER_RUN -e DOCKER_TAG=local -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.3_2.13.16 /working/docker/clean_install.sh /working"
+    DOCKER_RUN="$DOCKER_RUN -e DOCKER_TAG=local -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.7_2.13.17 /working/docker/clean_install.sh /working"
 
     JAR_CMD=$($DOCKER_RUN 1>&2)
     EXIT_CODE=$?

--- a/docker/build_jar.sh
+++ b/docker/build_jar.sh
@@ -6,7 +6,7 @@
 set -e
 
 # make jar.  cache sbt dependencies. capture output and stop db before returning.
-docker run --rm -e DOCKER_TAG -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.3_2.13.16 /working/docker/clean_install.sh /working
+docker run --rm -e DOCKER_TAG -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.7_2.13.17 /working/docker/clean_install.sh /working
 EXIT_CODE=$?
 
 if [ $EXIT_CODE != 0 ]; then

--- a/local-dev/templates/docker-rsync-local-rawls.sh
+++ b/local-dev/templates/docker-rsync-local-rawls.sh
@@ -97,7 +97,7 @@ start_server () {
     -e GOOGLE_APPLICATION_CREDENTIALS='/etc/rawls-account.json' \
     -e GIT_HASH=$GIT_HASH \
     -e RAWLS_LOG_APPENDER=Console-Standard \
-    sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.3_2.13.16 \
+    sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.7_2.13.17 \
     bash -c "git config --global --add safe.directory /app && sbt clean \~reStart"
 
     docker cp config/rawls-account.pem rawls-sbt:/etc/rawls-account.pem

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -84,7 +84,7 @@ object Settings {
   )
 
   // When updating this, also update Docker image (https://hub.docker.com/r/sbtscala/scala-sbt/tags)
-  val scala213 = "2.13.16"
+  val scala213 = "2.13.17"
 
   // common settings for all sbt subprojects, without enforcing that a database is present (for tests)
   val commonSettingsWithoutDb =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.6
+sbt.version=1.11.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
 


### PR DESCRIPTION
Ticket: CORE-69

* update sbt to 1.11.7
* update scala to 2.13.17
* scoverage plugin to 2.4.1, for compatibility with the updated Scala version
* update sbt-scala docker images to sbt 1.11.7/scala 2.13.17

This overlaps with Scala Steward's #3523. I'm making this PR to help slim down that other one, and to ensure the sbt/Scala/docker image updates are all in sync.