### PR TITLE
[CTM-482] Update bouncycastle

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -161,7 +161,11 @@ object Dependencies {
     "org.typelevel" %% "cats-parse" % "1.1.0",
     // override tools.jackson.core pulled in by logstash-logback-encoder 9.0
     "tools.jackson.core" % "jackson-core"     % "3.1.0",
-    "tools.jackson.core" % "jackson-databind" % "3.1.0"
+    "tools.jackson.core" % "jackson-databind" % "3.1.0",
+    // override bouncycastle to address CVE-2026-5598 (requires >= 1.84)
+    "org.bouncycastle" % "bcprov-jdk18on" % "1.84",
+    "org.bouncycastle" % "bcpkix-jdk18on" % "1.84",
+    "org.bouncycastle" % "bcutil-jdk18on" % "1.84"
   )
 
   val extraOpenTelemetryDependencies = Seq(


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-482

Bouncy Castle ships its cryptography library as three separate artifacts — bcprov-jdk18on (core crypto), bcutil-jdk18on (shared utilities), and bcpkix-jdk18on (PKI/X.509 support) — each with independent Maven coordinates. All three are pulled in transitively via jose4j and must be overridden explicitly to guarantee the version floor. Adds overrides for all three at 1.84. 

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
