### PR TITLE
CTM-570: bump tools.jackson.core and org.bouncycastle

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -162,12 +162,12 @@ object Dependencies {
     // override cats-parse to address conflicting dependency versions for scala-uri
     "org.typelevel" %% "cats-parse" % "1.1.0",
     // override tools.jackson.core pulled in by logstash-logback-encoder 9.0
-    "tools.jackson.core" % "jackson-core"     % "3.1.0",
-    "tools.jackson.core" % "jackson-databind" % "3.1.0",
+    "tools.jackson.core" % "jackson-core"     % "3.2.1",
+    "tools.jackson.core" % "jackson-databind" % "3.2.1",
     // override bouncycastle to address CVE-2026-5598 (requires >= 1.84)
-    "org.bouncycastle" % "bcprov-jdk18on" % "1.84",
-    "org.bouncycastle" % "bcpkix-jdk18on" % "1.84",
-    "org.bouncycastle" % "bcutil-jdk18on" % "1.84"
+    "org.bouncycastle" % "bcprov-jdk18on" % "1.85",
+    "org.bouncycastle" % "bcpkix-jdk18on" % "1.85",
+    "org.bouncycastle" % "bcutil-jdk18on" % "1.85"
   )
 
   // Defense-in-depth org exclusions of unused deps that were transitively pulled

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -27,6 +27,8 @@ object Merging {
     // [error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.4/protobuf-java-3.11.4.jar:google/protobuf/field_mask.proto
     // [error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf-v3_2.12/2.6.5/akka-protobuf-v3_2.12-2.6.5.jar:google/protobuf/field_mask.proto
     case PathList("google", "protobuf", _ @_*) => MergeStrategy.first
+    // Jackson 2 and Jackson 3 coexist functionally, but fail in assembly on this:
+    case "META-INF/FastDoubleParser-LICENSE" => MergeStrategy.first
     // [error] /home/sbtuser/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.15/scala-library-2.12.15.jar:scala/annotation/nowarn.class
     case PathList("scala", "annotation", _ @_*)            => MergeStrategy.first
     case PathList("javax", "ws", "rs", _ @_*)              => MergeStrategy.first


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-570

| dependency | old version | new version |
|--------|--------|--------|
| tools.jackson.core:jackson-core | 3.1.0 | 3.2.1 |
| tools.jackson.core:jackson-databind | 3.1.0 | 3.2.1 |
| org.bouncycastle:bcprov-jdk18on | 1.84 | 1.85 |
| org.bouncycastle: bcpkix-jdk18on | 1.84 | 1.85 |
| org.bouncycastle: bcutil-jdk18on | 1.84 | 1.85 |


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
