### PR TITLE
CORE-69: pin liquibase to 4.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -76,6 +76,9 @@ pullRequests.grouping = [ { name = "minor_patch", title = "CORE-69: Minor and pa
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 # the following example will allow to update foo when version is 1.1.x
 # updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1." } ]
+updates.pin  = [
+  { groupId = "org.liquibase", artifactId = "liquibase-core", version = "4." }
+]
 
 # The dependencies which match the given pattern are NOT updated.
 #


### PR DESCRIPTION
Ticket: CORE-69

Pins `liquibase-core` to 4.x to avoid any potential issues with changed functionality or license.

This will supersede #3522.