### PR TITLE
CTM-390: update TCL to latest

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -22,7 +22,7 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.`export`.BatchSpanProcessor
 import io.opentelemetry.sdk.trace.samplers.Sampler
 import io.opentelemetry.sdk.{resources, OpenTelemetrySdk}
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes
+import io.opentelemetry.semconv.ServiceAttributes
 import io.sentry.{Hint, Sentry, SentryEvent, SentryOptions}
 import org.broadinstitute.dsde.rawls.billing._
 import org.broadinstitute.dsde.rawls.config._
@@ -652,8 +652,8 @@ object Boot extends IOApp with LazyLogging {
     val maybeVersion = Option(getClass.getPackage.getImplementationVersion)
     val resourceBuilder =
       resources.Resource.getDefault.toBuilder
-        .put(ResourceAttributes.SERVICE_NAME, "rawls")
-    maybeVersion.foreach(version => resourceBuilder.put(ResourceAttributes.SERVICE_VERSION, version))
+        .put(ServiceAttributes.SERVICE_NAME, "rawls")
+    maybeVersion.foreach(version => resourceBuilder.put(ServiceAttributes.SERVICE_VERSION, version))
     val resource = HostResource
       .get()
       .merge(ContainerResource.get())

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -132,7 +132,7 @@ object Dependencies {
 
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.593.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.153-SNAPSHOT")
-  val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "1.1.65-SNAPSHOT" classifier "plain"))
+  val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "1.1.70-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.423")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-82c1f7d"
   val policyService = clientLibExclusions("bio.terra" % "terra-policy-client" % "1.0.41-SNAPSHOT")

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -28,17 +28,18 @@ object Merging {
     // [error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf-v3_2.12/2.6.5/akka-protobuf-v3_2.12-2.6.5.jar:google/protobuf/field_mask.proto
     case PathList("google", "protobuf", _ @_*) => MergeStrategy.first
     // [error] /home/sbtuser/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.15/scala-library-2.12.15.jar:scala/annotation/nowarn.class
-    case PathList("scala", "annotation", _ @_*)          => MergeStrategy.first
-    case PathList("javax", "ws", "rs", _ @_*)            => MergeStrategy.first
-    case "version.conf"                                  => MergeStrategy.concat
-    case "logback.xml"                                   => MergeStrategy.first
-    case x if x.endsWith("kotlin_module")                => MergeStrategy.first
-    case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.concat
-    case x if x.endsWith("arrow-git.properties")         => MergeStrategy.concat
-    case x if x.endsWith("aot.factories")                => MergeStrategy.first
-    case x if x.endsWith("public-suffix-list.txt")       => MergeStrategy.first
-    case "META-INF/proguard/concurrent.pro"              => MergeStrategy.concat
-    case "META-INF/license/LICENSE.boringssl.txt"        => MergeStrategy.discard
-    case x                                               => oldStrategy(x)
+    case PathList("scala", "annotation", _ @_*)            => MergeStrategy.first
+    case PathList("javax", "ws", "rs", _ @_*)              => MergeStrategy.first
+    case "version.conf"                                    => MergeStrategy.concat
+    case "logback.xml"                                     => MergeStrategy.first
+    case x if x.endsWith("kotlin_module")                  => MergeStrategy.first
+    case x if x.endsWith("io.netty.versions.properties")   => MergeStrategy.concat
+    case x if x.endsWith("arrow-git.properties")           => MergeStrategy.concat
+    case x if x.endsWith("aot.factories")                  => MergeStrategy.first
+    case x if x.endsWith("public-suffix-list.txt")         => MergeStrategy.first
+    case "META-INF/proguard/concurrent.pro"                => MergeStrategy.concat
+    case "META-INF/license/LICENSE.boringssl.txt"          => MergeStrategy.discard
+    case "META-INF/kotlin-project-structure-metadata.json" => MergeStrategy.discard
+    case x                                                 => oldStrategy(x)
   }
 }


### PR DESCRIPTION
Ticket: CTM-390

Updates terra-common-lib to latest 1.1.70-SNAPSHOT. Of note, this updates transitive dependency jose4j to 0.9.6, which resolves CTM-390