### PR TITLE
CTM-256: optimize order-by when querying for next batch of Quicksilver corrections

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrection.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrection.scala
@@ -53,7 +53,7 @@ trait CompactEntityCorrection {
     sql"""select id, workspace_id, entity_type, name, attributes
           from ENTITY_CORRECTIONS
           where status = 'OUTSTANDING'
-          order by workspace_id, entity_type, name
+          order by id
           limit $batchSize
          """
       .as[EntityCorrectionRecord]


### PR DESCRIPTION
Ticket: CTM-256

When getting the next batch of Quicksilver corrections, we had previously been sorting by `workspace_id, entity_type, name`. This order-by was slow in practice. Now, we are sorting by `id`, which is notably faster.

The ordering here doesn't actually matter, since we process each of these rows individually. Having a deterministic order helps for debugging, though.

I verified execution plans of the two order-by clauses and see that the before/after should speed up each batch of the loop by multiple seconds. We are currently on batch `38,897/300,829`, so this should make a visible difference.
