### PR TITLE
CTM-256: add consent columns for entity and attribute corrections

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -155,5 +155,6 @@
     <include file="changesets/20251029_drop_all_attribute_values.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20251205_quicksilver_corrections.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20260109_quicksilver_corrections_history.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20260112_quicksilver_corrections_consent.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20260112_quicksilver_corrections_consent.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20260112_quicksilver_corrections_consent.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+    <!--
+        Add a "consent" column to the ENTITY_CORRECTIONS and ATTRIBUTE_CORRECTIONS tables.
+        This will allow manual and granular control over which corrections to process, based
+        on user feedback.
+     -->
+    <changeSet logicalFilePath="dummy" author="davidan" id="quicksilver_entity_corrections_consent">
+        <addColumn tableName="ENTITY_CORRECTIONS">
+            <column name="consent" type="varchar(254)">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <createIndex indexName="idx_entity_corrections_consent" tableName="ENTITY_CORRECTIONS" unique="false">
+            <column name="consent"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet logicalFilePath="dummy" author="davidan" id="quicksilver_attribute_corrections_consent">
+        <addColumn tableName="ATTRIBUTE_CORRECTIONS">
+            <column name="consent" type="varchar(254)">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <createIndex indexName="idx_attribute_corrections_consent" tableName="ATTRIBUTE_CORRECTIONS" unique="false">
+            <column name="consent"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Ticket: CTM-256

Add a "consent" column to the ENTITY_CORRECTIONS and ATTRIBUTE_CORRECTIONS tables.

This will allow manual and granular control over which corrections to process, based on user feedback. As users tell us whether or not they want us to process corrections for their workspace(s), we can update values in these consent columns to mark what should get processed. We can also use these columns to slowly roll out corrections in prod.

My plan for rollout is:
* Phase 1: identify a few workspaces for the initial round of corrections. Choose workspaces which have not been modified since they were migrated. Manually issue SQL in the Rawls db to update the `ENTITY_CORRECTIONS.consent` column for these workspaces to have a value of 'Phase1'. Update the `getNextCorrectionBatch()` SQL in #3542 to include a `and ec.consent = 'Phase1'` clause; retain the existing SQL clause that checks modified date.
* Phase 2: all remaining workspaces which have not been modified since they were migrated. Remove the `and ec.consent = 'Phase1'`.
* Phase 3: workspaces which _have_ been modified. Once we have received user responses to Jason's outreach, manually issue SQL in the Rawls db to update the `ENTITY_CORRECTIONS.consent` and `ATTRIBUTE_CORRECTIONS.consent` columns to reflect the user's decisions. In the `getNextCorrectionBatch()` SQL, remove the clause that checks modified date; replace it with clauses that check for the user's consent in ENTITY_CORRECTIONS and ATTRIBUTE_CORRECTIONS.


Once this PR merges, I will adopt its functionality into #3542