### PR TITLE
CTM-119: ignore Scala Steward updates for fs2-reactive-streams

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -85,6 +85,9 @@ pullRequests.grouping = [ { name = "minor_patch", title = "CORE-69: Minor and pa
 updates.ignore = [
   # sbt 1.10.8 is dead on arrival according to their release page
   { groupId = "org.scala-sbt", artifactId = "sbt", version = "1.10.8" }
+  # fs2-reactive-streams includes cats-effect, and cats-effect 3.5.0 has breaking changes
+  # we don't want to deal with. Ignore updates to fs2-reactive-streams.
+  { groupId = "co.fs2", artifactId = "fs2-reactive-streams" }
 ]
 
 


### PR DESCRIPTION
Ticket: CTM-119

ignore Scala Steward updates for `fs2-reactive-streams` due to potentially breaking changes in its transitive dependency `cats-effect`.