### PR TITLE
CTM-173: legacy AttributeComponent cleanup

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -582,59 +582,6 @@ trait AttributeComponent {
         } yield updateResult
       }
 
-    // TODO CTM-173: only used in tests
-    def doesAttributeNameAlreadyExist(workspaceContext: Workspace,
-                                      entityType: String,
-                                      attributeName: AttributeName
-    ): ReadAction[Option[Boolean]] =
-      uniqueResult(AttributeColumnQueries.doesAttributeExist(workspaceContext, entityType, attributeName))
-
-    // TODO CTM-173: only used in tests
-    def renameAttribute(workspaceContext: Workspace,
-                        entityType: String,
-                        oldAttributeName: AttributeName,
-                        newAttributeName: AttributeName
-    ): ReadWriteAction[Int] =
-      for {
-        numRowsRenamed <- AttributeColumnQueries.renameAttribute(workspaceContext,
-                                                                 entityType,
-                                                                 oldAttributeName,
-                                                                 newAttributeName
-        )
-        _ <- workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID)
-      } yield numRowsRenamed
-
-    private object AttributeColumnQueries extends RawSqlQuery {
-      val driver: JdbcProfile = AttributeComponent.this.driver
-
-      def renameAttribute(workspaceContext: Workspace,
-                          entityType: String,
-                          oldAttributeName: AttributeName,
-                          newAttributeName: AttributeName
-      ): ReadWriteAction[Int] = {
-
-        val shardId = determineShard(workspaceContext.workspaceIdAsUUID)
-
-        sqlu"""update ENTITY_ATTRIBUTE_#$shardId ea join ENTITY e on ea.owner_id = e.id
-             set ea.namespace=${newAttributeName.namespace}, ea.name=${newAttributeName.name}
-             where e.workspace_id=${workspaceContext.workspaceIdAsUUID} and e.entity_type=$entityType
-                and ea.namespace=${oldAttributeName.namespace} and ea.name=${oldAttributeName.name} and ea.deleted=0
-        """
-      }
-
-      def doesAttributeExist(workspaceContext: Workspace,
-                             entityType: String,
-                             newAttributeName: AttributeName
-      ): ReadAction[Seq[Boolean]] = {
-        val shardId = determineShard(workspaceContext.workspaceIdAsUUID)
-
-        sql"""select exists (select ea.name from ENTITY_ATTRIBUTE_#$shardId ea join ENTITY e on ea.owner_id = e.id
-             where e.workspace_id=${workspaceContext.workspaceIdAsUUID} and e.entity_type=$entityType
-                 and ea.namespace=${newAttributeName.namespace} and ea.name=${newAttributeName.name} and ea.deleted=0)
-        """.as[Boolean]
-      }
-    }
-
     /**
      * Compares a collection of pre-existing attributes to a collection of attributes requested to save by a user,
      * finds the differences, saves the differences, and then returns the ids of the parent (entity|workspace) objects

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -483,9 +483,6 @@ trait AttributeComponent {
       )
     }
 
-    def findByNameQuery(attrName: AttributeName) =
-      filter(rec => rec.namespace === attrName.namespace && rec.name === attrName.name)
-
     def findByOwnerQuery(ownerIds: Seq[OWNER_ID]) =
       filter(_.ownerId inSetBind ownerIds)
 
@@ -585,16 +582,14 @@ trait AttributeComponent {
         } yield updateResult
       }
 
-    def deleteAttributes(workspaceContext: Workspace, entityType: String, attributeNames: Set[AttributeName]) =
-      workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID) andThen
-        DeleteAttributeColumnQueries.deleteAttributeColumn(workspaceContext, entityType, attributeNames)
-
+    // TODO CTM-173: only used in tests
     def doesAttributeNameAlreadyExist(workspaceContext: Workspace,
                                       entityType: String,
                                       attributeName: AttributeName
     ): ReadAction[Option[Boolean]] =
       uniqueResult(AttributeColumnQueries.doesAttributeExist(workspaceContext, entityType, attributeName))
 
+    // TODO CTM-173: only used in tests
     def renameAttribute(workspaceContext: Workspace,
                         entityType: String,
                         oldAttributeName: AttributeName,
@@ -608,26 +603,6 @@ trait AttributeComponent {
         )
         _ <- workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID)
       } yield numRowsRenamed
-
-    private object DeleteAttributeColumnQueries extends RawSqlQuery {
-      val driver: JdbcProfile = AttributeComponent.this.driver
-
-      def deleteAttributeColumn(workspaceContext: Workspace, entityType: String, attributeNames: Set[AttributeName]) = {
-        val attributeNamesSql = reduceSqlActionsWithDelim(attributeNames.map { attName =>
-          sql"""(${attName.namespace},${attName.name})"""
-        }.toSeq)
-
-        val shardId = determineShard(workspaceContext.workspaceIdAsUUID)
-
-        val deleteQueryBase = sql"""delete ea from ENTITY_ATTRIBUTE_#$shardId ea
-                                    join ENTITY e on e.id = ea.owner_id
-                                    where e.workspace_id = ${workspaceContext.workspaceIdAsUUID}
-                                      and e.entity_type = $entityType
-                                      and (ea.namespace, ea.name) in """
-
-        concatSqlActions(deleteQueryBase, sql"(", attributeNamesSql, sql")").as[Int]
-      }
-    }
 
     private object AttributeColumnQueries extends RawSqlQuery {
       val driver: JdbcProfile = AttributeComponent.this.driver

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -779,60 +779,6 @@ class AttributeComponentSpec
     assertResult(0)(runAndWait(workspaceAttributeQuery.filter(_.ownerId === workspaceId).result).size)
   }
 
-  it should "return false from doesAttributeNameAlreadyExist if the attribute name does not exist" in withMinimalTestDatabase {
-    _ =>
-      withWorkspaceContext(legacyTestData.workspace) { context =>
-        val exists = runAndWait(
-          entityAttributeShardQuery(context).doesAttributeNameAlreadyExist(context,
-                                                                           "Pair",
-                                                                           AttributeName.withDefaultNS("case2")
-          )
-        ).get
-        assert(!exists)
-      }
-  }
-
-  it should "change the attribute name when renameAttribute is called with valid arguments" in withLegacyDefaultTestDatabase {
-    withWorkspaceContext(legacyTestData.workspace) { context =>
-      val rowsUpdated = runAndWait(
-        entityAttributeShardQuery(context).renameAttribute(context,
-                                                           "Pair",
-                                                           AttributeName.withDefaultNS("case"),
-                                                           AttributeName.withDefaultNS("case2")
-        )
-      )
-      assert(rowsUpdated == 2)
-      val exists = runAndWait(
-        entityAttributeShardQuery(context).doesAttributeNameAlreadyExist(context,
-                                                                         "Pair",
-                                                                         AttributeName.withDefaultNS("case2")
-        )
-      ).get
-      assert(exists)
-    }
-  }
-
-  it should "change the attribute name and namespace when renameAttribute is called with an attribute with a new namespace" in withLegacyDefaultTestDatabase {
-    withWorkspaceContext(legacyTestData.workspace) { context =>
-      val rowsUpdated = runAndWait(
-        entityAttributeShardQuery(context).renameAttribute(context,
-                                                           "Pair",
-                                                           AttributeName.withDefaultNS("case"),
-                                                           AttributeName.fromDelimitedName("new_namespace:new_name")
-        )
-      )
-      assert(rowsUpdated == 2)
-      val exists = runAndWait(
-        entityAttributeShardQuery(context).doesAttributeNameAlreadyExist(
-          context,
-          "Pair",
-          AttributeName.fromDelimitedName("new_namespace:new_name")
-        )
-      ).get
-      assert(exists)
-    }
-  }
-
   it should "unmarshal attribute records" in withEmptyTestDatabase {
     val attributeRecs = Seq(
       ((1,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -2693,9 +2693,6 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   def withLegacyDefaultTestDatabase[T](testCode: => T): T =
     withCustomTestDatabaseInternal(legacyTestData)(testCode)
 
-  def withLegacyDefaultTestDatabase[T](testCode: SlickDataSource => T): T =
-    withCustomTestDatabaseInternal(legacyTestData)(testCode(slickDataSource))
-
   def withMinimalTestDatabase[T](testCode: SlickDataSource => T): T =
     withCustomTestDatabaseInternal(minimalTestData)(testCode(slickDataSource))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -2304,48 +2304,6 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       )
   }
 
-  class LocalEntityProviderTestData() extends TestData {
-    val workspaceName = WorkspaceName("namespace", "workspace-with-cache")
-    val wsAttrs = Map(AttributeName.withDefaultNS("description") -> AttributeString("a description"))
-    val creationTime = currentTime()
-    val workspace = Workspace(
-      workspaceName.namespace,
-      workspaceName.name,
-      UUID.randomUUID().toString,
-      "aBucket",
-      Some("workflow-collection"),
-      creationTime,
-      creationTime,
-      "testUser",
-      wsAttrs
-    )
-
-    val participant1 = Entity(
-      "participant1",
-      "participant",
-      Map(AttributeName.withDefaultNS("attr1") -> AttributeString("value1"),
-          AttributeName.withDefaultNS("attr2") -> AttributeString("value2")
-      )
-    )
-    val sample1 = Entity(
-      "sample1",
-      "sample",
-      Map(AttributeName.withDefaultNS("attr5") -> AttributeString("value5"),
-          AttributeName.withDefaultNS("attr6") -> AttributeString("value6")
-      )
-    )
-
-    override def save() =
-      DBIO.seq(
-        workspaceQuery.createOrUpdate(workspace),
-        withWorkspaceContext(workspace) { context =>
-          // note that we don't save sample1 here, it was only used to generate cache entries that will differ from what full queries return
-          entityQuery.save(context, participant1)
-        }
-      )
-
-  }
-
   /* This test data should remain constant! Changing this data set will likely break
    * many of the tests that rely on it. */
   class ConstantTestData(useCompact: Boolean = true) extends TestData {
@@ -2724,7 +2682,6 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   val constantData = new ConstantTestData(false)
   val compactConstantData = new ConstantTestData()
   val minimalTestData = new MinimalTestData()
-  val localEntityProviderTestData = new LocalEntityProviderTestData()
   val protectedWorkspaceTestData = new ProtectedWorkspaceTestData()
 
   def withDefaultTestDatabase[T](testCode: => T): T =
@@ -2744,9 +2701,6 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
 
   def withProtectedWorkspaceTestDatabase[T](testCode: SlickDataSource => T): T =
     withCustomTestDatabaseInternal(protectedWorkspaceTestData)(testCode(slickDataSource))
-
-  def withLocalEntityProviderTestDatabase[T](testCode: SlickDataSource => T): T =
-    withCustomTestDatabaseInternal(localEntityProviderTestData)(testCode(slickDataSource))
 
   def withConstantTestDatabase[T](testCode: => T): T =
     withCustomTestDatabaseInternal(constantData)(testCode)


### PR DESCRIPTION
Ticket: CTM-173

Deletes methods in `AttributeComponent` and its callers that were unused, or were only used in tests.

This is not comprehensive - trying to make gradual progress in cleaning up the legacy non-Quicksilver code.