### PR TITLE
CTM-124: Redirect slack notifications to dsde-qa

### DIFF
--- a/.github/workflows/workflows-complex-canary-gcp-batch.yaml
+++ b/.github/workflows/workflows-complex-canary-gcp-batch.yaml
@@ -33,7 +33,7 @@ jobs:
   report-workflow:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
     with:
-      notify-slack-channels-upon-workflow-failure: "#dsp-analysis-prod-alerts"
+      notify-slack-channels-upon-workflow-failure: "#dsde-qa"
       notify-slack-custom-icon: ":sad-terra:"
     permissions:
       id-token: write

--- a/.github/workflows/workflows-simple-canary-prod-test.yaml
+++ b/.github/workflows/workflows-simple-canary-prod-test.yaml
@@ -32,7 +32,7 @@ jobs:
   report-workflow:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
     with:
-      notify-slack-channels-upon-workflow-failure: "#dsp-analysis-prod-alerts"
+      notify-slack-channels-upon-workflow-failure: "#dsde-qa"
       notify-slack-custom-icon: ":sad-terra:"
     permissions:
       id-token: write


### PR DESCRIPTION
Ticket: [CTM-124](https://broadworkbench.atlassian.net/browse/CTM-124)

Redirect slack notifications to a central channel.
Am I missing any?

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[CTM-124]: https://broadworkbench.atlassian.net/browse/CTM-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ