### PR TITLE
CTM-604: bump workbench-libs, which bumps swagger-ui

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,11 +8,11 @@ object Dependencies {
   val jacksonV      = "2.20.1"
   val jacksonAnnotationsV = "2.20"
 
-  val workbenchLibsHash = "80e4b8d"
-  val serviceTestV = s"5.0-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.33-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.36-${workbenchLibsHash}"
-  val workbenchModelV  = s"0.20-${workbenchLibsHash}"
+  val workbenchLibsHash = "fccb671"
+  val serviceTestV = s"6.2-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.36-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.43-${workbenchLibsHash}"
+  val workbenchModelV  = s"0.21-${workbenchLibsHash}"
   val workbenchMetricsV  = s"0.8-${workbenchLibsHash}"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -29,8 +29,8 @@ import org.broadinstitute.dsde.rawls.config._
 import org.broadinstitute.dsde.rawls.credentials.RawlsCredential
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.HttpDataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.resourcebuffer.ResourceBufferDAO
-import org.typelevel.log4cats.slf4j.Slf4jLogger
-import org.typelevel.log4cats.{Logger, StructuredLogger}
+import org.typelevel.log4cats.slf4j.{Slf4jFactory, Slf4jLogger}
+import org.typelevel.log4cats.{Logger, LoggerFactory, StructuredLogger}
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 import org.broadinstitute.dsde.rawls.dataaccess._
@@ -609,9 +609,10 @@ object Boot extends IOApp with LazyLogging {
     val oidcConfig = config.getConfig("oidc")
 
     implicit val logger: StructuredLogger[F] = Slf4jLogger.getLogger[F]
+    implicit val loggerFactory: LoggerFactory[F] = Slf4jFactory.create[F]
     for {
       googleStorage <- GoogleStorageServiceFactory.createGoogleStorageService(appConfigManager)
-      googleServiceHttp <- GoogleServiceHttpFactory.createGoogleServiceHttp(appConfigManager, executionContext)
+      googleServiceHttp <- GoogleServiceHttpFactory.createGoogleServiceHttp(appConfigManager)
       topicAdmin <- GoogleTopicAdminFactory.createGoogleTopicAdmin(appConfigManager)
       bqServiceFactory = GoogleBigQueryServiceFactory.createGoogleBigQueryServiceFactory(
         appConfigManager

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/GoogleServiceHttpFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/GoogleServiceHttpFactory.scala
@@ -5,23 +5,23 @@ import org.broadinstitute.dsde.rawls.config.RawlsConfigManager
 import org.broadinstitute.dsde.rawls.serviceFactory.DisabledServiceFactory.newDisabledService
 import org.broadinstitute.dsde.workbench.google2.{GoogleServiceHttp, NotificationCreaterConfig}
 import org.http4s.Uri
-import org.http4s.blaze.client.BlazeClientBuilder
-import org.typelevel.log4cats.StructuredLogger
+import org.http4s.ember.client.EmberClientBuilder
+import org.typelevel.log4cats.{LoggerFactory, StructuredLogger}
 
 import scala.concurrent.ExecutionContext
 
 object GoogleServiceHttpFactory {
-  def createGoogleServiceHttp[F[_]: Async](appConfigManager: RawlsConfigManager, executionContext: ExecutionContext)(
-    implicit
+  def createGoogleServiceHttp[F[_]: Async](appConfigManager: RawlsConfigManager)(implicit
     F: Sync[F] with Temporal[F],
-    logger: StructuredLogger[F]
+    logger: StructuredLogger[F],
+    loggerFactory: LoggerFactory[F]
   ): Resource[F, GoogleServiceHttp[F]] =
     appConfigManager.gcsConfig match {
       case Some(gcsConfig) =>
         val pathToCredentialJson = gcsConfig.getString("pathToCredentialJson")
         val googleApiUri = Uri.unsafeFromString(gcsConfig.getString("google-api-uri"))
         val metadataNotificationConfig = NotificationCreaterConfig(pathToCredentialJson, googleApiUri)
-        BlazeClientBuilder[F].withExecutionContext(executionContext).resource.flatMap { httpClient =>
+        EmberClientBuilder.default[F].build.flatMap { httpClient =>
           GoogleServiceHttp.withRetryAndLogging(httpClient, metadataNotificationConfig)
         }
       case None =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -287,7 +287,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
   ): cats.effect.Resource[IO, GoogleBigQueryService[IO]] = {
     val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
     val job = mock[Job]
-    when(job.getQueryResults(any())).thenReturn(createTableResult(data))
+    when(job.getQueryResults()).thenReturn(createTableResult(data))
     when(job.getStatistics).thenReturn(stats)
     when(job.waitFor()).thenReturn(job)
     when(bigQueryService.runJob(any(), any())).thenReturn(IO(job))
@@ -658,11 +658,11 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
                        table2: List[Map[String, String]]
   ): OngoingStubbing[IO[Job]] = {
     val job1 = mock[Job]
-    when(job1.getQueryResults(any())).thenReturn(createTableResult(table1))
+    when(job1.getQueryResults()).thenReturn(createTableResult(table1))
     when(job1.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
     when(job1.waitFor()).thenReturn(job1)
     val job2 = mock[Job]
-    when(job2.getQueryResults(any())).thenReturn(createTableResult(table2))
+    when(job2.getQueryResults()).thenReturn(createTableResult(table2))
     when(job2.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
     when(job2.waitFor()).thenReturn(job2)
     when(bigQueryService.runJob(any(), any()))
@@ -949,7 +949,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val data = List[Map[String, String]]()
     val stats = mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS)
     val job = mock[Job]
-    when(job.getQueryResults(any())).thenReturn(createTableResult(data))
+    when(job.getQueryResults()).thenReturn(createTableResult(data))
     when(job.getStatistics).thenReturn(stats)
     when(job.waitFor()).thenReturn(job)
     when(bigQueryService.runJob(any(), any())).thenReturn(IO(job))
@@ -1038,7 +1038,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
     val stats = mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS)
     val job = mock[Job]
-    when(job.getQueryResults(any())).thenReturn(createTableResult(table))
+    when(job.getQueryResults()).thenReturn(createTableResult(table))
     when(job.getStatistics).thenReturn(stats)
     when(job.waitFor()).thenReturn(job)
     when(bigQueryService.runJob(any(), any())).thenReturn(IO(job))
@@ -1125,7 +1125,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
     val stats = mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS)
     val job = mock[Job]
-    when(job.getQueryResults(any())).thenReturn(createTableResult(table))
+    when(job.getQueryResults()).thenReturn(createTableResult(table))
     when(job.getStatistics).thenReturn(stats)
     when(job.waitFor()).thenReturn(job)
     when(bigQueryService.runJob(any(), any())).thenReturn(IO(job))
@@ -1207,7 +1207,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
     val stats = mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS)
     val job = mock[Job]
-    when(job.getQueryResults(any())).thenReturn(createTableResult(table))
+    when(job.getQueryResults()).thenReturn(createTableResult(table))
     when(job.getStatistics).thenReturn(stats)
     when(job.waitFor()).thenReturn(job)
     when(bigQueryService.runJob(any(), any())).thenReturn(IO(job))
@@ -1934,7 +1934,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
     val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
     val job = mock[Job]
-    when(job.getQueryResults(any())).thenReturn(createTableResult(table))
+    when(job.getQueryResults()).thenReturn(createTableResult(table))
     when(job.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
     when(job.waitFor()).thenReturn(job)
     when(bigQueryService.runJob(any(), any()))
@@ -2000,7 +2000,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
     val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
     val job2 = mock[Job]
-    when(job2.getQueryResults(any())).thenReturn(createTableResult(table2))
+    when(job2.getQueryResults()).thenReturn(createTableResult(table2))
     when(job2.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
     when(job2.waitFor()).thenReturn(job2)
     when(bigQueryService.runJob(any(), any())).thenReturn(IO(job2))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,14 +82,14 @@ object Dependencies {
   val jerseyJnhConnector: ModuleID = "org.glassfish.jersey.connectors" % "jersey-jnh-connector" % "3.1.11"
   val janino: ModuleID = "org.codehaus.janino" % "janino" % "3.1.12" // For if-else logic in logging config
 
-  val workbenchLibsHash = "80e4b8d"
+  val workbenchLibsHash = "adcc4d4"
 
-  val workbenchModelV  = s"0.20-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.33-${workbenchLibsHash}"
-  val workbenchNotificationsV = s"0.8-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.36-${workbenchLibsHash}"
-  val workbenchOauth2V = s"0.8-${workbenchLibsHash}"
-  val workbenchOpenTelemetryV = s"0.8-$workbenchLibsHash"
+  val workbenchModelV  = s"0.21-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.36-${workbenchLibsHash}"
+  val workbenchNotificationsV = s"2.1-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.42-${workbenchLibsHash}"
+  val workbenchOauth2V = s"0.11-${workbenchLibsHash}"
+  val workbenchOpenTelemetryV = s"0.10-$workbenchLibsHash"
 
   def excludeWorkbenchGoogle = ExclusionRule("org.broadinstitute.dsde.workbench", "workbench-google_2.13")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,12 +82,12 @@ object Dependencies {
   val jerseyJnhConnector: ModuleID = "org.glassfish.jersey.connectors" % "jersey-jnh-connector" % "3.1.11"
   val janino: ModuleID = "org.codehaus.janino" % "janino" % "3.1.12" // For if-else logic in logging config
 
-  val workbenchLibsHash = "adcc4d4"
+  val workbenchLibsHash = "fccb671"
 
   val workbenchModelV  = s"0.21-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.36-${workbenchLibsHash}"
   val workbenchNotificationsV = s"2.1-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.42-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.43-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.11-${workbenchLibsHash}"
   val workbenchOpenTelemetryV = s"0.10-$workbenchLibsHash"
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-604

CTM-601

Bumps to latest version of workbench-libs' oauth2, to take advantage of its bump of swagger-ui. See https://github.com/broadinstitute/workbench-libs/pull/1753.

Net effect is that the swagger-ui used by Rawls goes from `5.17.14` to `5.32.11`. which satisfies https://broadworkbench.atlassian.net/browse/CTM-601.
