### PR TITLE
[CTM-343] Filter out ai zones when getting compute zones

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -469,6 +469,8 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
 
       // `getZones()` returns the zones as resource urls of form `https://www.googleapis.com/compute/v1/projects/project_id/zones/us-central1-b",
       // Hence split it by `/` and get last element of array to get the zone
+      // the filter is due to new AI zones in these regions are not accepted by GCP Batch
+      // so we exlude them explicitly, see CTM-343
       zonesAsResourceUrls.map(_.split("/").last).filterNot(zone => zone.matches(""".*-(ai\w*)$"""))
     } { case e =>
       throw new RawlsException(s"Something went wrong while retrieving zones for region `$region` under Google " +

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -471,7 +471,7 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
       // Hence split it by `/` and get last element of array to get the zone
       // the filter is due to new AI zones in these regions are not accepted by GCP Batch
       // so we exlude them explicitly, see CTM-343
-      zonesAsResourceUrls.map(_.split("/").last).filterNot(zone => zone.matches(""".*-(ai\w*)$"""))
+      zonesAsResourceUrls.map(_.split("/").last).filterNot(zone => zone.matches(".*-ai.*$"))
     } { case e =>
       throw new RawlsException(s"Something went wrong while retrieving zones for region `$region` under Google " +
                                  s"project `${googleProject.value}`.",

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -469,7 +469,7 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
 
       // `getZones()` returns the zones as resource urls of form `https://www.googleapis.com/compute/v1/projects/project_id/zones/us-central1-b",
       // Hence split it by `/` and get last element of array to get the zone
-      zonesAsResourceUrls.map(_.split("/").last)
+      zonesAsResourceUrls.map(_.split("/").last).filterNot(zone => zone.matches(""".*-(ai\w*)$"""))
     } { case e =>
       throw new RawlsException(s"Something went wrong while retrieving zones for region `$region` under Google " +
                                  s"project `${googleProject.value}`.",

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -466,11 +466,10 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
       val getter =
         getComputeManager(getBucketServiceAccountCredential).regions().get(googleProject.value, region.toLowerCase)
       val zonesAsResourceUrls = executeGoogleRequest(getter).getZones.asScala.toList
-
       // `getZones()` returns the zones as resource urls of form `https://www.googleapis.com/compute/v1/projects/project_id/zones/us-central1-b",
       // Hence split it by `/` and get last element of array to get the zone
-      // the filter is due to new AI zones in these regions are not accepted by GCP Batch
-      // so we exlude them explicitly, see CTM-343
+      // the filter is because AI zones in these regions are not accepted by GCP Batch,
+      // so we exclude them explicitly, see CTM-343
       zonesAsResourceUrls.map(_.split("/").last).filterNot(zone => zone.matches(".*-ai.*$"))
     } { case e =>
       throw new RawlsException(s"Something went wrong while retrieving zones for region `$region` under Google " +

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -6,13 +6,18 @@ import akka.stream.ActorMaterializer
 import cats.effect.IO
 import com.google.api.Metric
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
+import com.google.api.client.googleapis.services.AbstractGoogleClientRequest
 import com.google.api.client.json.gson.GsonFactory
+import com.google.api.services.compute.Compute
+import com.google.api.services.compute.model.Region
 import com.google.cloud.monitoring.v3.MetricServiceClient.ListTimeSeriesPagedResponse
 import com.google.cloud.storage.{Cors, HttpMethod, StorageClass}
 import com.google.monitoring.v3.{Point, TimeInterval, TimeSeries, TypedValue}
 import com.google.protobuf.Timestamp
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.HttpGoogleServicesDAO._
+import org.broadinstitute.dsde.rawls.google.GoogleUtilities
+import org.broadinstitute.dsde.rawls.metrics.GoogleInstrumented.GoogleCounters
 import org.broadinstitute.dsde.rawls.model.{
   BucketMetric,
   GoogleProjectId,
@@ -26,7 +31,7 @@ import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.{times, verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -273,5 +278,48 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with MockitoTe
       BucketMetric("REGIONAL", "soft-deleted-object", 5432)
     )
     response.metrics.toSet shouldBe expectedMetrics
+  }
+  it should "not return zones ending with -ai* in getComputeZonesForRegion" in {
+    val mockCompute = mock[Compute]
+    val mockRegions = mock[Compute#Regions]
+    val mockGet = mock[Compute#Regions#Get]
+    val mockRegion = mock[Region]
+
+    val zones = java.util.Arrays.asList(
+      "https://www.googleapis.com/compute/v1/projects/project/zones/us-central1-a",
+      "https://www.googleapis.com/compute/v1/projects/project/zones/us-central1-b",
+      "https://www.googleapis.com/compute/v1/projects/project/zones/us-central-ai1a"
+    )
+
+    when(mockCompute.regions()).thenReturn(mockRegions)
+    when(mockRegions.get(anyString(), anyString())).thenReturn(mockGet)
+    when(mockGet.execute()).thenReturn(mockRegion)
+    when(mockRegion.getZones).thenReturn(zones)
+
+    val googleServicesDAO = new MockHttpGoogleServicesDAO(
+      GoogleClientSecrets.load(GsonFactory.getDefaultInstance, new StringReader("{}")),
+      "fakeClientEmail",
+      "fakeSubEmail",
+      "fakePemFile",
+      "fakeAppsDomain",
+      "fakeGroupPrefix",
+      "fakeAppName",
+      "fakeServiceProject",
+      "fakeBillingPemEmail",
+      "fakeBillingPemFile",
+      "fakeBillingEmail",
+      "fakeBillingGroupEmail",
+      "fakeCredentialsJson",
+      "fakeResourceBufferJsonFile"
+    ) {
+      override def getComputeManager(credential: com.google.api.client.auth.oauth2.Credential): Compute = mockCompute
+      override def executeGoogleRequest[T](request: AbstractGoogleClientRequest[T], logRequest: Boolean)(implicit
+        counters: GoogleCounters
+      ): T = mockRegion.asInstanceOf[T]
+    }
+
+    val result = await(googleServicesDAO.getComputeZonesForRegion(GoogleProjectId("project"), "us-central1"))
+    result should contain allOf ("us-central1-a", "us-central1-b")
+    result should not contain "us-central-ai1a"
   }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-343

This is due to Google's addition of [new AI zones](https://docs.cloud.google.com/compute/docs/regions-zones/ai-zones), are not being recognized by Google Batch, see error below

`Job gets no longer retryable information Batch Error: code - CODE_GCE_BAD_REQUEST, description - googleapi: Error 400: Invalid value for field 'resource.distributionPolicy.zones[1].zone': 'zones/us-central1-ai1a'. Zone (us-central1-ai1a) must be a valid zone in region us-central1., invalid, already retried 3 times, errors record CODE_GCE_BAD_REQUEST.`

This filters out ai zones when getting the compute zones for a region, which effectively means that [when we submit a Batch request](https://github.com/broadinstitute/rawls/blob/5c2865461804b2bf1fe7b91f8d657b73499699b7/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala#L252), this ai zone is excluded

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
