### PR TITLE
CTM-604: Scala update for new swagger-ui version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,7 @@ object Dependencies {
   val jerseyJnhConnector: ModuleID = "org.glassfish.jersey.connectors" % "jersey-jnh-connector" % "3.1.11"
   val janino: ModuleID = "org.codehaus.janino" % "janino" % "3.1.12" // For if-else logic in logging config
 
-  val workbenchLibsHash = "fccb671"
+  val workbenchLibsHash = "76e472e"
 
   val workbenchModelV  = s"0.21-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.36-${workbenchLibsHash}"


### PR DESCRIPTION
CTM-604

Incorporate the swagger-ui fix from https://github.com/broadinstitute/workbench-libs/pull/1755

One of a series of 4 PRs:
1. https://github.com/broadinstitute/firecloud-orchestration/pull/1720
2. https://github.com/broadinstitute/rawls/pull/3570
3. https://github.com/broadinstitute/sam/pull/1758
4. https://github.com/DataBiosphere/leonardo/pull/4921
