### PR TITLE
[CTM-501] override netty

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -166,8 +166,12 @@ object Dependencies {
     "org.bouncycastle" % "bcprov-jdk18on" % "1.84",
     "org.bouncycastle" % "bcpkix-jdk18on" % "1.84",
     "org.bouncycastle" % "bcutil-jdk18on" % "1.84",
-    // override netty-codec-http to address CVE-2026-42587 (requires >= 4.1.133.Final)
-    "io.netty" % "netty-codec-http" % "4.1.133.Final"
+    // override netty-codec* to address CVE-2026-42587 (requires >= 4.1.133.Final)
+    "io.netty" % "netty-codec"       % "4.1.133.Final",
+    "io.netty" % "netty-codec-dns"   % "4.1.133.Final",
+    "io.netty" % "netty-codec-http"  % "4.1.133.Final",
+    "io.netty" % "netty-codec-http2" % "4.1.133.Final",
+    "io.netty" % "netty-codec-socks" % "4.1.133.Final"
   )
 
   val extraOpenTelemetryDependencies = Seq(


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-501
https://github.com/broadinstitute/rawls/pull/3562 missed some overrides to bring all netty-codec up to a safe version.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
