### PR TITLE
[CTM-421] Upgrade jackson-core

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,7 +70,7 @@ object Dependencies {
   val cats: ModuleID =            "org.typelevel"                 %% "cats-core"                 % "2.13.0"
   val fs2Reactive: ModuleID =     "co.fs2"                        %% "fs2-reactive-streams" % "3.6.1" // 3.7.0 has possibly-breaking changes
   val logbackClassic: ModuleID =  "ch.qos.logback"                % "logback-classic"       % "1.5.21"
-  val logstashLogback: ModuleID = "net.logstash.logback"          % "logstash-logback-encoder" % "9.0"
+  val logstashLogback: ModuleID = "net.logstash.logback"          % "logstash-logback-encoder" % "8.1"
   val scalaUri: ModuleID =        "com.indoorvivants"                  %% "scala-uri"            % "4.2.0"
   val scalatest: ModuleID =       "org.scalatest"                 %% "scalatest"            % "3.2.19" % "test"
   val mockito: ModuleID =         "org.scalatestplus"             %% "mockito-4-2"          % "3.2.11.0" % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,6 @@ object Dependencies {
   val metricsStatsd: ModuleID =      "com.readytalk"         %  "metrics3-statsd"  % "4.2.0"
 
   val scalaLogging: ModuleID =    "com.typesafe.scala-logging"    %% "scala-logging"        % "3.9.6"
-  val jacksonCore: ModuleID =     "com.fasterxml.jackson.core"    % "jackson-core"          % "2.20.1"
   val jodaTime: ModuleID =        "joda-time"                     % "joda-time"             % "2.14.0"
   val typesafeConfig: ModuleID =  "com.typesafe"                  % "config"                % "1.4.5"
   val sentryLogback: ModuleID =   "io.sentry"                     % "sentry-logback"        % "8.27.1"
@@ -214,9 +213,7 @@ object Dependencies {
   )
 
   val modelDependencies = Seq(
-    // I am not certain why I need jackson-core here but IntelliJ is confused without it and tests don't run
     workbenchModel,
-    jacksonCore,
     akkaHttpSprayJson,
     akkaHttp,
     akkaStream,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,7 +70,7 @@ object Dependencies {
   val cats: ModuleID =            "org.typelevel"                 %% "cats-core"                 % "2.13.0"
   val fs2Reactive: ModuleID =     "co.fs2"                        %% "fs2-reactive-streams" % "3.6.1" // 3.7.0 has possibly-breaking changes
   val logbackClassic: ModuleID =  "ch.qos.logback"                % "logback-classic"       % "1.5.21"
-  val logstashLogback: ModuleID = "net.logstash.logback"          % "logstash-logback-encoder" % "8.1"
+  val logstashLogback: ModuleID = "net.logstash.logback"          % "logstash-logback-encoder" % "9.0"
   val scalaUri: ModuleID =        "com.indoorvivants"                  %% "scala-uri"            % "4.2.0"
   val scalatest: ModuleID =       "org.scalatest"                 %% "scalatest"            % "3.2.19" % "test"
   val mockito: ModuleID =         "org.scalatestplus"             %% "mockito-4-2"          % "3.2.11.0" % Test
@@ -158,7 +158,10 @@ object Dependencies {
     // override commons-codec to address a non-CVE warning from DefectDojo
     "commons-codec"                 % "commons-codec"         % "1.20.0",
     // override cats-parse to address conflicting dependency versions for scala-uri
-    "org.typelevel" %% "cats-parse" % "1.1.0"
+    "org.typelevel" %% "cats-parse" % "1.1.0",
+    // override tools.jackson.core pulled in by logstash-logback-encoder 9.0
+    "tools.jackson.core" % "jackson-core"     % "3.1.0",
+    "tools.jackson.core" % "jackson-databind" % "3.1.0"
   )
 
   val extraOpenTelemetryDependencies = Seq(


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-421
---
Overrides jackson-core to 3.1.0 to avoid vulnerability in 3.0.0.  
I've also removed the specific versioning and use of jackson directly in `Dependencies.scala`, as it seems to be unused and unneeded, but reviewers please verify.

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
