### PR TITLE
CTM-570: update sam-client, which updates jackson 2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -134,7 +134,7 @@ object Dependencies {
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-client" % "2.382.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.153-SNAPSHOT")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "1.1.70-SNAPSHOT" classifier "plain"))
-  val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.440")
+  val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.451")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-82c1f7d"
   val policyService = clientLibExclusions("bio.terra" % "terra-policy-client" % "1.0.41-SNAPSHOT")
 


### PR DESCRIPTION
Ticket: CTM-570

Update `sam-client` to latest, which carries transitive upgrades to the Jackson 2 libraries

## Before
<img width="749" height="441" alt="rawls-jackson-before" src="https://github.com/user-attachments/assets/5d97ba46-9aa2-40d9-a448-8df0f21447b9" />

## After
<img width="791" height="444" alt="rawls-jackson-after" src="https://github.com/user-attachments/assets/4137616b-3aa4-48ba-9ab4-d835d15ba777" />
