### PR TITLE
CTM-256: increase quicksilver correction batch size

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -161,7 +161,7 @@ quicksilverCorrections {
   startupDelay = 5 minutes        # generous pause to let other backrawls monitors get started
   pollInterval = 500 milliseconds # pause between batches to allow for garbage collection etc
   batchTimeout = 10 minutes       # should time out an errant batch
-  batchSize = 50                  # number of corrections to process per batch; small to keep computation light
+  batchSize = 250                 # number of corrections to process per batch; small to keep computation light
   dryRun = false                  # perform the corrections
   continueWhenDone = true         # after all available corrections are processed, should
                                   #    we continue to look for new corrections to arrive?


### PR DESCRIPTION
Ticket: CTM-256

The `getNextCorrectionBatch` SQL query is slow - on the order of 10 seconds. This PR increases the batch size for corrections ... this means we will execute the SQL query 5x fewer times, but return 5x more rows each time.