### PR TITLE
CTM-332: handle mixed-but-not-correctable attribute statuses

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
@@ -134,10 +134,15 @@ trait QuicksilverMigrationMonitorSupport extends LazyLogging {
   ): EntityCorrectionStatusType = {
     val attrStatuses = attributeStatuses.values.toSet
 
+    // when no attributes exist, use Correct; there is nothing that could be corrected
     if (attrStatuses.isEmpty) {
       EntityCorrectionStatus.Correct
+
+      // if any attribute was corrected, mark the entity as Corrected
     } else if (attrStatuses.contains(AttributeCorrectionStatus.Corrected)) {
       EntityCorrectionStatus.Corrected
+
+      // handle cases where all attributes have the same status
     } else if (attrStatuses == Set(AttributeCorrectionStatus.Correct)) {
       EntityCorrectionStatus.Correct
     } else if (attrStatuses == Set(AttributeCorrectionStatus.Reordered)) {
@@ -154,8 +159,18 @@ trait QuicksilverMigrationMonitorSupport extends LazyLogging {
       EntityCorrectionStatus.NotAList
     } else if (attrStatuses == Set(AttributeCorrectionStatus.TypeDifferent)) {
       EntityCorrectionStatus.TypeDifferent
+
+      // single-status sets were handled above. Now handle cases where attributes
+      // have multiple cases.
+      //
+      // if any attribute is correctable (e.g. "Reordered"), mark the entity as Mixed.
+      // Mixed entities will get processed by the correction monitor.
     } else if (attrStatuses.contains(AttributeCorrectionStatus.Reordered)) {
       EntityCorrectionStatus.Mixed
+
+      // We have multiple attribute statuses, but none of them is "Reordered".
+      // Mark the entity as MixedButNotCorrectable, which will not be processed by
+      // the correction monitor.
     } else {
       EntityCorrectionStatus.MixedButNotCorrectable
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupport.scala
@@ -22,9 +22,9 @@ object AttributeCorrectionStatus extends Enumeration {
 
 object EntityCorrectionStatus extends Enumeration {
   type EntityCorrectionStatusType = Value
-  val CurrentGone, Correct, CorrectModified, Correctable, CorrectableModified, Corrected, Mixed, MixedModified,
-    Intersect, IntersectModified, Different, DifferentModified, NothingInCommon, NothingInCommonModified, NotAList,
-    NotAListModified, TypeDifferent, TypeDifferentModified = Value
+  val CurrentGone, Correct, CorrectModified, Correctable, CorrectableModified, Corrected, Mixed, MixedButNotCorrectable,
+    MixedModified, Intersect, IntersectModified, Different, DifferentModified, NothingInCommon, NothingInCommonModified,
+    NotAList, NotAListModified, TypeDifferent, TypeDifferentModified = Value
 }
 
 trait QuicksilverMigrationMonitorSupport extends LazyLogging {
@@ -154,8 +154,10 @@ trait QuicksilverMigrationMonitorSupport extends LazyLogging {
       EntityCorrectionStatus.NotAList
     } else if (attrStatuses == Set(AttributeCorrectionStatus.TypeDifferent)) {
       EntityCorrectionStatus.TypeDifferent
-    } else {
+    } else if (attrStatuses.contains(AttributeCorrectionStatus.Reordered)) {
       EntityCorrectionStatus.Mixed
+    } else {
+      EntityCorrectionStatus.MixedButNotCorrectable
     }
 
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/QuicksilverMigrationMonitorSupportSpec.scala
@@ -236,10 +236,19 @@ class QuicksilverMigrationMonitorSupportSpec
     }
   }
 
-  it should s"return Mixed when attributes have multiple statuses" in {
+  it should s"return MixedButNotCorrectable when attributes have multiple statuses but none are Reordered" in {
     val statusMap = Map(
       AttributeName.withDefaultNS("foo") -> AttributeCorrectionStatus.Correct,
       AttributeName.withLibraryNS("bar") -> AttributeCorrectionStatus.Different
+    )
+    val actual = calculateEntityStatus(statusMap)
+    actual shouldBe EntityCorrectionStatus.MixedButNotCorrectable
+  }
+
+  it should s"return Mixed when attributes have multiple statuses and some are Reordered" in {
+    val statusMap = Map(
+      AttributeName.withDefaultNS("foo") -> AttributeCorrectionStatus.Correct,
+      AttributeName.withLibraryNS("bar") -> AttributeCorrectionStatus.Reordered
     )
     val actual = calculateEntityStatus(statusMap)
     actual shouldBe EntityCorrectionStatus.Mixed


### PR DESCRIPTION
Ticket: CTM-332

For Quicksilver corrections, add a new `MixedButNotCorrectable` entity status to differentiate from `Mixed`.
* 'MixedButNotCorrectable': attributes in this entity have multiple distinct statuses, but none of them qualify to be processed as a correction
* 'Mixed': attributes in this entity have multiple distinct statuses, and at least one of those attributes is of status `Reordered` and thus should be processed as a correction

This resolves an issue introduced in #3552, in which the monitor processes an entity of type 'Mixed`, finds no correctable attributes in it, and moves on ... but in its next loop it finds the same entity again. Now, it will mark that entity as `MixedButNotCorrectable` so it won't keep re-processing it.

My comment in #3552 of "I've also removed ATTRIBUTE_CORRECTIONS ... we never actually needed that;" was a lie. We did need it; it prevented this loop. But I think this PR is a cleaner and more performant way to handle it.