### PR TITLE
pin jersey-jnh-connector updates to 3.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -77,7 +77,11 @@ pullRequests.grouping = [ { name = "minor_patch", title = "CORE-69: Minor and pa
 # the following example will allow to update foo when version is 1.1.x
 # updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1." } ]
 updates.pin  = [
-  { groupId = "org.liquibase", artifactId = "liquibase-core", version = "4." }
+  # Liquibase 5 has license and major feature changes; ignore it until we see a need to update
+  { groupId = "org.liquibase", artifactId = "liquibase-core", version = "4." },
+  # jersey-jnh-connector is used by the TPS client, and the TPS client relies on Jersey 3.
+  # Therefore, also pin the jersey-jnh-connector to 3.
+  { groupId = "org.glassfish.jersey.connectors", artifactId = "jersey-jnh-connector", version = "3." }
 ]
 
 # The dependencies which match the given pattern are NOT updated.


### PR DESCRIPTION
Ticket: CORE-69

Tells Scala Steward to pin the `jersey-jnh-connector` version to 3.x. This is in response to #3532, which tries to update it to 4.x.

Copying the inline code comment here:
> jersey-jnh-connector is used by the TPS client, and the TPS client relies on Jersey 3.
> Therefore, also pin the jersey-jnh-connector to 3.

<img width="814" height="842" alt="Screenshot 2025-12-11 at 10 55 00 AM" src="https://github.com/user-attachments/assets/11c8cae2-6478-47a5-8939-3e0e4323e51d" />
