### PR TITLE
CTM-332: disable Quicksilver correction monitor

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -174,9 +174,6 @@ object BootMonitors extends LazyLogging {
       )
 
       startFastPassMonitor(system, appConfigManager.conf, slickDataSource, googleIamDAO, googleStorageDAO)
-
-      // Quicksilver correction monitor
-      launchQuicksilverCorrections(system, appConfigManager.conf, slickDataSource)
     }
 
     val cloneWorkspaceFileTransferMonitorConfigRoot =


### PR DESCRIPTION
Ticket: CTM-332

Quick PR to disable the Quicksilver correction monitor.

This eliminates the frequent SQL polling queries that look for new, unprocessed corrections. 

I will follow up with a more extensive PR to entirely remove all the correction code.