### PR TITLE
CTM-256: Quicksilver correction analysis

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -152,4 +152,6 @@
     <include file="changesets/20251015_entity_indexing.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20251023_truncate_entity_attributes.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20251029_drop_all_attribute_values.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20251205_quicksilver_corrections.xml" relativeToChangelogFile="true"/>
+
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20251205_quicksilver_corrections.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20251205_quicksilver_corrections.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+    <!--
+        In production, the ENTITY_CORRECTIONS table will already have been created by a manual
+        process. Thus, the "IF NOT EXISTS" clause is important to ensure this changeset runs correctly.
+     -->
+    <changeSet logicalFilePath="dummy" author="davidan" id="quicksilver_corrections">
+        <sql>
+            CREATE TABLE IF NOT EXISTS `ENTITY_CORRECTIONS` (
+              `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+              `workspace_id` binary(16) NOT NULL,
+              `entity_type` varchar(254) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin DEFAULT NULL,
+              `name` varchar(254) NOT NULL,
+              `attributes` json DEFAULT NULL,
+              `status` varchar(254) NOT NULL DEFAULT 'OUTSTANDING',
+              PRIMARY KEY (`id`),
+              UNIQUE KEY `idx_corrections_entity_type_name` (`workspace_id`,`entity_type`,`name`),
+              KEY `idx_corrections_status` (`status`)
+            ) DEFAULT CHARSET=utf8mb3;
+        </sql>
+
+        <sql>
+            CREATE TABLE IF NOT EXISTS `ATTRIBUTE_CORRECTIONS` (
+              `correction_id` bigint unsigned NOT NULL,
+              `namespace` varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
+              `name` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
+              `status` varchar(254) NOT NULL,
+              PRIMARY KEY (`correction_id`, `namespace`, `name`),
+              KEY `idx_attrcorrections_status` (`status`),
+              CONSTRAINT `FK_ATTRCORRECTION_PARENT_ENTITY` FOREIGN KEY (`correction_id`) REFERENCES `ENTITY_CORRECTIONS` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT
+              ) DEFAULT CHARSET=utf8mb3;
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -156,3 +156,11 @@ bard {
   bardUrl = ""
   connectionPoolSize = 10
 }
+
+quicksilverCorrections {
+  startupDelay = 5 minutes        # generous pause to let other backrawls monitors get started
+  pollInterval = 500 milliseconds # pause between batches to allow for garbage collection etc
+  batchTimeout = 10 minutes       # should time out an errant batch
+  batchSize = 50                  # number of corrections to process per batch; small to keep computation light
+  dryRun = true                   # analyze only; don't change actual entity data
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityComponent.scala
@@ -45,7 +45,8 @@ trait CompactEntityComponent extends LazyLogging {
 class CompactEntityQuery(driverComponent: DriverComponent)
     extends CompactEntityKeysCache
     with RawSqlQuery
-    with CompactEntitySerialization {
+    with CompactEntitySerialization
+    with CompactEntityCorrection {
   override val driver = driverComponent.driver
   import driverComponent.uniqueResult
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrection.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrection.scala
@@ -3,10 +3,10 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.AttributeName
-import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatusType.AttributeCorrectionStatusType
-import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatusType.EntityCorrectionStatusType
+import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatus.AttributeCorrectionStatusType
+import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatus.EntityCorrectionStatusType
+import org.broadinstitute.dsde.rawls.monitor.ModifiedStatusType
 import org.broadinstitute.dsde.rawls.monitor.ModifiedStatusType.ModifiedStatusType
-import org.broadinstitute.dsde.rawls.monitor.{EntityCorrection, EntityCorrectionRecord, ModifiedStatusType}
 import slick.jdbc.GetResult
 import slick.jdbc.MySQLProfile.api._
 
@@ -49,6 +49,7 @@ trait CompactEntityCorrection {
   implicit val getEntityCorrectionRecord: GetResult[EntityCorrectionRecord] =
     GetResult(r => EntityCorrectionRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<))
 
+  /** retrieve the next N corrections from ENTITY_CORRECTIONS */
   def getNextCorrectionBatch(batchSize: Int): ReadAction[List[EntityCorrection]] =
     sql"""select id, workspace_id, entity_type, name, attributes, status
           from ENTITY_CORRECTIONS
@@ -59,6 +60,7 @@ trait CompactEntityCorrection {
       .as[EntityCorrectionRecord]
       .map(recs => recs.toList.map(r => EntityCorrection.fromRecord(r)))
 
+  /** update a single ENTITY_CORRECTIONS's status */
   def updateCorrectionStatus(workspaceId: UUID,
                              entityType: String,
                              entityName: String,
@@ -69,6 +71,7 @@ trait CompactEntityCorrection {
          and entity_type = $entityType
          and name = $entityName;""".asUpdate
 
+  /** upsert ATTRIBUTE_CORRECTIONS statuses */
   def updateAttributeStatuses(workspaceId: UUID,
                               entityType: String,
                               entityName: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrection.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrection.scala
@@ -1,0 +1,93 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+import org.broadinstitute.dsde.rawls.entities.compact.CompactEntitySerialization
+import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
+import org.broadinstitute.dsde.rawls.model.AttributeName
+import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatusType.AttributeCorrectionStatusType
+import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatusType.EntityCorrectionStatusType
+import org.broadinstitute.dsde.rawls.monitor.ModifiedStatusType.ModifiedStatusType
+import org.broadinstitute.dsde.rawls.monitor.{EntityCorrection, EntityCorrectionRecord, ModifiedStatusType}
+import slick.jdbc.GetResult
+import slick.jdbc.MySQLProfile.api._
+
+import java.util.UUID
+
+// low-level representation of a correction as saved in MySQL
+case class EntityCorrectionRecord(
+  id: Long,
+  workspaceId: UUID,
+  entityType: String,
+  entityName: String,
+  attributes: String,
+  status: String
+)
+
+// high-level representation of a correction for use in the Scala tier
+object EntityCorrection {
+  def fromRecord(rec: EntityCorrectionRecord): EntityCorrection =
+    new EntityCorrection(
+      rec.id,
+      rec.workspaceId,
+      rec.entityType,
+      rec.entityName,
+      CompactEntitySerialization.fromSql(Option(rec.attributes)),
+      ModifiedStatusType.fromString(rec.status)
+    )
+}
+case class EntityCorrection(
+  id: Long,
+  workspaceId: UUID,
+  entityType: String,
+  entityName: String,
+  attributes: AttributeMap,
+  status: ModifiedStatusType
+)
+
+trait CompactEntityCorrection {
+  this: CompactEntityQuery =>
+
+  implicit val getEntityCorrectionRecord: GetResult[EntityCorrectionRecord] =
+    GetResult(r => EntityCorrectionRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<))
+
+  def getNextCorrectionBatch(batchSize: Int): ReadAction[List[EntityCorrection]] =
+    sql"""select id, workspace_id, entity_type, name, attributes, status
+          from ENTITY_CORRECTIONS
+          order by workspace_id, entity_type, name
+          where status is null
+          limit $batchSize;
+         """
+      .as[EntityCorrectionRecord]
+      .map(recs => recs.toList.map(r => EntityCorrection.fromRecord(r)))
+
+  def updateCorrectionStatus(workspaceId: UUID,
+                             entityType: String,
+                             entityName: String,
+                             status: EntityCorrectionStatusType
+  ): ReadWriteAction[Int] =
+    sql"""update ENTITY_CORRECTIONS set status = ${status.toString}
+         where workspace_id = $workspaceId
+         and entity_type = $entityType
+         and name = $entityName;""".asUpdate
+
+  def updateAttributeStatuses(workspaceId: UUID,
+                              entityType: String,
+                              entityName: String,
+                              statuses: Map[AttributeName, AttributeCorrectionStatusType]
+  ): ReadWriteAction[Int] = {
+    val startSql =
+      sql"""insert into ATTRIBUTE_CORRECTIONS(workspace_id, entity_type, entity_name, namespace, name, status)
+          values """
+
+    val valuesSql = reduceSqlActionsWithDelim(
+      statuses.map { case (attrName, status) =>
+        sql"""($workspaceId, $entityType, $entityName, ${attrName.namespace}, ${attrName.name}, ${status.toString})"""
+      }.toSeq,
+      sql","
+    )
+
+    val endSql = sql""" as newvalues on duplicate key update status = newvalues.status;"""
+
+    concatSqlActions(startSql, valuesSql, endSql).asUpdate
+
+  }
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrection.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrection.scala
@@ -44,13 +44,17 @@ trait CompactEntityCorrection {
   implicit val getEntityCorrectionRecord: GetResult[EntityCorrectionRecord] =
     GetResult(r => EntityCorrectionRecord(r.<<, r.<<, r.<<, r.<<, r.<<))
 
+  /** count the outstanding corrections */
+  def countOutstandingCorrections: ReadAction[Int] =
+    sql"""select count(1) from ENTITY_CORRECTIONS where status = 'OUTSTANDING'""".as[Int].head
+
   /** retrieve the next N corrections from ENTITY_CORRECTIONS */
   def getNextCorrectionBatch(batchSize: Int): ReadAction[List[EntityCorrection]] =
     sql"""select id, workspace_id, entity_type, name, attributes
           from ENTITY_CORRECTIONS
+          where status = 'OUTSTANDING'
           order by workspace_id, entity_type, name
-          where status is null
-          limit $batchSize;
+          limit $batchSize
          """
       .as[EntityCorrectionRecord]
       .map(recs => recs.toList.map(r => EntityCorrection.fromRecord(r)))
@@ -67,18 +71,16 @@ trait CompactEntityCorrection {
          and name = $entityName;""".asUpdate
 
   /** upsert ATTRIBUTE_CORRECTIONS statuses */
-  def updateAttributeStatuses(workspaceId: UUID,
-                              entityType: String,
-                              entityName: String,
+  def updateAttributeStatuses(correctionId: Long,
                               statuses: Map[AttributeName, AttributeCorrectionStatusType]
   ): ReadWriteAction[Int] = {
     val startSql =
-      sql"""insert into ATTRIBUTE_CORRECTIONS(workspace_id, entity_type, entity_name, namespace, name, status)
+      sql"""insert into ATTRIBUTE_CORRECTIONS(correction_id, namespace, name, status)
           values """
 
     val valuesSql = reduceSqlActionsWithDelim(
       statuses.map { case (attrName, status) =>
-        sql"""($workspaceId, $entityType, $entityName, ${attrName.namespace}, ${attrName.name}, ${status.toString})"""
+        sql"""($correctionId, ${attrName.namespace}, ${attrName.name}, ${status.toString})"""
       }.toSeq,
       sql","
     )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrection.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrection.scala
@@ -5,8 +5,6 @@ import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.AttributeName
 import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatus.AttributeCorrectionStatusType
 import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatus.EntityCorrectionStatusType
-import org.broadinstitute.dsde.rawls.monitor.ModifiedStatusType
-import org.broadinstitute.dsde.rawls.monitor.ModifiedStatusType.ModifiedStatusType
 import slick.jdbc.GetResult
 import slick.jdbc.MySQLProfile.api._
 
@@ -18,8 +16,7 @@ case class EntityCorrectionRecord(
   workspaceId: UUID,
   entityType: String,
   entityName: String,
-  attributes: String,
-  status: String
+  attributes: String
 )
 
 // high-level representation of a correction for use in the Scala tier
@@ -30,8 +27,7 @@ object EntityCorrection {
       rec.workspaceId,
       rec.entityType,
       rec.entityName,
-      CompactEntitySerialization.fromSql(Option(rec.attributes)),
-      ModifiedStatusType.fromString(rec.status)
+      CompactEntitySerialization.fromSql(Option(rec.attributes))
     )
 }
 case class EntityCorrection(
@@ -39,19 +35,18 @@ case class EntityCorrection(
   workspaceId: UUID,
   entityType: String,
   entityName: String,
-  attributes: AttributeMap,
-  status: ModifiedStatusType
+  attributes: AttributeMap
 )
 
 trait CompactEntityCorrection {
   this: CompactEntityQuery =>
 
   implicit val getEntityCorrectionRecord: GetResult[EntityCorrectionRecord] =
-    GetResult(r => EntityCorrectionRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<))
+    GetResult(r => EntityCorrectionRecord(r.<<, r.<<, r.<<, r.<<, r.<<))
 
   /** retrieve the next N corrections from ENTITY_CORRECTIONS */
   def getNextCorrectionBatch(batchSize: Int): ReadAction[List[EntityCorrection]] =
-    sql"""select id, workspace_id, entity_type, name, attributes, status
+    sql"""select id, workspace_id, entity_type, name, attributes
           from ENTITY_CORRECTIONS
           order by workspace_id, entity_type, name
           where status is null

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -31,6 +31,7 @@ import org.broadinstitute.dsde.rawls.model.{
   WorkspaceCloudPlatform
 }
 import org.broadinstitute.dsde.rawls.monitor.AvroUpsertMonitorSupervisor.AvroUpsertMonitorConfig
+import org.broadinstitute.dsde.rawls.monitor.QuicksilverMigrationMonitor.QuicksilverMigrationMonitorConfig
 import org.broadinstitute.dsde.rawls.util
 import org.broadinstitute.dsde.rawls.workspace.{WorkspaceRepository, WorkspaceService, WorkspaceSettingRepository}
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
@@ -173,6 +174,9 @@ object BootMonitors extends LazyLogging {
       )
 
       startFastPassMonitor(system, appConfigManager.conf, slickDataSource, googleIamDAO, googleStorageDAO)
+
+      // Quicksilver correction monitor
+      launchQuicksilverCorrections(system, appConfigManager.conf, slickDataSource)
     }
 
     val cloneWorkspaceFileTransferMonitorConfigRoot =
@@ -376,6 +380,25 @@ object BootMonitors extends LazyLogging {
         dataSource
       )
     )
+
+  private def launchQuicksilverCorrections(system: ActorSystem, appConfig: Config, slickDataSource: SlickDataSource) = {
+    val conf = appConfig.getConfig("quicksilverCorrections")
+    // create Quicksilver migration config
+    val quicksilverMigrationMonitorConfig = QuicksilverMigrationMonitorConfig(
+      startupDelay = conf.getDuration("startupDelay").toScala,
+      pollInterval = conf.getDuration("pollInterval").toScala,
+      batchTimeout = conf.getDuration("batchTimeout").toScala,
+      batchSize = conf.getInt("batchSize"),
+      dryRun = conf.getBoolean("dryRun")
+    )
+    // start Quicksilver migration monitor
+    system.actorOf(
+      QuicksilverMigrationMonitor.props(
+        quicksilverMigrationMonitorConfig,
+        slickDataSource
+      )
+    )
+  }
 
   private def resetLaunchingWorkflows(dataSource: SlickDataSource) =
     Await.result(dataSource.inTransaction { dataAccess =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitor.scala
@@ -1,0 +1,145 @@
+package org.broadinstitute.dsde.rawls.monitor
+
+import akka.actor.{Actor, PoisonPill, Props}
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, EntityCorrection, ReadWriteAction}
+import org.broadinstitute.dsde.rawls.model.AttributeName
+import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatusType.AttributeCorrectionStatusType
+import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatusType.EntityCorrectionStatusType
+import org.broadinstitute.dsde.rawls.monitor.QuicksilverMigrationMonitor.{
+  AllDone,
+  Init,
+  NextBatch,
+  ProcessBatch,
+  QuicksilverMigrationMonitorConfig
+}
+import slick.dbio.DBIO
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+object QuicksilverMigrationMonitor {
+
+  // config
+  final case class QuicksilverMigrationMonitorConfig(startupDelay: FiniteDuration,
+                                                     pollInterval: FiniteDuration,
+                                                     batchSize: Int,
+                                                     dryRun: Boolean = true
+  )
+
+  // actor messages
+  sealed trait QuicksilverMonitorMessage
+  private case object Init extends QuicksilverMonitorMessage
+  private case object NextBatch extends QuicksilverMonitorMessage
+  private case class ProcessBatch(corrections: List[EntityCorrection])
+  private case object AllDone extends QuicksilverMonitorMessage
+
+  def props(
+    config: QuicksilverMigrationMonitorConfig,
+    dataSource: SlickDataSource
+  ): Props =
+    Props(
+      new QuicksilverMigrationMonitor(config, dataSource)
+    )
+
+}
+
+class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorConfig, dataSource: SlickDataSource)
+    extends Actor
+    with QuicksilverMigrationMonitorSupport
+    with LazyLogging {
+
+  import context._
+
+  override def receive: Receive = {
+    case Init                                              => startAll()
+    case NextBatch                                         => nextBatch()
+    case ProcessBatch(corrections: List[EntityCorrection]) => processBatch(corrections)
+    case AllDone                                           => self ! PoisonPill
+  }
+
+  private def startAll() =
+    context.system.scheduler.scheduleOnce(config.startupDelay, self, NextBatch)
+
+  private def nextBatch() =
+    dataSource.inTransaction { dataAccess =>
+      // select the next ${config.batchSize} rows from ENTITY_CORRECTIONS
+      dataAccess.compactEntityQuery.getNextCorrectionBatch(config.batchSize) map { batch =>
+        if (batch.isEmpty) {
+          logger.info("********** all corrections complete **********")
+          self ! AllDone
+        } else {
+          self ! ProcessBatch(batch)
+        }
+      }
+    }
+
+  /**
+   * Compare this batch of corrections to the current entities.
+   */
+  private def processBatch(corrections: List[EntityCorrection]): Future[Int] = {
+    // loop over each corrected entity from ENTITY_CORRECTIONS
+    val futures = corrections.map { correction =>
+      dataSource.inTransaction { dataAccess =>
+        // TODO: compare this workspace's last-modified date to its migration date
+        for {
+          // retrieve the corresponding current entity from ENTITY
+          currentEntity <- dataAccess.compactEntityQuery.getEntity(correction.workspaceId,
+                                                                   correction.entityType,
+                                                                   correction.entityName
+          )
+          // compare the corrected entity to the current entity
+          (entityStatus, attributeStatusMap) = compareEntities(currentEntity, correction)
+          // persist the analysis result
+          numUpdated <- persistAnalysisResult(dataAccess, correction, entityStatus, attributeStatusMap)
+        } yield {
+          // move on to the next batch
+          context.system.scheduler.scheduleOnce(config.pollInterval, self, NextBatch)
+          numUpdated
+        }
+      }
+    }
+    Future.sequence(futures).map { counts =>
+      val rowsUpdated = counts.sum
+      logger.info(s"processed batch of ${corrections.size} corrections with $rowsUpdated rows updated.")
+      rowsUpdated
+    }
+  }
+
+  /**
+   * Write the comparison results back to the database, updating ENTITY_CORRECTIONS
+   * and upserting to ATTRIBUTE_CORRECTIONS
+   */
+  private def persistAnalysisResult(dataAccess: DataAccess,
+                                    correction: EntityCorrection,
+                                    entityStatus: EntityCorrectionStatusType,
+                                    attributeStatusMap: Map[AttributeName, AttributeCorrectionStatusType]
+  ): ReadWriteAction[Int] = {
+    logger.info(
+      s"[${correction.workspaceId}] ${correction.entityType}/${correction.entityName}: $entityStatus (${attributeStatusMap.size})"
+    )
+    for {
+      persistEntityStatus <-
+        dataAccess.compactEntityQuery.updateCorrectionStatus(correction.workspaceId,
+                                                             correction.entityType,
+                                                             correction.entityName,
+                                                             entityStatus
+        )
+      persistAttributeStatuses <-
+        dataAccess.compactEntityQuery.updateAttributeStatuses(correction.workspaceId,
+                                                              correction.entityType,
+                                                              correction.entityName,
+                                                              attributeStatusMap
+        )
+      performCorrections <-
+        if (config.dryRun) {
+          DBIO.successful(0)
+        } else {
+          // TODO: write corrected entities back to the ENTITY table
+          DBIO.successful(0)
+        }
+    } yield persistEntityStatus + persistAttributeStatuses
+  }
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitor.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.dsde.rawls.monitor
 
 import akka.actor.{Actor, PoisonPill, Props}
+import akka.pattern.pipe
+import akka.util.Timeout
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, EntityCorrection, ReadWriteAction}
@@ -18,6 +20,7 @@ object QuicksilverMigrationMonitor {
   // config
   final case class QuicksilverMigrationMonitorConfig(startupDelay: FiniteDuration,
                                                      pollInterval: FiniteDuration,
+                                                     batchTimeout: Timeout,
                                                      batchSize: Int,
                                                      dryRun: Boolean = true
   )
@@ -25,8 +28,10 @@ object QuicksilverMigrationMonitor {
   // actor messages
   sealed private trait QuicksilverMonitorMessage
   private case object Init extends QuicksilverMonitorMessage
-  private case object NextBatch extends QuicksilverMonitorMessage
-  private case class ProcessBatch(corrections: List[EntityCorrection])
+  private case object CountOutstanding extends QuicksilverMonitorMessage
+  private case class NextBatch(iteration: Int, expectedIterations: Int) extends QuicksilverMonitorMessage
+  private case class ProcessBatch(corrections: List[EntityCorrection], iteration: Int, expectedIterations: Int)
+      extends QuicksilverMonitorMessage
   private case object AllDone extends QuicksilverMonitorMessage
 
   // actor-creator
@@ -48,43 +53,73 @@ private class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorCon
 
   import context._
 
+  implicit val askTimeout: Timeout = config.batchTimeout
+
   // routing
   override def receive: Receive = {
-    case Init                                              => startAll()
-    case NextBatch                                         => nextBatch()
-    case ProcessBatch(corrections: List[EntityCorrection]) => processBatch(corrections)
-    case AllDone                                           => self ! PoisonPill
+    case Init                                               => startAll()
+    case CountOutstanding                                   => countOutstanding() pipeTo self
+    case NextBatch(iteration: Int, expectedIterations: Int) => nextBatch(iteration, expectedIterations) pipeTo self
+    case ProcessBatch(corrections: List[EntityCorrection], iteration: Int, expectedIterations: Int) =>
+      processBatch(corrections, iteration, expectedIterations) pipeTo self
+    case AllDone => self ! PoisonPill
+    case x       =>
+      logger.error(s"Unexpected message: ${x.getClass.getName}: $x")
+      self ! PoisonPill
   }
 
   /** kick things off */
+  logger.info("initializing ...")
   self ! Init
 
-  /** start processing: wait for the startupDelay, then process the next batch */
-  private def startAll() =
-    context.system.scheduler.scheduleOnce(config.startupDelay, self, NextBatch)
+  /** wait for the startupDelay, start the actor doing work */
+  private def startAll() = {
+    logger.info("starting ...")
+    context.system.scheduler.scheduleOnce(config.startupDelay, self, CountOutstanding)
+  }
+
+  /** count the outstanding corrections so log messages can show progress */
+  private def countOutstanding(): Future[QuicksilverMonitorMessage] = {
+    logger.info("counting outstanding corrections ...")
+    dataSource.inTransaction { dataAccess =>
+      dataAccess.compactEntityQuery.countOutstandingCorrections map { count =>
+        val expectedIterations = Math.ceil(count / config.batchSize).toInt
+        NextBatch(1, expectedIterations)
+      }
+    }
+  }
 
   /** query for the next batch of corrections */
-  private def nextBatch() =
+  private def nextBatch(iteration: Int, expectedIterations: Int): Future[QuicksilverMonitorMessage] = {
+    logger.debug(s"querying for next batch (${config.batchSize}) ...")
     dataSource.inTransaction { dataAccess =>
       // select the next ${config.batchSize} rows from ENTITY_CORRECTIONS
       dataAccess.compactEntityQuery.getNextCorrectionBatch(config.batchSize) map { batch =>
         if (batch.isEmpty) {
           logger.info("********** all corrections complete **********")
-          self ! AllDone
+          AllDone
         } else {
-          self ! ProcessBatch(batch)
+          logger.debug(s"... retrieved ${batch.size} corrections ...")
+          ProcessBatch(batch, iteration, expectedIterations)
         }
       }
+    } recover { case t: Throwable =>
+      logger.error(s"${t.getClass.getName}: ${t.getMessage}")
+      throw t
     }
+  }
 
   /**
    * Compare this batch of corrections to the current entities.
    */
-  private def processBatch(corrections: List[EntityCorrection]): Future[Int] = {
+  private def processBatch(corrections: List[EntityCorrection],
+                           iteration: Int,
+                           expectedIterations: Int
+  ): Future[QuicksilverMonitorMessage] = {
+    logger.debug(s"processing batch of ${corrections.size} corrections ...")
     // loop over each corrected entity from ENTITY_CORRECTIONS
     val futures = corrections.map { correction =>
       dataSource.inTransaction { dataAccess =>
-        // TODO: compare this workspace's last-modified date to its migration date
         for {
           // retrieve the corresponding current entity from ENTITY
           currentEntity <- dataAccess.compactEntityQuery.getEntity(correction.workspaceId,
@@ -95,17 +130,18 @@ private class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorCon
           (entityStatus, attributeStatusMap) = compareEntities(currentEntity.map(_.toEntity), correction)
           // persist the analysis result
           numUpdated <- persistAnalysisResult(dataAccess, correction, entityStatus, attributeStatusMap)
-        } yield {
-          // move on to the next batch
-          context.system.scheduler.scheduleOnce(config.pollInterval, self, NextBatch)
-          numUpdated
-        }
+        } yield numUpdated
       }
     }
     Future.sequence(futures).map { counts =>
       val rowsUpdated = counts.sum
-      logger.info(s"processed batch of ${corrections.size} corrections with $rowsUpdated rows updated.")
-      rowsUpdated
+      logger.info(
+        f"($iteration%,d/$expectedIterations%,d): processed batch of ${corrections.size} corrections with $rowsUpdated rows updated."
+      )
+      NextBatch(iteration + 1, expectedIterations)
+    } recover { case t: Throwable =>
+      logger.error(s"${t.getClass.getName}: ${t.getMessage}")
+      throw t
     }
   }
 
@@ -118,7 +154,7 @@ private class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorCon
                                     entityStatus: EntityCorrectionStatusType,
                                     attributeStatusMap: Map[AttributeName, AttributeCorrectionStatusType]
   ): ReadWriteAction[Int] = {
-    logger.info(
+    logger.trace(
       s"[${correction.workspaceId}] ${correction.entityType}/${correction.entityName}: $entityStatus (${attributeStatusMap.size})"
     )
     for {
@@ -129,11 +165,7 @@ private class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorCon
                                                              entityStatus
         )
       persistAttributeStatuses <-
-        dataAccess.compactEntityQuery.updateAttributeStatuses(correction.workspaceId,
-                                                              correction.entityType,
-                                                              correction.entityName,
-                                                              attributeStatusMap
-        )
+        dataAccess.compactEntityQuery.updateAttributeStatuses(correction.id, attributeStatusMap)
       _ <-
         if (config.dryRun) {
           DBIO.successful(0)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitor.scala
@@ -5,17 +5,9 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, EntityCorrection, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.model.AttributeName
-import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatus
 import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatus.AttributeCorrectionStatusType
-import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatus
 import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatus.EntityCorrectionStatusType
-import org.broadinstitute.dsde.rawls.monitor.QuicksilverMigrationMonitor.{
-  AllDone,
-  Init,
-  NextBatch,
-  ProcessBatch,
-  QuicksilverMigrationMonitorConfig
-}
+import org.broadinstitute.dsde.rawls.monitor.QuicksilverMigrationMonitor._
 import slick.dbio.DBIO
 
 import scala.concurrent.Future
@@ -49,7 +41,7 @@ object QuicksilverMigrationMonitor {
 }
 
 // the actor
-class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorConfig, dataSource: SlickDataSource)
+private class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorConfig, dataSource: SlickDataSource)
     extends Actor
     with QuicksilverMigrationMonitorSupport
     with LazyLogging {
@@ -100,7 +92,7 @@ class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorConfig, dat
                                                                    correction.entityName
           )
           // compare the corrected entity to the current entity
-          (entityStatus, attributeStatusMap) = compareEntities(currentEntity, correction)
+          (entityStatus, attributeStatusMap) = compareEntities(currentEntity.map(_.toEntity), correction)
           // persist the analysis result
           numUpdated <- persistAnalysisResult(dataAccess, correction, entityStatus, attributeStatusMap)
         } yield {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitor.scala
@@ -5,8 +5,10 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, EntityCorrection, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.model.AttributeName
-import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatusType.AttributeCorrectionStatusType
-import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatusType.EntityCorrectionStatusType
+import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatus
+import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatus.AttributeCorrectionStatusType
+import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatus
+import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatus.EntityCorrectionStatusType
 import org.broadinstitute.dsde.rawls.monitor.QuicksilverMigrationMonitor.{
   AllDone,
   Init,
@@ -29,12 +31,13 @@ object QuicksilverMigrationMonitor {
   )
 
   // actor messages
-  sealed trait QuicksilverMonitorMessage
+  sealed private trait QuicksilverMonitorMessage
   private case object Init extends QuicksilverMonitorMessage
   private case object NextBatch extends QuicksilverMonitorMessage
   private case class ProcessBatch(corrections: List[EntityCorrection])
   private case object AllDone extends QuicksilverMonitorMessage
 
+  // actor-creator
   def props(
     config: QuicksilverMigrationMonitorConfig,
     dataSource: SlickDataSource
@@ -45,6 +48,7 @@ object QuicksilverMigrationMonitor {
 
 }
 
+// the actor
 class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorConfig, dataSource: SlickDataSource)
     extends Actor
     with QuicksilverMigrationMonitorSupport
@@ -52,6 +56,7 @@ class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorConfig, dat
 
   import context._
 
+  // routing
   override def receive: Receive = {
     case Init                                              => startAll()
     case NextBatch                                         => nextBatch()
@@ -59,9 +64,14 @@ class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorConfig, dat
     case AllDone                                           => self ! PoisonPill
   }
 
+  /** kick things off */
+  self ! Init
+
+  /** start processing: wait for the startupDelay, then process the next batch */
   private def startAll() =
     context.system.scheduler.scheduleOnce(config.startupDelay, self, NextBatch)
 
+  /** query for the next batch of corrections */
   private def nextBatch() =
     dataSource.inTransaction { dataAccess =>
       // select the next ${config.batchSize} rows from ENTITY_CORRECTIONS
@@ -132,7 +142,7 @@ class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorConfig, dat
                                                               correction.entityName,
                                                               attributeStatusMap
         )
-      performCorrections <-
+      _ <-
         if (config.dryRun) {
           DBIO.successful(0)
         } else {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
@@ -1,61 +1,53 @@
 package org.broadinstitute.dsde.rawls.monitor
 
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{CompactEntityRecord, EntityCorrection}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.EntityCorrection
 import org.broadinstitute.dsde.rawls.model.{
   Attribute,
   AttributeEntityReference,
   AttributeEntityReferenceList,
   AttributeName,
   AttributeValue,
-  AttributeValueList
+  AttributeValueList,
+  Entity
 }
 import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatus.AttributeCorrectionStatusType
 import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatus.EntityCorrectionStatusType
 
 object AttributeCorrectionStatus extends Enumeration {
   type AttributeCorrectionStatusType = Value
-  val CurrentAttrGone, Correct, Reordered, StartsWith, Different, TypeDifferent = Value
+  val Correct, Reordered, StartsWith, Different, TypeDifferent = Value
 }
 
 object EntityCorrectionStatus extends Enumeration {
   type EntityCorrectionStatusType = Value
-  val CurrentGone, Correct, Correctable, Mixed, StartsWith, Different = Value
-}
-
-object ModifiedStatusType extends Enumeration {
-  type ModifiedStatusType = Value
-  val Unmodified, Modified = Value
-  def fromString(str: String): ModifiedStatusType = str.toLowerCase match {
-    case "unmodified" => Unmodified
-    case "modified"   => Modified
-    case x            => throw new Exception(s"$x is not a ModifiedStatusType")
-  }
+  val CurrentGone, Correct, Correctable, Mixed, StartsWith, Different, TypeDifferent = Value
 }
 
 trait QuicksilverMigrationMonitorSupport {
 
-  def compareEntities(current: Option[CompactEntityRecord],
+  def compareEntities(current: Option[Entity],
                       correction: EntityCorrection
   ): (EntityCorrectionStatusType, Map[AttributeName, AttributeCorrectionStatusType]) = current match {
     // current entity does not exist
     case None => (EntityCorrectionStatus.CurrentGone, Map())
     // current entity exists; compare its attributes
-    case Some(cr) =>
+    case Some(e) =>
       // get the current attribute map
-      val currentAttributes = cr.toEntity.attributes
+      val currentAttributes = e.attributes
       // loop through the correction's attributes
-      val attrComparisons: Map[AttributeName, AttributeCorrectionStatusType] = correction.attributes.map {
+      val attrComparisons: Map[AttributeName, AttributeCorrectionStatusType] = correction.attributes.flatMap {
         case (attributeName, correctionValue) =>
           // get the corresponding current attribute
           val currentValue = currentAttributes.get(attributeName)
           currentValue match {
             // current attribute does not exist
-            case None               => (attributeName, AttributeCorrectionStatus.CurrentAttrGone)
-            case Some(currentValue) => (attributeName, compareAttrs(currentValue, correctionValue))
+            case None               => None
+            case Some(currentValue) => Some((attributeName, compareAttrs(currentValue, correctionValue)))
           }
       }
       // determine overall entity status from attribute statuses
-      (EntityCorrectionStatus.CurrentGone, attrComparisons)
+      val entityStatus = calculateEntityStatus(attrComparisons)
+      (entityStatus, attrComparisons)
   }
 
   def compareAttrs(current: Attribute, correction: Attribute): AttributeCorrectionStatusType =
@@ -115,9 +107,23 @@ trait QuicksilverMigrationMonitorSupport {
     attributeStatuses: Map[AttributeName, AttributeCorrectionStatusType]
   ): EntityCorrectionStatusType = {
     val attrStatuses = attributeStatuses.values.toSet
-    // CurrentAttrGone, Correct, Reordered, StartsWith, Different, TypeDifferent
-    // TODO: calculate status!
-    EntityCorrectionStatus.Mixed
+
+    if (attrStatuses.isEmpty) {
+      EntityCorrectionStatus.Correct
+    } else if (attrStatuses == Set(AttributeCorrectionStatus.Correct)) {
+      EntityCorrectionStatus.Correct
+    } else if (attrStatuses == Set(AttributeCorrectionStatus.Reordered)) {
+      EntityCorrectionStatus.Correctable
+    } else if (attrStatuses == Set(AttributeCorrectionStatus.Different)) {
+      EntityCorrectionStatus.Different
+    } else if (attrStatuses == Set(AttributeCorrectionStatus.StartsWith)) {
+      EntityCorrectionStatus.StartsWith
+    } else if (attrStatuses == Set(AttributeCorrectionStatus.TypeDifferent)) {
+      EntityCorrectionStatus.TypeDifferent
+    } else {
+      EntityCorrectionStatus.Mixed
+    }
+
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
@@ -15,12 +15,12 @@ import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatus.EntityCorrec
 
 object AttributeCorrectionStatus extends Enumeration {
   type AttributeCorrectionStatusType = Value
-  val Correct, Reordered, StartsWith, Different, TypeDifferent = Value
+  val Correct, Reordered, Intersect, Different, NothingInCommon, TypeDifferent = Value
 }
 
 object EntityCorrectionStatus extends Enumeration {
   type EntityCorrectionStatusType = Value
-  val CurrentGone, Correct, Correctable, Mixed, StartsWith, Different, TypeDifferent = Value
+  val CurrentGone, Correct, Correctable, Mixed, Intersect, Different, NothingInCommon, TypeDifferent = Value
 }
 
 trait QuicksilverMigrationMonitorSupport {
@@ -72,36 +72,44 @@ trait QuicksilverMigrationMonitorSupport {
     compareLists[AttributeEntityReference](current.list, correction.list)
 
   // inspect the elements of the lists
-  def compareLists[T](current: Seq[T], correction: Seq[T]): AttributeCorrectionStatusType = {
-    val sameSize = current.size == correction.size
+  def compareLists[T](current: Seq[T], correction: Seq[T]): AttributeCorrectionStatusType =
 
-    if (sameSize) {
-      if (current == correction) {
-        // exactly equal; this is correct
-        AttributeCorrectionStatus.Correct
+    if (current == correction) {
+      // exactly equal; this is correct
+      AttributeCorrectionStatus.Correct
+    } else {
+      // generate a map of AttributeValue -> count, where $count is the number of times that element appears
+      // in the list
+      val currentCounts = current.groupBy(identity).map { case (attrVal, seq) => (attrVal, seq.size) }
+      val correctionCounts = correction.groupBy(identity).map { case (attrVal, seq) => (attrVal, seq.size) }
+      // compare the elements and their counts; this is an unordered comparison
+      if (currentCounts == correctionCounts) {
+        // list has the same elements, and in the same counts, but did not pass the
+        // current.list == correction.list comparison; it must have been reordered
+        AttributeCorrectionStatus.Reordered
       } else {
-        // generate a map of AttributeValue -> count, where $count is the number of times that element appears
-        // in the list
-        val currentCounts = current.groupBy(identity).map { case (attrVal, seq) => (attrVal, seq.size) }
-        val correctionCounts = correction.groupBy(identity).map { case (attrVal, seq) => (attrVal, seq.size) }
-        // compare the elements and their counts; this is an unordered comparison
-        if (currentCounts == correctionCounts) {
-          // list has the same elements, and in the same counts, but did not pass the
-          // current.list == correction.list comparison; it must have been reordered
-          AttributeCorrectionStatus.Reordered
+        // the elements in the two lists are different. Check the intersection of the two lists
+        // to see if the intersection is in the same order; if so, it is because elements have
+        // been added/removed without otherwise reordering.
+        val intersection = current.toSet intersect correction.toSet
+
+        if (intersection.isEmpty) {
+          // no elements in common
+          AttributeCorrectionStatus.NothingInCommon
         } else {
-          // list has different elements, or some of those elements have different counts
-          AttributeCorrectionStatus.Different
+          // filter each list to only contain the elements in the intersection
+          val currentFiltered = current.filter(x => intersection contains x)
+          val correctionFiltered = correction.filter(x => intersection contains x)
+
+          if (currentFiltered == correctionFiltered) {
+            // the intersection of
+            AttributeCorrectionStatus.Intersect
+          } else {
+            AttributeCorrectionStatus.Different
+          }
         }
       }
-    } else {
-      if (current.startsWith(correction)) {
-        AttributeCorrectionStatus.StartsWith
-      } else {
-        AttributeCorrectionStatus.Different
-      }
     }
-  }
 
   def calculateEntityStatus(
     attributeStatuses: Map[AttributeName, AttributeCorrectionStatusType]
@@ -116,8 +124,10 @@ trait QuicksilverMigrationMonitorSupport {
       EntityCorrectionStatus.Correctable
     } else if (attrStatuses == Set(AttributeCorrectionStatus.Different)) {
       EntityCorrectionStatus.Different
-    } else if (attrStatuses == Set(AttributeCorrectionStatus.StartsWith)) {
-      EntityCorrectionStatus.StartsWith
+    } else if (attrStatuses == Set(AttributeCorrectionStatus.Intersect)) {
+      EntityCorrectionStatus.Intersect
+    } else if (attrStatuses == Set(AttributeCorrectionStatus.NothingInCommon)) {
+      EntityCorrectionStatus.NothingInCommon
     } else if (attrStatuses == Set(AttributeCorrectionStatus.TypeDifferent)) {
       EntityCorrectionStatus.TypeDifferent
     } else {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
@@ -1,31 +1,23 @@
 package org.broadinstitute.dsde.rawls.monitor
 
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{
-  CompactEntityQuery,
-  CompactEntityRecord,
-  EntityCorrection,
-  ReadAction
-}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{CompactEntityRecord, EntityCorrection}
 import org.broadinstitute.dsde.rawls.model.{
   Attribute,
+  AttributeEntityReference,
   AttributeEntityReferenceList,
   AttributeName,
-  AttributeValueList,
-  Entity
+  AttributeValue,
+  AttributeValueList
 }
-import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatusType._
-import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatusType._
-import slick.jdbc.MySQLProfile.api._
+import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatus.AttributeCorrectionStatusType
+import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatus.EntityCorrectionStatusType
 
-import java.util.UUID
-import scala.collection.Set
-
-object AttributeCorrectionStatusType extends Enumeration {
+object AttributeCorrectionStatus extends Enumeration {
   type AttributeCorrectionStatusType = Value
   val CurrentAttrGone, Correct, Reordered, StartsWith, Different, TypeDifferent = Value
 }
 
-object EntityCorrectionStatusType extends Enumeration {
+object EntityCorrectionStatus extends Enumeration {
   type EntityCorrectionStatusType = Value
   val CurrentGone, Correct, Correctable, Mixed, StartsWith, Different = Value
 }
@@ -46,7 +38,7 @@ trait QuicksilverMigrationMonitorSupport {
                       correction: EntityCorrection
   ): (EntityCorrectionStatusType, Map[AttributeName, AttributeCorrectionStatusType]) = current match {
     // current entity does not exist
-    case None => (CurrentGone, Map())
+    case None => (EntityCorrectionStatus.CurrentGone, Map())
     // current entity exists; compare its attributes
     case Some(cr) =>
       // get the current attribute map
@@ -58,19 +50,19 @@ trait QuicksilverMigrationMonitorSupport {
           val currentValue = currentAttributes.get(attributeName)
           currentValue match {
             // current attribute does not exist
-            case None               => (attributeName, CurrentAttrGone)
+            case None               => (attributeName, AttributeCorrectionStatus.CurrentAttrGone)
             case Some(currentValue) => (attributeName, compareAttrs(currentValue, correctionValue))
           }
       }
       // determine overall entity status from attribute statuses
-      (CurrentGone, attrComparisons)
+      (EntityCorrectionStatus.CurrentGone, attrComparisons)
   }
 
   def compareAttrs(current: Attribute, correction: Attribute): AttributeCorrectionStatusType =
     (current, correction) match {
       // current attribute is not the same type as correction attribute
       case _ if current.getClass != correction.getClass =>
-        TypeDifferent
+        AttributeCorrectionStatus.TypeDifferent
       case (x: AttributeValueList, y: AttributeValueList)                     => compareLists(x, y)
       case (x: AttributeEntityReferenceList, y: AttributeEntityReferenceList) => compareLists(x, y)
       case _                                                                  =>
@@ -79,14 +71,45 @@ trait QuicksilverMigrationMonitorSupport {
         )
     }
 
-  def compareLists(current: AttributeValueList, correction: AttributeValueList): AttributeCorrectionStatusType = ???
-  // TODO: compare!
+  def compareLists(current: AttributeValueList, correction: AttributeValueList): AttributeCorrectionStatusType =
+    compareLists[AttributeValue](current.list, correction.list)
 
   def compareLists(current: AttributeEntityReferenceList,
                    correction: AttributeEntityReferenceList
   ): AttributeCorrectionStatusType =
-    ???
-  // TODO: compare!
+    compareLists[AttributeEntityReference](current.list, correction.list)
+
+  // inspect the elements of the lists
+  def compareLists[T](current: Seq[T], correction: Seq[T]): AttributeCorrectionStatusType = {
+    val sameSize = current.size == correction.size
+
+    if (sameSize) {
+      if (current == correction) {
+        // exactly equal; this is correct
+        AttributeCorrectionStatus.Correct
+      } else {
+        // generate a map of AttributeValue -> count, where $count is the number of times that element appears
+        // in the list
+        val currentCounts = current.groupBy(identity).map { case (attrVal, seq) => (attrVal, seq.size) }
+        val correctionCounts = correction.groupBy(identity).map { case (attrVal, seq) => (attrVal, seq.size) }
+        // compare the elements and their counts; this is an unordered comparison
+        if (currentCounts == correctionCounts) {
+          // list has the same elements, and in the same counts, but did not pass the
+          // current.list == correction.list comparison; it must have been reordered
+          AttributeCorrectionStatus.Reordered
+        } else {
+          // list has different elements, or some of those elements have different counts
+          AttributeCorrectionStatus.Different
+        }
+      }
+    } else {
+      if (current.startsWith(correction)) {
+        AttributeCorrectionStatus.StartsWith
+      } else {
+        AttributeCorrectionStatus.Different
+      }
+    }
+  }
 
   def calculateEntityStatus(
     attributeStatuses: Map[AttributeName, AttributeCorrectionStatusType]
@@ -94,7 +117,7 @@ trait QuicksilverMigrationMonitorSupport {
     val attrStatuses = attributeStatuses.values.toSet
     // CurrentAttrGone, Correct, Reordered, StartsWith, Different, TypeDifferent
     // TODO: calculate status!
-    Mixed
+    EntityCorrectionStatus.Mixed
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
@@ -1,0 +1,100 @@
+package org.broadinstitute.dsde.rawls.monitor
+
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{
+  CompactEntityQuery,
+  CompactEntityRecord,
+  EntityCorrection,
+  ReadAction
+}
+import org.broadinstitute.dsde.rawls.model.{
+  Attribute,
+  AttributeEntityReferenceList,
+  AttributeName,
+  AttributeValueList,
+  Entity
+}
+import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatusType._
+import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatusType._
+import slick.jdbc.MySQLProfile.api._
+
+import java.util.UUID
+import scala.collection.Set
+
+object AttributeCorrectionStatusType extends Enumeration {
+  type AttributeCorrectionStatusType = Value
+  val CurrentAttrGone, Correct, Reordered, StartsWith, Different, TypeDifferent = Value
+}
+
+object EntityCorrectionStatusType extends Enumeration {
+  type EntityCorrectionStatusType = Value
+  val CurrentGone, Correct, Correctable, Mixed, StartsWith, Different = Value
+}
+
+object ModifiedStatusType extends Enumeration {
+  type ModifiedStatusType = Value
+  val Unmodified, Modified = Value
+  def fromString(str: String): ModifiedStatusType = str.toLowerCase match {
+    case "unmodified" => Unmodified
+    case "modified"   => Modified
+    case x            => throw new Exception(s"$x is not a ModifiedStatusType")
+  }
+}
+
+trait QuicksilverMigrationMonitorSupport {
+
+  def compareEntities(current: Option[CompactEntityRecord],
+                      correction: EntityCorrection
+  ): (EntityCorrectionStatusType, Map[AttributeName, AttributeCorrectionStatusType]) = current match {
+    // current entity does not exist
+    case None => (CurrentGone, Map())
+    // current entity exists; compare its attributes
+    case Some(cr) =>
+      // get the current attribute map
+      val currentAttributes = cr.toEntity.attributes
+      // loop through the correction's attributes
+      val attrComparisons: Map[AttributeName, AttributeCorrectionStatusType] = correction.attributes.map {
+        case (attributeName, correctionValue) =>
+          // get the corresponding current attribute
+          val currentValue = currentAttributes.get(attributeName)
+          currentValue match {
+            // current attribute does not exist
+            case None               => (attributeName, CurrentAttrGone)
+            case Some(currentValue) => (attributeName, compareAttrs(currentValue, correctionValue))
+          }
+      }
+      // determine overall entity status from attribute statuses
+      (CurrentGone, attrComparisons)
+  }
+
+  def compareAttrs(current: Attribute, correction: Attribute): AttributeCorrectionStatusType =
+    (current, correction) match {
+      // current attribute is not the same type as correction attribute
+      case _ if current.getClass != correction.getClass =>
+        TypeDifferent
+      case (x: AttributeValueList, y: AttributeValueList)                     => compareLists(x, y)
+      case (x: AttributeEntityReferenceList, y: AttributeEntityReferenceList) => compareLists(x, y)
+      case _                                                                  =>
+        throw new Exception(
+          s"unexpected classes found! current: ${current.getClass.getName}; correction: ${correction.getClass.getName}"
+        )
+    }
+
+  def compareLists(current: AttributeValueList, correction: AttributeValueList): AttributeCorrectionStatusType = ???
+  // TODO: compare!
+
+  def compareLists(current: AttributeEntityReferenceList,
+                   correction: AttributeEntityReferenceList
+  ): AttributeCorrectionStatusType =
+    ???
+  // TODO: compare!
+
+  def calculateEntityStatus(
+    attributeStatuses: Map[AttributeName, AttributeCorrectionStatusType]
+  ): EntityCorrectionStatusType = {
+    val attrStatuses = attributeStatuses.values.toSet
+    // CurrentAttrGone, Correct, Reordered, StartsWith, Different, TypeDifferent
+    // TODO: calculate status!
+    Mixed
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupportSpec.scala
@@ -1,54 +1,23 @@
 package org.broadinstitute.dsde.rawls.monitor
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
-import akka.testkit.TestKit
-import cats.effect.unsafe.implicits.global
-import org.broadinstitute.dsde.rawls.dataaccess._
-import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
-import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
-import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.MessageRequest
-import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
-import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
-  AddUpdateAttribute,
-  AttributeUpdateOperation,
-  EntityUpdateDefinition
-}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.EntityCorrection
 import org.broadinstitute.dsde.rawls.model.{
   AttributeEntityReference,
-  AttributeFormat,
+  AttributeEntityReferenceList,
   AttributeName,
+  AttributeNumber,
   AttributeString,
   AttributeValueList,
-  Entity,
-  ImportStatuses,
-  RawlsRequestContext,
-  TypedAttributeListSerializer,
-  UserInfo,
-  WorkspaceName
+  Entity
 }
-import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
-import org.broadinstitute.dsde.rawls.webservice.ApiServiceSpec
-import org.broadinstitute.dsde.workbench.google2.GcsBlobName
-import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
-import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
-import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{times, verify, when}
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.concurrent.Eventually
-import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
+import org.broadinstitute.dsde.rawls.monitor.AttributeCorrectionStatus.AttributeCorrectionStatusType
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.mockito.MockitoSugar
 
 import java.util.UUID
-import java.util.concurrent.TimeUnit
-import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.language.postfixOps
 
-class QuicksilverMigrationMonitorSupportSpec()
+class QuicksilverMigrationMonitorSupportSpec
     extends QuicksilverMigrationMonitorSupport
     with AnyFlatSpecLike
     with Matchers {
@@ -143,4 +112,93 @@ class QuicksilverMigrationMonitorSupportSpec()
     actual shouldBe AttributeCorrectionStatus.Different
   }
 
+  behavior of "compareAttrs"
+
+  it should "return TypeDifferent with different classes" in {
+    val current = AttributeValueList(
+      Seq(
+        AttributeString("foo"),
+        AttributeString("bar")
+      )
+    )
+    val correction = AttributeEntityReferenceList(
+      Seq(
+        AttributeEntityReference("type", "name1"),
+        AttributeEntityReference("type", "name2")
+      )
+    )
+    val actual = compareAttrs(current, correction)
+    actual shouldBe AttributeCorrectionStatus.TypeDifferent
+  }
+
+  behavior of "compareEntities"
+
+  it should "return CurrentGone if current entity does not exist" in {
+    val current = None
+    val correction = EntityCorrection(
+      1,
+      UUID.randomUUID(),
+      "type",
+      "name",
+      Map()
+    )
+    val (actualStatus, actualAttrStatusMap) = compareEntities(current, correction)
+    actualStatus shouldBe EntityCorrectionStatus.CurrentGone
+    actualAttrStatusMap shouldBe empty
+  }
+
+  it should "skip attributes that no longer exist" in {
+    val current = Some(
+      Entity("type", "name", Map(AttributeName.withDefaultNS("second") -> AttributeValueList(Seq(AttributeNumber(42)))))
+    )
+    val correction = EntityCorrection(
+      1,
+      UUID.randomUUID(),
+      "type",
+      "name",
+      Map(
+        AttributeName.withDefaultNS("first") -> AttributeValueList(Seq(AttributeNumber(99))),
+        AttributeName.withDefaultNS("second") -> AttributeValueList(Seq(AttributeNumber(42)))
+      )
+    )
+    val (actualStatus, actualAttrStatusMap) = compareEntities(current, correction)
+    actualStatus shouldBe EntityCorrectionStatus.Correct
+    actualAttrStatusMap shouldBe Map(AttributeName.withDefaultNS("second") -> AttributeCorrectionStatus.Correct)
+  }
+
+  behavior of "calculateEntityStatus"
+
+  it should "return Correct for empty attributes" in {
+    val statusMap = Map.empty[AttributeName, AttributeCorrectionStatusType]
+    val actual = calculateEntityStatus(statusMap)
+    actual shouldBe EntityCorrectionStatus.Correct
+  }
+
+  val consistentCases = Map(
+    AttributeCorrectionStatus.Correct -> EntityCorrectionStatus.Correct,
+    AttributeCorrectionStatus.Reordered -> EntityCorrectionStatus.Correctable,
+    AttributeCorrectionStatus.StartsWith -> EntityCorrectionStatus.StartsWith,
+    AttributeCorrectionStatus.Different -> EntityCorrectionStatus.Different,
+    AttributeCorrectionStatus.TypeDifferent -> EntityCorrectionStatus.TypeDifferent
+  )
+
+  consistentCases foreach { case (attrStatus, expectedEntityStatus) =>
+    it should s"return $expectedEntityStatus when all attributes are $attrStatus" in {
+      val statusMap = Map(
+        AttributeName.withDefaultNS("foo") -> attrStatus,
+        AttributeName.withLibraryNS("bar") -> attrStatus
+      )
+      val actual = calculateEntityStatus(statusMap)
+      actual shouldBe expectedEntityStatus
+    }
+  }
+
+  it should s"return Mixed when attributes have multiple statuses" in {
+    val statusMap = Map(
+      AttributeName.withDefaultNS("foo") -> AttributeCorrectionStatus.Correct,
+      AttributeName.withLibraryNS("bar") -> AttributeCorrectionStatus.Different
+    )
+    val actual = calculateEntityStatus(statusMap)
+    actual shouldBe EntityCorrectionStatus.Mixed
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupportSpec.scala
@@ -41,7 +41,7 @@ class QuicksilverMigrationMonitorSupportSpec
     actual shouldBe AttributeCorrectionStatus.Correct
   }
 
-  it should "return StartsWith when it does actually start with" in {
+  it should "return Intersect when it starts with" in {
     val current = AttributeValueList(
       Seq(
         AttributeString("foo"),
@@ -56,7 +56,47 @@ class QuicksilverMigrationMonitorSupportSpec
       )
     )
     val actual = compareLists(current, correction)
-    actual shouldBe AttributeCorrectionStatus.StartsWith
+    actual shouldBe AttributeCorrectionStatus.Intersect
+  }
+
+  it should "return Intersect when common elements are in the same order" in {
+    val current = AttributeValueList(
+      Seq(
+        AttributeString("foo"),
+        AttributeString("bar"),
+        AttributeString("baz")
+      )
+    )
+    val correction = AttributeValueList(
+      Seq(
+        AttributeString("bar"),
+        AttributeString("baz"),
+        AttributeString("qux"),
+        AttributeString("qdf")
+      )
+    )
+    val actual = compareLists(current, correction)
+    actual shouldBe AttributeCorrectionStatus.Intersect
+  }
+
+  it should "return Different when common elements are ordered but different quantity" in {
+    val current = AttributeValueList(
+      Seq(
+        AttributeString("foo"),
+        AttributeString("bar"),
+        AttributeString("bar"),
+        AttributeString("baz")
+      )
+    )
+    val correction = AttributeValueList(
+      Seq(
+        AttributeString("bar"),
+        AttributeString("baz"),
+        AttributeString("qux")
+      )
+    )
+    val actual = compareLists(current, correction)
+    actual shouldBe AttributeCorrectionStatus.Different
   }
 
   it should "return Reordered when it was reordered" in {
@@ -95,7 +135,7 @@ class QuicksilverMigrationMonitorSupportSpec
     actual shouldBe AttributeCorrectionStatus.Different
   }
 
-  it should "return Different with different elements" in {
+  it should "return NothingInCommon with different elements" in {
     val current = AttributeValueList(
       Seq(
         AttributeString("cat"),
@@ -109,7 +149,7 @@ class QuicksilverMigrationMonitorSupportSpec
       )
     )
     val actual = compareLists(current, correction)
-    actual shouldBe AttributeCorrectionStatus.Different
+    actual shouldBe AttributeCorrectionStatus.NothingInCommon
   }
 
   behavior of "compareAttrs"
@@ -177,8 +217,9 @@ class QuicksilverMigrationMonitorSupportSpec
   val consistentCases = Map(
     AttributeCorrectionStatus.Correct -> EntityCorrectionStatus.Correct,
     AttributeCorrectionStatus.Reordered -> EntityCorrectionStatus.Correctable,
-    AttributeCorrectionStatus.StartsWith -> EntityCorrectionStatus.StartsWith,
+    AttributeCorrectionStatus.Intersect -> EntityCorrectionStatus.Intersect,
     AttributeCorrectionStatus.Different -> EntityCorrectionStatus.Different,
+    AttributeCorrectionStatus.NothingInCommon -> EntityCorrectionStatus.NothingInCommon,
     AttributeCorrectionStatus.TypeDifferent -> EntityCorrectionStatus.TypeDifferent
   )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupportSpec.scala
@@ -1,0 +1,146 @@
+package org.broadinstitute.dsde.rawls.monitor
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
+import akka.testkit.TestKit
+import cats.effect.unsafe.implicits.global
+import org.broadinstitute.dsde.rawls.dataaccess._
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
+import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.MessageRequest
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
+  AddUpdateAttribute,
+  AttributeUpdateOperation,
+  EntityUpdateDefinition
+}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  AttributeFormat,
+  AttributeName,
+  AttributeString,
+  AttributeValueList,
+  Entity,
+  ImportStatuses,
+  RawlsRequestContext,
+  TypedAttributeListSerializer,
+  UserInfo,
+  WorkspaceName
+}
+import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
+import org.broadinstitute.dsde.rawls.webservice.ApiServiceSpec
+import org.broadinstitute.dsde.workbench.google2.GcsBlobName
+import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{times, verify, when}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.language.postfixOps
+
+class QuicksilverMigrationMonitorSupportSpec()
+    extends QuicksilverMigrationMonitorSupport
+    with AnyFlatSpecLike
+    with Matchers {
+
+  behavior of "compareLists"
+
+  it should "return Correct for exact-same value lists" in {
+    val current = AttributeValueList(
+      Seq(
+        AttributeString("foo"),
+        AttributeString("bar")
+      )
+    )
+    val correction = AttributeValueList(
+      Seq(
+        AttributeString("foo"),
+        AttributeString("bar")
+      )
+    )
+    val actual = compareLists(current, correction)
+    actual shouldBe AttributeCorrectionStatus.Correct
+  }
+
+  it should "return StartsWith when it does actually start with" in {
+    val current = AttributeValueList(
+      Seq(
+        AttributeString("foo"),
+        AttributeString("bar"),
+        AttributeString("baz")
+      )
+    )
+    val correction = AttributeValueList(
+      Seq(
+        AttributeString("foo"),
+        AttributeString("bar")
+      )
+    )
+    val actual = compareLists(current, correction)
+    actual shouldBe AttributeCorrectionStatus.StartsWith
+  }
+
+  it should "return Reordered when it was reordered" in {
+    val current = AttributeValueList(
+      Seq(
+        AttributeString("bar"),
+        AttributeString("foo")
+      )
+    )
+    val correction = AttributeValueList(
+      Seq(
+        AttributeString("foo"),
+        AttributeString("bar")
+      )
+    )
+    val actual = compareLists(current, correction)
+    actual shouldBe AttributeCorrectionStatus.Reordered
+  }
+
+  it should "return Different with same elements but in different counts" in {
+    val current = AttributeValueList(
+      Seq(
+        AttributeString("foo"),
+        AttributeString("bar"),
+        AttributeString("foo")
+      )
+    )
+    val correction = AttributeValueList(
+      Seq(
+        AttributeString("foo"),
+        AttributeString("bar"),
+        AttributeString("bar")
+      )
+    )
+    val actual = compareLists(current, correction)
+    actual shouldBe AttributeCorrectionStatus.Different
+  }
+
+  it should "return Different with different elements" in {
+    val current = AttributeValueList(
+      Seq(
+        AttributeString("cat"),
+        AttributeString("dog")
+      )
+    )
+    val correction = AttributeValueList(
+      Seq(
+        AttributeString("foo"),
+        AttributeString("bar")
+      )
+    )
+    val actual = compareLists(current, correction)
+    actual shouldBe AttributeCorrectionStatus.Different
+  }
+
+}


### PR DESCRIPTION
Ticket: CTM-256

Adds a new boot-monitor to analyze Quicksilver "corrections". 

Before merging this PR into production, we will have manually created and populated the `ENTITY_CORRECTIONS` table, which contains re-migrated Quicksilver list attributes.

This new boot-monitor will cycle through that `ENTITY_CORRECTIONS` table and compare the re-migrated data against the currently-active data in `ENTITY`. It will then save its analysis to the `ENTITY_CORRECTIONS` and `ATTRIBUTE_CORRECTIONS` tables, _without altering anything in ENTITY_.

At some point after this analysis is complete and we humans have had a chance to quantify the analysis results, we'll move on to any potential rewrites to the `ENTITY` table. This would require (a) follow-on PR(s).


