### PR TITLE
[TSPS-672] Add types to pageSize and offset query params in api-docs.yaml

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3992,11 +3992,15 @@ paths:
           description: how many google projects to return at a time
           required: false
           default: 100
+          schema:
+            type: integer
         - name: offset
           in: query
           description: The number of items to skip before starting to collect the result
           required: false
           default: 0
+          schema:
+            type: integer
       responses:
         200:
           description: Successful Request

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -528,16 +528,16 @@ paths:
           in: query
           description: how many workspaces to return at a time
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
         - name: offset
           in: query
           description: The number of items to skip before starting to collect the result
           required: false
-          default: 0
           schema:
             type: integer
+            default: 0
       responses:
         200:
           description: Success
@@ -3991,16 +3991,16 @@ paths:
           in: query
           description: how many google projects to return at a time
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
         - name: offset
           in: query
           description: The number of items to skip before starting to collect the result
           required: false
-          default: 0
           schema:
             type: integer
+            default: 0
       responses:
         200:
           description: Successful Request

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -529,11 +529,15 @@ paths:
           description: how many workspaces to return at a time
           required: false
           default: 100
+          schema:
+            type: integer
         - name: offset
           in: query
           description: The number of items to skip before starting to collect the result
           required: false
           default: 0
+          schema:
+            type: integer
       responses:
         200:
           description: Success


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/TSPS-672

Teaspoons builds a rawls client using api-docs.yaml. We recently tried to update the client but it was failing because a few types were missing from the api docs. This PR adds the missing types.

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
