### PR TITLE
[CTM 431] Call Sam for auth domains in workspace admin

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
@@ -745,6 +745,17 @@ class HttpSamDAO(baseSamServiceURL: String,
 
       callback.future.map(_.booleanValue())
     }
+
+    override def adminGetResourceAuthDomain(resourceTypeName: SamResourceTypeName,
+                                            resourceId: String,
+                                            ctx: RawlsRequestContext
+    ): Future[Seq[String]] = retry(when401or5xx) { () =>
+      val callback = new SamApiCallback[util.List[String]]("adminGetResourceAuthDomain")
+
+      adminApi(ctx).adminGetResourceAuthDomainAsync(resourceTypeName.value, resourceId, callback)
+
+      callback.future.map(_.asScala.toSeq)
+    }
   }
 
   override def getStatus(): Future[SubsystemStatus] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
@@ -211,6 +211,11 @@ trait SamAdminDAO {
                                          action: SamResourceAction,
                                          ctx: RawlsRequestContext
   ): Future[Boolean]
+
+  def adminGetResourceAuthDomain(resourceTypeName: SamResourceTypeName,
+                                 resourceId: String,
+                                 ctx: RawlsRequestContext
+  ): Future[Seq[String]]
 }
 
 object SamDAO {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
@@ -189,9 +189,14 @@ class WorkspaceAdminService(
         )
       workspaceOpt <- workspaceRepository.getWorkspaceByGoogleProject(googleProjectId)
       workspace = workspaceOpt.getOrElse(throw NoSuchWorkspaceException(googleProjectId.toString))
+      authDomains <- samDAO.admin.adminGetResourceAuthDomain(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
       settings <- workspaceSettingRepository.getWorkspaceSettings(workspace.workspaceIdAsUUID)
-    } yield WorkspaceAdminResponse(WorkspaceDetails.fromWorkspaceAndOptions(workspace, None, useAttributes = false),
-                                   settings
+    } yield WorkspaceAdminResponse(
+      WorkspaceDetails.fromWorkspaceAndOptions(workspace,
+                                               Some(authDomains.map(n => ManagedGroupRef(RawlsGroupName(n))).toSet),
+                                               useAttributes = false
+      ),
+      settings
     )
 
   // moved out of WorkspaceSupport because the only usage was in this file,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminService.scala
@@ -11,6 +11,8 @@ import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
   ErrorReportSource,
   GoogleProjectId,
+  ManagedGroupRef,
+  RawlsGroupName,
   RawlsRequestContext,
   SamResourceTypeAdminActions,
   SamResourceTypeName,
@@ -105,9 +107,13 @@ class WorkspaceAdminService(
         )
       workspaceOpt <- workspaceRepository.getWorkspace(workspaceId)
       workspace = workspaceOpt.getOrElse(throw NoSuchWorkspaceException(workspaceId.toString))
+      authDomains <- samDAO.admin.adminGetResourceAuthDomain(SamResourceTypeNames.workspace, workspaceId.toString, ctx)
       settings <- workspaceSettingRepository.getWorkspaceSettings(workspaceId)
     } yield WorkspaceAdminResponse(
-      WorkspaceDetails.fromWorkspaceAndOptions(workspace, None, useAttributes = false),
+      WorkspaceDetails.fromWorkspaceAndOptions(workspace,
+                                               Some(authDomains.map(n => ManagedGroupRef(RawlsGroupName(n))).toSet),
+                                               useAttributes = false
+      ),
       settings
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
@@ -288,6 +288,11 @@ class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: Executi
                                                     action: SamResourceAction,
                                                     ctx: RawlsRequestContext
     ): Future[Boolean] = Future.successful(false)
+
+    override def adminGetResourceAuthDomain(resourceTypeName: SamResourceTypeName,
+                                            resourceId: String,
+                                            ctx: RawlsRequestContext
+    ): Future[Seq[String]] = Future.successful(Seq.empty)
   }
 
   override def setPolicyPublic(resourceTypeName: SamResourceTypeName,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
@@ -165,9 +165,10 @@ class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
     }
   }
 
-  "getWorkspaceByGoogleProjectId" should "return the workspace with its settings if the user is an admin" in {
+  "getWorkspaceByGoogleProjectId" should "return the workspace with its settings and auth domains if the user is an admin" in {
     val workspaceId = workspace.workspaceIdAsUUID
     val googleProjectId = workspace.googleProjectId
+    val authDomainGroups = Seq("group1", "group2")
 
     val workspaceRepository = mock[WorkspaceRepository]
     when(workspaceRepository.getWorkspaceByGoogleProject(googleProjectId))
@@ -184,6 +185,13 @@ class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
         ArgumentMatchers.any()
       )
     ).thenReturn(Future.successful(true))
+    when(
+      samAdminDAO.adminGetResourceAuthDomain(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspace.workspaceId),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(authDomainGroups))
     val samDAO = mock[SamDAO]
     when(samDAO.admin).thenReturn(samAdminDAO)
 
@@ -195,7 +203,11 @@ class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
 
     val returnedWorkspace = Await.result(service.getWorkspaceByGoogleProjectId(googleProjectId), Duration.Inf)
     returnedWorkspace shouldEqual WorkspaceAdminResponse(
-      WorkspaceDetails.fromWorkspaceAndOptions(workspace, None, false),
+      WorkspaceDetails.fromWorkspaceAndOptions(
+        workspace,
+        Some(authDomainGroups.map(n => ManagedGroupRef(RawlsGroupName(n))).toSet),
+        false
+      ),
       List.empty
     )
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
@@ -111,9 +111,10 @@ class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
 
     val returnedWorkspace = Await.result(service.getWorkspaceById(workspaceId), Duration.Inf)
     returnedWorkspace shouldEqual WorkspaceAdminResponse(
-      WorkspaceDetails.fromWorkspaceAndOptions(workspace,
-                                               Some(authDomainGroups.map(n => ManagedGroupRef(RawlsGroupName(n))).toSet),
-                                               false
+      WorkspaceDetails.fromWorkspaceAndOptions(
+        workspace,
+        Some(authDomainGroups.map(n => ManagedGroupRef(RawlsGroupName(n))).toSet),
+        false
       ),
       List.empty
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAdminServiceUnitTests.scala
@@ -6,6 +6,8 @@ import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamAdminDAO,
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
   GoogleProjectId,
+  ManagedGroupRef,
+  RawlsGroupName,
   RawlsRequestContext,
   RawlsUserEmail,
   RawlsUserSubjectId,
@@ -73,8 +75,9 @@ class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
     Map.empty
   )
 
-  "getWorkspaceById" should "return the workspace with its settings if the user is an admin" in {
+  "getWorkspaceById" should "return the workspace with its settings and auth domains if the user is an admin" in {
     val workspaceId = workspace.workspaceIdAsUUID
+    val authDomainGroups = Seq("group1", "group2")
 
     val workspaceRepository = mock[WorkspaceRepository]
     when(workspaceRepository.getWorkspace(workspaceId)).thenReturn(Future.successful(Option(workspace)))
@@ -90,6 +93,13 @@ class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
         ArgumentMatchers.any()
       )
     ).thenReturn(Future.successful(true))
+    when(
+      samAdminDAO.adminGetResourceAuthDomain(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceId.toString),
+        ArgumentMatchers.any()
+      )
+    ).thenReturn(Future.successful(authDomainGroups))
     val samDAO = mock[SamDAO]
     when(samDAO.admin).thenReturn(samAdminDAO)
 
@@ -101,7 +111,10 @@ class WorkspaceAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
 
     val returnedWorkspace = Await.result(service.getWorkspaceById(workspaceId), Duration.Inf)
     returnedWorkspace shouldEqual WorkspaceAdminResponse(
-      WorkspaceDetails.fromWorkspaceAndOptions(workspace, None, false),
+      WorkspaceDetails.fromWorkspaceAndOptions(workspace,
+                                               Some(authDomainGroups.map(n => ManagedGroupRef(RawlsGroupName(n))).toSet),
+                                               false
+      ),
       List.empty
     )
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -132,7 +132,7 @@ object Dependencies {
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.593.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.153-SNAPSHOT")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "1.1.70-SNAPSHOT" classifier "plain"))
-  val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.423")
+  val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.440")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-82c1f7d"
   val policyService = clientLibExclusions("bio.terra" % "terra-policy-client" % "1.0.41-SNAPSHOT")
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-431
Uses the new Sam admin auth domain API to fetch auth domains for a workspace in the Rawls admin API.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
