### PR TITLE
CTM-256: add columns to ENTITY_CORRECTIONS to record history

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -154,5 +154,6 @@
     <include file="changesets/20251023_truncate_entity_attributes.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20251029_drop_all_attribute_values.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20251205_quicksilver_corrections.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20260109_quicksilver_corrections_history.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20260109_quicksilver_corrections_history.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20260109_quicksilver_corrections_history.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+    <!--
+        Add columns to the ENTITY_CORRECTIONS table:
+            * corrected_at: timestamp of when this correction was written back to the live ENTITY table
+            * history: the attributes from the live ENTITY table just before the correction was written
+     -->
+    <changeSet logicalFilePath="dummy" author="davidan" id="quicksilver_corrections_history">
+        <addColumn tableName="ENTITY_CORRECTIONS">
+            <column name="corrected_at" type="TIMESTAMP(3)">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <addColumn tableName="ENTITY_CORRECTIONS">
+            <column name="history" type="json">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Ticket: CTM-256

This isolates the liquibase change from #3542 so it can be applied separately and before the rest of #3542 merges.

This will allow the schema changes to propagate through live environments so I can manually test in dev and/or staging before merging that other PR.