### PR TITLE
CTM-256: no fatal failure when Quicksilver correction is not a list

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.monitor
 
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.slick.EntityCorrection
 import org.broadinstitute.dsde.rawls.model.{
   Attribute,
@@ -15,15 +16,15 @@ import org.broadinstitute.dsde.rawls.monitor.EntityCorrectionStatus.EntityCorrec
 
 object AttributeCorrectionStatus extends Enumeration {
   type AttributeCorrectionStatusType = Value
-  val Correct, Reordered, Intersect, Different, NothingInCommon, TypeDifferent = Value
+  val Correct, Reordered, Intersect, Different, NothingInCommon, NotAList, TypeDifferent = Value
 }
 
 object EntityCorrectionStatus extends Enumeration {
   type EntityCorrectionStatusType = Value
-  val CurrentGone, Correct, Correctable, Mixed, Intersect, Different, NothingInCommon, TypeDifferent = Value
+  val CurrentGone, Correct, Correctable, Mixed, Intersect, Different, NothingInCommon, NotAList, TypeDifferent = Value
 }
 
-trait QuicksilverMigrationMonitorSupport {
+trait QuicksilverMigrationMonitorSupport extends LazyLogging {
 
   def compareEntities(current: Option[Entity],
                       correction: EntityCorrection
@@ -52,15 +53,20 @@ trait QuicksilverMigrationMonitorSupport {
 
   def compareAttrs(current: Attribute, correction: Attribute): AttributeCorrectionStatusType =
     (current, correction) match {
-      // current attribute is not the same type as correction attribute
-      case _ if current.getClass != correction.getClass =>
-        AttributeCorrectionStatus.TypeDifferent
-      case (x: AttributeValueList, y: AttributeValueList)                     => compareLists(x, y)
+      // when the correction is a value list
+      case (x: AttributeValueList, y: AttributeValueList) => compareLists(x, y)
+      case (_, _: AttributeValueList)                     => AttributeCorrectionStatus.TypeDifferent
+      // when the correction is an entity-reference list
       case (x: AttributeEntityReferenceList, y: AttributeEntityReferenceList) => compareLists(x, y)
-      case _                                                                  =>
-        throw new Exception(
-          s"unexpected classes found! current: ${current.getClass.getName}; correction: ${correction.getClass.getName}"
+      case (_, _: AttributeEntityReferenceList)                               => AttributeCorrectionStatus.TypeDifferent
+      // when the correction is something else, which should never happen but
+      // in reality we've seen it does happen
+      case _ =>
+        logger.warn(
+          s"unexpected attribute class found! current: ${current.getClass.getName}; correction: ${correction.getClass.getName}"
         )
+        AttributeCorrectionStatus.NotAList
+
     }
 
   def compareLists(current: AttributeValueList, correction: AttributeValueList): AttributeCorrectionStatusType =
@@ -128,6 +134,8 @@ trait QuicksilverMigrationMonitorSupport {
       EntityCorrectionStatus.Intersect
     } else if (attrStatuses == Set(AttributeCorrectionStatus.NothingInCommon)) {
       EntityCorrectionStatus.NothingInCommon
+    } else if (attrStatuses == Set(AttributeCorrectionStatus.NotAList)) {
+      EntityCorrectionStatus.NotAList
     } else if (attrStatuses == Set(AttributeCorrectionStatus.TypeDifferent)) {
       EntityCorrectionStatus.TypeDifferent
     } else {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.monitor
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.slick.EntityCorrection
+import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.{
   Attribute,
   AttributeEntityReference,
@@ -43,7 +44,16 @@ trait QuicksilverMigrationMonitorSupport extends LazyLogging {
           currentValue match {
             // current attribute does not exist
             case None               => None
-            case Some(currentValue) => Some((attributeName, compareAttrs(currentValue, correctionValue)))
+            case Some(currentValue) =>
+              Some(
+                (attributeName,
+                 compareAttrs(currentValue,
+                              correctionValue,
+                              hint =
+                                s"${correction.entityType}/${correction.entityName}/${toDelimitedName(attributeName)}"
+                 )
+                )
+              )
           }
       }
       // determine overall entity status from attribute statuses
@@ -51,7 +61,7 @@ trait QuicksilverMigrationMonitorSupport extends LazyLogging {
       (entityStatus, attrComparisons)
   }
 
-  def compareAttrs(current: Attribute, correction: Attribute): AttributeCorrectionStatusType =
+  def compareAttrs(current: Attribute, correction: Attribute, hint: String): AttributeCorrectionStatusType =
     (current, correction) match {
       // when the correction is a value list
       case (x: AttributeValueList, y: AttributeValueList) => compareLists(x, y)
@@ -63,7 +73,7 @@ trait QuicksilverMigrationMonitorSupport extends LazyLogging {
       // in reality we've seen it does happen
       case _ =>
         logger.warn(
-          s"unexpected attribute class found! current: ${current.getClass.getName}; correction: ${correction.getClass.getName}"
+          s"unexpected attribute class found in $hint - current: ${current.getClass.getName}; correction: ${correction.getClass.getName}"
         )
         AttributeCorrectionStatus.NotAList
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupportSpec.scala
@@ -220,6 +220,7 @@ class QuicksilverMigrationMonitorSupportSpec
     AttributeCorrectionStatus.Intersect -> EntityCorrectionStatus.Intersect,
     AttributeCorrectionStatus.Different -> EntityCorrectionStatus.Different,
     AttributeCorrectionStatus.NothingInCommon -> EntityCorrectionStatus.NothingInCommon,
+    AttributeCorrectionStatus.NotAList -> EntityCorrectionStatus.NotAList,
     AttributeCorrectionStatus.TypeDifferent -> EntityCorrectionStatus.TypeDifferent
   )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupportSpec.scala
@@ -167,7 +167,7 @@ class QuicksilverMigrationMonitorSupportSpec
         AttributeEntityReference("type", "name2")
       )
     )
-    val actual = compareAttrs(current, correction)
+    val actual = compareAttrs(current, correction, hint = "irrelevant")
     actual shouldBe AttributeCorrectionStatus.TypeDifferent
   }
 


### PR DESCRIPTION
Ticket: CTM-256

In practice, we see that some Quicksilver corrections are not a list attribute; they're coming through as AttributeValueRawJson.

This PR makes it such that this use case is no longer a fatal failure, and analysis can continue.

Meanwhile, I'll try to investigate the data and see why this is happening.