### PR TITLE
CTM-332: Quicksilver corrections phase 3, based on user consent

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrection.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrection.scala
@@ -46,15 +46,9 @@ trait CompactEntityCorrection {
 
   val CORRECTION_SQL =
     """
-       from ATTRIBUTE_CORRECTIONS ac
-            join ENTITY_CORRECTIONS ec on ac.correction_id = ec.id
-            join WORKSPACE_SETTINGS ws on ec.workspace_id = ws.WORKSPACE_ID
-            join WORKSPACE w on ec.workspace_id = w.id
-          where ac.status = 'Reordered'
-            and ec.status in ('Correctable', 'Mixed')
-	        and ws.SETTING_TYPE = 'CompactDataTables'
-	        and ws.STATUS = 'Applied'
-            and w.last_modified <= ws.LAST_UPDATED
+       from ENTITY_CORRECTIONS ec
+          where ec.status in ('Correctable', 'Mixed')
+	        and ec.consent = 'Yes'
       """
 
   /** count the outstanding corrections */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitor.scala
@@ -148,10 +148,7 @@ private class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorCon
       val dbActions = groupedCorrections.map { case (workspaceId, workspaceCorrections) =>
         for {
 
-          // re-verify workspace has not been modified since its migration.
-          // we have to do this again even though getNextCorrectionBatch checked it already;
-          // we do it again inside this db transaction to avoid any race conditions
-          isWorkspaceModified <- checkWorkspaceModified(dataAccess, workspaceId)
+          isWorkspaceModified <- DBIO.successful(false)
 
           correctionAttempts =
             if (isWorkspaceModified) {
@@ -203,46 +200,6 @@ private class QuicksilverMigrationMonitor(config: QuicksilverMigrationMonitorCon
       throw t
     }
   }
-
-  private def checkWorkspaceModified(dataAccess: DataAccess, workspaceId: UUID): ReadWriteAction[Boolean] =
-    for {
-      // re-verify workspace has not been modified since its migration.
-      // we have to do this again even though getNextCorrectionBatch checked it already;
-      // we do it again inside this db transaction to avoid any race conditions
-      isWorkspaceModifiedAfterMigration <- dataAccess.compactEntityQuery.checkWorkspaceLastModified(workspaceId)
-
-      // verify workspace has not run a workflow since its migration;
-      // only check this if the last-modified check above returned false (if it returned true or None,
-      // this workflow check is redundant)
-      isWorkflowRunAfterMigration <-
-        if (isWorkspaceModifiedAfterMigration.contains(false)) {
-          dataAccess.compactEntityQuery.checkWorkspaceLastWorkflowRun(workspaceId)
-        } else {
-          DBIO.successful(None)
-        }
-
-      // if isWorkspaceModifiedAfterMigration is None, the workspace doesn't exist;
-      //     mark all corrections as "the workspace is gone"
-      _ <-
-        if (isWorkspaceModifiedAfterMigration.isEmpty) {
-          dataAccess.compactEntityQuery.updateWorkspaceGone(workspaceId)
-        } else {
-          DBIO.successful(0)
-        }
-
-      // if isWorkspaceModifiedAfterMigration contains true, the workspace has been
-      //     modified since it was migrated to Quicksilver;
-      // if isWorkflowRunAfterMigration contains true, the workspace has run a workflow
-      //     since it was migrated to Quicksilver;
-      // in either case, mark all corrections as "the workspace is modified"
-      _ <-
-        if (isWorkspaceModifiedAfterMigration.contains(true) || isWorkflowRunAfterMigration.contains(true)) {
-          dataAccess.compactEntityQuery.updateWorkspaceModified(workspaceId)
-        } else {
-          DBIO.successful(0)
-        }
-
-    } yield isWorkflowRunAfterMigration.contains(true) || isWorkspaceModifiedAfterMigration.contains(true)
 
   private def persistCorrectedEntity(dataAccess: DataAccess,
                                      correction: EntityCorrection,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrectionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/CompactEntityCorrectionSpec.scala
@@ -22,10 +22,10 @@ class CompactEntityCorrectionSpec extends TestDriverComponentWithFlatSpecAndMatc
     runAndWait(sql"""
        insert into ENTITY_CORRECTIONS(id, workspace_id, entity_type, name, attributes, status, consent)
        values
-        (111, $wsid, 'type1', 'name1', '{}', 'Correctable', 'Phase1'),
-        (222, $wsid, 'type2', 'name2', '{}', 'Different', 'Phase1'),
-        (333, $wsid, 'type3', 'name3', '{}', 'Mixed', 'Phase1'),
-        (444, $wsid, 'type4', 'name4', '{}', 'CorrectableModified', 'Phase1')
+        (111, $wsid, 'type1', 'name1', '{}', 'Correctable', 'Yes'),
+        (222, $wsid, 'type2', 'name2', '{}', 'Different', 'Yes'),
+        (333, $wsid, 'type3', 'name3', '{}', 'Mixed', 'Yes'),
+        (444, $wsid, 'type4', 'name4', '{}', 'CorrectableModified', 'Yes')
            """.asUpdate)
 
     // insert to ATTRIBUTE_CORRECTIONS
@@ -59,48 +59,6 @@ class CompactEntityCorrectionSpec extends TestDriverComponentWithFlatSpecAndMatc
     actual shouldBe 2
   }
 
-  it should "not count any corrections if workspace has been modified since migration" in withMinimalTestDatabase { _ =>
-    // insert to ENTITY_CORRECTIONS
-    runAndWait(sql"""
-       insert into ENTITY_CORRECTIONS(id, workspace_id, entity_type, name, attributes, status, consent)
-       values
-        (111, $wsid, 'type1', 'name1', '{}', 'Correctable', 'Phase1'),
-        (222, $wsid, 'type2', 'name2', '{}', 'Different', 'Phase1'),
-        (333, $wsid, 'type3', 'name3', '{}', 'Mixed', 'Phase1'),
-        (444, $wsid, 'type4', 'name4', '{}', 'CorrectableModified', 'Phase1')
-           """.asUpdate)
-
-    // insert to ATTRIBUTE_CORRECTIONS
-    runAndWait(sql"""
-       insert into ATTRIBUTE_CORRECTIONS(correction_id, namespace, name, status)
-       values
-        -- parent correction is Correctable; this should get counted
-        (111, 'default', 'attr1', 'Reordered'),
-        -- parent correction is Different; these should NOT be counted
-        (222, 'default', 'attr1', 'Different'),
-        (222, 'pfb', 'attr1', 'Reordered'),
-        -- parent correction is Mixed; only the Reordered attr should get counted
-        (333, 'default', 'attr1', 'Reordered'),
-        (333, 'pfb', 'attr1', 'Different'),
-        (333, 'default', 'attr2', 'TypeDifferent'),
-        -- parent correction is CorrectableModified; none should get counted
-        (444, 'default', 'attr1', 'Reordered'),
-        (444, 'pfb', 'attr1', 'Reordered'),
-        (444, 'default', 'attr2', 'Reordered'),
-        (444, 'pfb', 'attr2', 'Reordered')
-           """.asUpdate)
-
-    // insert workspace setting, using a last-updated date in the past
-    runAndWait(sql"""
-            insert into WORKSPACE_SETTINGS(WORKSPACE_ID, SETTING_TYPE, STATUS, CONFIG, USER_ID, LAST_UPDATED)
-            values ($wsid, 'CompactDataTables', 'Applied', '{}', 'fake-user', '1977-01-21')
-        """.asUpdate)
-
-    val actual = runAndWait(q.countOutstandingCorrections)
-
-    actual shouldBe 0
-  }
-
   behavior of "getNextCorrectionBatch()"
 
   it should "get the next correction batch" in withMinimalTestDatabase { _ =>
@@ -108,10 +66,10 @@ class CompactEntityCorrectionSpec extends TestDriverComponentWithFlatSpecAndMatc
     runAndWait(sql"""
        insert into ENTITY_CORRECTIONS(id, workspace_id, entity_type, name, attributes, status, consent)
        values
-        (111, $wsid, 'type1', 'name1', '{}', 'Correctable', 'Phase1'),
-        (222, $wsid, 'type2', 'name2', '{}', 'Different', 'Phase1'),
-        (333, $wsid, 'type3', 'name3', '{}', 'Mixed', 'Phase1'),
-        (444, $wsid, 'type4', 'name4', '{}', 'CorrectableModified', 'Phase1')
+        (111, $wsid, 'type1', 'name1', '{}', 'Correctable', 'Yes'),
+        (222, $wsid, 'type2', 'name2', '{}', 'Different', 'Yes'),
+        (333, $wsid, 'type3', 'name3', '{}', 'Mixed', 'Yes'),
+        (444, $wsid, 'type4', 'name4', '{}', 'CorrectableModified', 'Yes')
            """.asUpdate)
 
     // insert to ATTRIBUTE_CORRECTIONS
@@ -154,10 +112,10 @@ class CompactEntityCorrectionSpec extends TestDriverComponentWithFlatSpecAndMatc
     runAndWait(sql"""
        insert into ENTITY_CORRECTIONS(id, workspace_id, entity_type, name, attributes, status, consent)
        values
-        (111, $wsid, 'type1', 'name1', '{}', 'Correctable', 'Phase1'),
-        (222, $wsid, 'type2', 'name2', '{}', 'Different', 'Phase1'),
-        (333, $wsid, 'type3', 'name3', '{}', 'Mixed', 'Phase1'),
-        (444, $wsid, 'type4', 'name4', '{}', 'CorrectableModified', 'Phase1')
+        (111, $wsid, 'type1', 'name1', '{}', 'Correctable', 'Yes'),
+        (222, $wsid, 'type2', 'name2', '{}', 'Different', 'Yes'),
+        (333, $wsid, 'type3', 'name3', '{}', 'Mixed', 'Yes'),
+        (444, $wsid, 'type4', 'name4', '{}', 'CorrectableModified', 'Yes')
            """.asUpdate)
 
     // insert to ATTRIBUTE_CORRECTIONS
@@ -194,14 +152,14 @@ class CompactEntityCorrectionSpec extends TestDriverComponentWithFlatSpecAndMatc
     )
   }
 
-  it should "retrieve both Phase1 and Phase2 (null) corrections" in withMinimalTestDatabase { _ =>
+  it should "retrieve only consent='Yes' corrections" in withMinimalTestDatabase { _ =>
     // insert to ENTITY_CORRECTIONS
     runAndWait(sql"""
        insert into ENTITY_CORRECTIONS(id, workspace_id, entity_type, name, attributes, status, consent)
        values
         (111, $wsid, 'type1', 'name1', '{}', 'Correctable', null),
         (222, $wsid, 'type2', 'name2', '{}', 'Correctable', null),
-        (333, $wsid, 'type3', 'name3', '{}', 'Correctable', 'Phase1'),
+        (333, $wsid, 'type3', 'name3', '{}', 'Correctable', 'Yes'),
         (444, $wsid, 'type4', 'name4', '{}', 'Correctable', null)
            """.asUpdate)
 
@@ -229,56 +187,10 @@ class CompactEntityCorrectionSpec extends TestDriverComponentWithFlatSpecAndMatc
 
     val actual = runAndWait(q.getNextCorrectionBatch(20))
 
-    actual should have size 10
+    actual should have size 1
     actual.toSet shouldBe Set(
-      EntityCorrection(111, wsid, "type1", "name1", Map()),
-      EntityCorrection(222, wsid, "type2", "name2", Map()),
-      EntityCorrection(333, wsid, "type3", "name3", Map()),
-      EntityCorrection(444, wsid, "type4", "name4", Map())
+      EntityCorrection(333, wsid, "type3", "name3", Map())
     )
-  }
-
-  it should "not retrieve any corrections for batch if workspace has been modified since migration" in withMinimalTestDatabase {
-    _ =>
-      // insert to ENTITY_CORRECTIONS
-      runAndWait(sql"""
-       insert into ENTITY_CORRECTIONS(id, workspace_id, entity_type, name, attributes, status, consent)
-       values
-        (111, $wsid, 'type1', 'name1', '{}', 'Correctable', 'Phase1'),
-        (222, $wsid, 'type2', 'name2', '{}', 'Different', 'Phase1'),
-        (333, $wsid, 'type3', 'name3', '{}', 'Mixed', 'Phase1'),
-        (444, $wsid, 'type4', 'name4', '{}', 'CorrectableModified', 'Phase1')
-           """.asUpdate)
-
-      // insert to ATTRIBUTE_CORRECTIONS
-      runAndWait(sql"""
-       insert into ATTRIBUTE_CORRECTIONS(correction_id, namespace, name, status)
-       values
-        -- parent correction is Correctable; this should get counted
-        (111, 'default', 'attr1', 'Reordered'),
-        -- parent correction is Different; these should NOT be counted
-        (222, 'default', 'attr1', 'Different'),
-        (222, 'pfb', 'attr1', 'Reordered'),
-        -- parent correction is Mixed; only the Reordered attr should get counted
-        (333, 'default', 'attr1', 'Reordered'),
-        (333, 'pfb', 'attr1', 'Different'),
-        (333, 'default', 'attr2', 'TypeDifferent'),
-        -- parent correction is CorrectableModified; none should get counted
-        (444, 'default', 'attr1', 'Reordered'),
-        (444, 'pfb', 'attr1', 'Reordered'),
-        (444, 'default', 'attr2', 'Reordered'),
-        (444, 'pfb', 'attr2', 'Reordered')
-           """.asUpdate)
-
-      // insert workspace setting, using a last-updated date in the past
-      runAndWait(sql"""
-            insert into WORKSPACE_SETTINGS(WORKSPACE_ID, SETTING_TYPE, STATUS, CONFIG, USER_ID, LAST_UPDATED)
-            values ($wsid, 'CompactDataTables', 'Applied', '{}', 'fake-user', '1977-01-21')
-        """.asUpdate)
-
-      val actual = runAndWait(q.getNextCorrectionBatch(20))
-
-      actual shouldBe empty
   }
 
   behavior of "updateWorkspaceGone()"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSpec.scala
@@ -156,12 +156,12 @@ class QuicksilverMigrationMonitorSpec(_system: ActorSystem)
         .toSql(
           correctedSample1.attributes
         )
-        .compactPrint}, 'Mixed', 'Phase1'),
+        .compactPrint}, 'Mixed', 'Yes'),
         (222, $wsid, ${correctedSet.entityType}, ${correctedSet.name}, ${CompactEntitySerialization
         .toSql(
           correctedSet.attributes
         )
-        .compactPrint}, 'Mixed', 'Phase1')
+        .compactPrint}, 'Mixed', 'Yes')
            """.asUpdate)
 
     // insert to ATTRIBUTE_CORRECTIONS
@@ -227,7 +227,7 @@ class QuicksilverMigrationMonitorSpec(_system: ActorSystem)
         .toSql(
           correctedSet.attributes
         )
-        .compactPrint}, 'Mixed', 'Phase1')
+        .compactPrint}, 'Mixed', 'Yes')
            """.asUpdate)
 
     // insert to ATTRIBUTE_CORRECTIONS
@@ -286,12 +286,12 @@ class QuicksilverMigrationMonitorSpec(_system: ActorSystem)
         .toSql(
           correctedSample1.attributes
         )
-        .compactPrint}, 'Mixed', 'Phase1'),
+        .compactPrint}, 'Mixed', 'Yes'),
         (555, $wsid, ${correctedSet.entityType}, ${correctedSet.name}, ${CompactEntitySerialization
         .toSql(
           correctedSet.attributes
         )
-        .compactPrint}, 'Mixed', 'Phase1')
+        .compactPrint}, 'Mixed', 'Yes')
            """.asUpdate)
 
     // insert to ATTRIBUTE_CORRECTIONS
@@ -346,143 +346,6 @@ class QuicksilverMigrationMonitorSpec(_system: ActorSystem)
 
   }
 
-  it should "apply no corrections if the workspace has been modified since migration" in withMinimalTestDatabase { _ =>
-    // create entities, some of which need to be corrected
-    runAndWait(q.batchWriteEntities(wsid, currentEntities, insertOnly = true))
-
-    // insert to ENTITY_CORRECTIONS
-    runAndWait(sql"""
-       insert into ENTITY_CORRECTIONS(id, workspace_id, entity_type, name, attributes, status, consent)
-       values
-        (777, $wsid, ${correctedSample1.entityType}, ${correctedSample1.name}, ${CompactEntitySerialization
-        .toSql(
-          correctedSample1.attributes
-        )
-        .compactPrint}, 'Mixed', 'Phase1'),
-        (888, $wsid, ${correctedSet.entityType}, ${correctedSet.name}, ${CompactEntitySerialization
-        .toSql(
-          correctedSet.attributes
-        )
-        .compactPrint}, 'Mixed', 'Phase1')
-           """.asUpdate)
-
-    // insert to ATTRIBUTE_CORRECTIONS
-    runAndWait(sql"""
-       insert into ATTRIBUTE_CORRECTIONS(correction_id, namespace, name, status)
-       values
-        (777, 'default', 'reorderedNums', 'Reordered'),
-        (777, 'default', 'okNums', 'Correct'),
-        (777, 'pfb', 'reorderedStrings', 'Reordered'),
-        (888, 'default', 'reorderedSamples', 'Reordered'),
-        (888, 'default', 'okSamples', 'Correct')
-           """.asUpdate)
-
-    // insert workspace setting, using a date in the past
-    runAndWait(sql"""
-            insert into WORKSPACE_SETTINGS(WORKSPACE_ID, SETTING_TYPE, STATUS, CONFIG, USER_ID, LAST_UPDATED)
-            values ($wsid, 'CompactDataTables', 'Applied', '{}', 'fake-user', '1977-01-21')
-        """.asUpdate)
-
-    val monitorConfig = QuicksilverMigrationMonitorConfig(
-      startupDelay = 100 milliseconds,
-      completionInterval = 2 hours,
-      pollInterval = 100 milliseconds,
-      batchTimeout = 2 seconds,
-      batchSize = 20,
-      dryRun = true
-    )
-    system.actorOf(QuicksilverMigrationMonitor.props(monitorConfig, slickDataSource))
-
-    // give it 4 seconds to ensure nothing happens
-    Thread.sleep(4 * 1000)
-
-    val actual =
-      runAndWait(q.getEntities(wsid, currentEntities.map(_.toPointer).toSet))
-        .map(_.toEntity)
-    actual should contain theSameElementsAs currentEntities
-  }
-
-  it should "apply no corrections if the workspace has run a workflow since migration" in withDefaultTestDatabase {
-    val testWsid = testData.workspaceSuccessfulSubmission.workspaceIdAsUUID
-
-    // create entities, some of which need to be corrected
-    runAndWait(q.batchWriteEntities(testWsid, currentEntities, insertOnly = true))
-
-    // insert to ENTITY_CORRECTIONS
-    runAndWait(sql"""
-       insert into ENTITY_CORRECTIONS(id, workspace_id, entity_type, name, attributes, status, consent)
-       values
-        (999, $testWsid, ${correctedSample1.entityType}, ${correctedSample1.name}, ${CompactEntitySerialization
-        .toSql(
-          correctedSample1.attributes
-        )
-        .compactPrint}, 'Mixed', 'Phase1'),
-        (100, $testWsid, ${correctedSet.entityType}, ${correctedSet.name}, ${CompactEntitySerialization
-        .toSql(
-          correctedSet.attributes
-        )
-        .compactPrint}, 'Mixed', 'Phase1')
-           """.asUpdate)
-
-    // insert to ATTRIBUTE_CORRECTIONS
-    runAndWait(sql"""
-       insert into ATTRIBUTE_CORRECTIONS(correction_id, namespace, name, status)
-       values
-        (999, 'default', 'reorderedNums', 'Reordered'),
-        (999, 'default', 'okNums', 'Correct'),
-        (999, 'pfb', 'reorderedStrings', 'Reordered'),
-        (100, 'default', 'reorderedSamples', 'Reordered'),
-        (100, 'default', 'okSamples', 'Correct')
-           """.asUpdate)
-
-    // insert workspace setting
-    runAndWait(sql"""
-            insert into WORKSPACE_SETTINGS(WORKSPACE_ID, SETTING_TYPE, STATUS, CONFIG, USER_ID, LAST_UPDATED)
-            values ($testWsid, 'CompactDataTables', 'Applied', '{}', 'fake-user', DATE_ADD(now(), INTERVAL 2 SECOND))
-        """.asUpdate)
-
-    // update workflows to be more recent
-    runAndWait(sql"""
-                     update WORKFLOW
-                     set status_last_changed = DATE_ADD(now(), INTERVAL 5 SECOND)
-                     where SUBMISSION_ID in (
-                      select ID
-                       from SUBMISSION
-                       where WORKSPACE_ID = $testWsid
-                     )
-        """.asUpdate)
-
-    val monitorConfig = QuicksilverMigrationMonitorConfig(
-      startupDelay = 100 milliseconds,
-      completionInterval = 2 hours,
-      pollInterval = 100 milliseconds,
-      batchTimeout = 2 seconds,
-      batchSize = 20,
-      dryRun = true
-    )
-    system.actorOf(QuicksilverMigrationMonitor.props(monitorConfig, slickDataSource))
-
-    // give it 4 seconds to ensure nothing happens
-    Thread.sleep(4 * 1000)
-
-    val actual =
-      runAndWait(q.getEntities(testWsid, currentEntities.map(_.toPointer).toSet))
-        .map(_.toEntity)
-    actual should contain theSameElementsAs currentEntities
-
-    // assert ENTITY_CORRECTIONS has "*Modified" statuses.
-    val actualStatuses = runAndWait(sql"""
-            select id, status
-            from ENTITY_CORRECTIONS
-        """.as[(Int, String)]).toSeq
-
-    actualStatuses should contain theSameElementsAs Seq(
-      (999, "MixedModified"),
-      (100, "MixedModified")
-    )
-
-  }
-
   it should "save the uncorrected entity attributes before correcting" in withMinimalTestDatabase { _ =>
     // create entities, some of which need to be corrected
     runAndWait(q.batchWriteEntities(wsid, currentEntities, insertOnly = true))
@@ -495,12 +358,12 @@ class QuicksilverMigrationMonitorSpec(_system: ActorSystem)
         .toSql(
           correctedSample1.attributes
         )
-        .compactPrint}, 'Mixed', 'Phase1'),
+        .compactPrint}, 'Mixed', 'Yes'),
         (222, $wsid, ${correctedSet.entityType}, ${correctedSet.name}, ${CompactEntitySerialization
         .toSql(
           correctedSet.attributes
         )
-        .compactPrint}, 'Mixed', 'Phase1')
+        .compactPrint}, 'Mixed', 'Yes')
            """.asUpdate)
 
     // insert to ATTRIBUTE_CORRECTIONS


### PR DESCRIPTION
Ticket: CTM-332

_DO NOT MERGE until Quicksilver Phase 2 is complete._

Move on to Quicksilver corrections Phase 3. In this phase, we will process all corrections where an end user has specifically asked us to correct their workspaces. This is a simplified implementation as compared to Phase 2: we just look for `consent = 'Yes'` in the database, instead of needing to check any workspace-last-modified dates or when the last workflow was run.

Separately, and manually, I will update the `ENTITY_CORRECTIONS` table to add `consent = 'Yes` values for the workspaces mentioned in our outreach Google form responses.